### PR TITLE
feat: Add Updates channel and update notification

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -37,11 +37,13 @@ object Constants {
 
         object Channels {
             private const val CHANNEL_ID = "$APP_ID.notification.channel.id"
-            const val CHANNEL_ID_ACTIVE_DOWNLOADS = "$CHANNEL_ID.ACTIVE_DOWNLOADS"
+            const val CHANNEL_ID_ACTIVE_TASKS = "$CHANNEL_ID.ACTIVE_TASKS"
+            const val CHANNEL_ID_UPDATES = "$CHANNEL_ID.UPDATES"
             const val CHANNEL_ID_DOWNLOADED = "$CHANNEL_ID.DOWNLOADED"
 
             val ALL_CHANNEL_IDS = listOf(
-                CHANNEL_ID_ACTIVE_DOWNLOADS,
+                CHANNEL_ID_ACTIVE_TASKS,
+                CHANNEL_ID_UPDATES,
                 CHANNEL_ID_DOWNLOADED,
             )
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
@@ -9,7 +9,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import org.strigate.ferrot.R
-import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_ACTIVE_DOWNLOADS
+import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_ACTIVE_TASKS
 import org.strigate.ferrot.presentation.MainActivity
 
 abstract class ForegroundCoroutineWorker(
@@ -32,11 +32,11 @@ abstract class ForegroundCoroutineWorker(
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
-        val notification = NotificationCompat.Builder(context, CHANNEL_ID_ACTIVE_DOWNLOADS)
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID_ACTIVE_TASKS)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .setSmallIcon(R.drawable.ic_logo)
-            .setChannelId(CHANNEL_ID_ACTIVE_DOWNLOADS)
+            .setChannelId(CHANNEL_ID_ACTIVE_TASKS)
             .setContentTitle(notificationText)
             .setOngoing(true)
             .setContentIntent(pendingIntent)

--- a/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
@@ -9,8 +9,9 @@ import org.strigate.ferrot.app.Constants.Notifications.ChannelGroups.ALL_CHANNEL
 import org.strigate.ferrot.app.Constants.Notifications.ChannelGroups.CHANNEL_GROUP_ID_FOREGROUND
 import org.strigate.ferrot.app.Constants.Notifications.ChannelGroups.CHANNEL_GROUP_ID_GENERAL
 import org.strigate.ferrot.app.Constants.Notifications.Channels.ALL_CHANNEL_IDS
-import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_ACTIVE_DOWNLOADS
+import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_ACTIVE_TASKS
 import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_DOWNLOADED
+import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_UPDATES
 import org.strigate.ferrot.app.Constants.Notifications.Groups.GROUP_ID_DOWNLOADED
 import org.strigate.ferrot.util.NotificationOps.createNotificationChannel
 import org.strigate.ferrot.util.NotificationOps.createNotificationChannelGroup
@@ -45,12 +46,21 @@ class NotificationService @Inject constructor(
         )
         createNotificationChannel(
             context = appContext,
-            channelId = CHANNEL_ID_ACTIVE_DOWNLOADS,
-            channelName = appContext.getString(R.string.notification_channel_name_active_downloads),
-            channelDescription = appContext.getString(R.string.notification_channel_description_active_downloads),
+            channelId = CHANNEL_ID_ACTIVE_TASKS,
+            channelName = appContext.getString(R.string.notification_channel_name_active_tasks),
+            channelDescription = appContext.getString(R.string.notification_channel_description_active_tasks),
             channelImportance = NotificationManager.IMPORTANCE_LOW,
             color = R.color.coral,
             groupId = CHANNEL_GROUP_ID_FOREGROUND,
+        )
+        createNotificationChannel(
+            context = appContext,
+            channelId = CHANNEL_ID_UPDATES,
+            channelName = appContext.getString(R.string.notification_channel_name_updates),
+            channelDescription = appContext.getString(R.string.notification_channel_description_updates),
+            channelImportance = NotificationManager.IMPORTANCE_DEFAULT,
+            color = R.color.coral,
+            groupId = CHANNEL_GROUP_ID_GENERAL,
         )
         createNotificationChannel(
             context = appContext,
@@ -60,6 +70,25 @@ class NotificationService @Inject constructor(
             channelImportance = NotificationManager.IMPORTANCE_DEFAULT,
             color = R.color.coral,
             groupId = CHANNEL_GROUP_ID_GENERAL,
+        )
+    }
+
+    fun notifyAvailableUpdate(
+        contentTitle: String,
+        contentText: String,
+    ) {
+        notify(
+            context = appContext,
+            channelId = CHANNEL_ID_UPDATES,
+            groupId = null,
+            summaryTitleResource = R.string.notification_summary_title,
+            contentTitle = contentTitle,
+            contentText = contentText,
+            colorResource = R.color.coral,
+            iconResource = R.drawable.ic_logo,
+            largeIcon = null,
+            priority = NotificationCompat.PRIORITY_HIGH,
+            tag = "update_available"
         )
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -51,6 +51,7 @@ class WorkerFactory @Inject constructor(
                     appContext = appContext,
                     workerParameters = workerParameters,
                     updatePathProvider = updatePathProvider,
+                    notificationService = notificationService,
                     availableUpdateUseCase = availableUpdateUseCase,
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,13 +1,16 @@
 <resources>
     <string name="notification_channel_group_name_foreground">Foreground</string>
     <string name="notification_channel_group_name_general">General</string>
-    <string name="notification_channel_name_active_downloads">Active downloads</string>
+    <string name="notification_channel_name_active_tasks">Active tasks</string>
     <string name="notification_channel_name_downloaded">Downloaded</string>
-    <string name="notification_channel_description_active_downloads">Active downloads</string>
+    <string name="notification_channel_name_updates">Updates</string>
+    <string name="notification_channel_description_active_tasks">Active tasks</string>
     <string name="notification_channel_description_downloaded">Downloaded</string>
+    <string name="notification_channel_description_updates">Updates</string>
 
     <string name="notification_summary_title">You have new notifications</string>
     <string name="notification_download_title">Downloading</string>
+    <string name="notification_update_title">Update</string>
 
     <string name="worker_notification_text_updating_dependencies">Updating dependencies</string>
     <string name="worker_notification_text_downloading_update">Downloading update</string>


### PR DESCRIPTION
- Introduce `CHANNEL_ID_UPDATES` and include in `ALL_CHANNEL_IDS`
- Rename `CHANNEL_ID_ACTIVE_DOWNLOADS` to `CHANNEL_ID_ACTIVE_TASKS` and update usages in `ForegroundCoroutineWorker`
- Add `notifyAvailableUpdate(...)` in `NotificationService` posting on `CHANNEL_ID_UPDATES` with fixed tag `update_available` and no `groupId`
- Register updates channel in `initializeNotificationChannels()` and create `CHANNEL_ID_ACTIVE_TASKS`
- Inject `NotificationService` into `DownloadAvailableUpdateWorker` via `WorkerFactory`
- Trigger `notifyAvailableUpdate(...)` after `saveAvailableUpdate(...)` using `available_update_ready`
- Add/rename strings: `notification_channel_name_active_tasks`, `notification_channel_description_active_tasks`, `notification_channel_name_updates`, `notification_channel_description_updates`, `notification_update_title`