### PR TITLE
refactor: Rename temp file to part file and tidy resources

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -41,7 +41,6 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
     private val notificationService: NotificationService,
     private val availableUpdateUseCase: AvailableUpdateUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
-
     override suspend fun doWork(): Result {
         enableForeground(
             notificationText = appContext.getString(R.string.worker_notification_text_downloading_update),
@@ -67,10 +66,7 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
 
             val savedTag = savedAvailableUpdate?.tag
             if (savedTag != null && isNewerVersion(savedTag, latestTag)) {
-                Log.d(
-                    LOG_TAG,
-                    "Saved update (${savedTag}) is newer than latest ($latestTag); keeping saved update.",
-                )
+                Log.d(LOG_TAG, "Saved update (${savedTag}) is newer than latest ($latestTag)")
                 return Result.success()
             }
             if (!isNewerVersion(latestTag, currentTag)) {
@@ -128,22 +124,21 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
                 }
             }
 
-            val tempFile = File(apkFile.parentFile, apkFile.name + ".part")
-            Log.d(LOG_TAG, "Downloading update to ${tempFile.absolutePath}")
-
+            val partFile = File(apkFile.parentFile, apkFile.name + ".part")
+            Log.d(LOG_TAG, "Downloading update to ${partFile.absolutePath}")
             try {
-                downloadFile(downloadUrl, tempFile)
+                downloadFile(downloadUrl, partFile)
                 if (expectedDigest.startsWith("sha256:", true)) {
-                    if (!validateSha256(tempFile, expectedDigest)) {
-                        tempFile.delete()
+                    if (!validateSha256(partFile, expectedDigest)) {
+                        partFile.delete()
                         clearAvailableUpdate()
                         return Result.failure()
                     }
                 }
                 if (apkFile.exists()) apkFile.delete()
-                if (!tempFile.renameTo(apkFile)) {
-                    Log.w(LOG_TAG, "Failed to rename temp file to final output")
-                    tempFile.delete()
+                if (!partFile.renameTo(apkFile)) {
+                    Log.w(LOG_TAG, "Failed to rename part file to final output")
+                    partFile.delete()
                     clearAvailableUpdate()
                     return Result.failure()
                 }
@@ -152,9 +147,10 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
                 saveAvailableUpdate(latestTag, apkFile.absolutePath)
                 notifyAvailableUpdate(latestTag)
                 Result.success()
+
             } catch (throwable: Throwable) {
                 Log.wtf(LOG_TAG, "Download failed", throwable)
-                tempFile.delete()
+                partFile.delete()
                 clearAvailableUpdate()
                 Result.failure()
             }

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,17 +1,12 @@
 <resources>
     <string name="app_name">Ferrot</string>
     <string name="copyright">© %1$d Michael Bentz / Strigate</string>
-
     <string name="file_provider">fileprovider</string>
-
     <string name="settings_description_website">ferrot.org</string>
-
     <string name="url_website">https://ferrot.org/</string>
     <string name="url_privacy">https://github.com/strigate/ferrot/blob/main/PRIVACY.md</string>
     <string name="url_license">https://github.com/strigate/ferrot/blob/main/LICENSE</string>
-
     <string name="github_latest_release">https://api.github.com/repos/strigate/ferrot/releases/latest</string>
     <string name="github_release_apk_name">ferrot-release.apk</string>
-
     <string name="content_description_strigate_logo">Strigate logo</string>
 </resources>


### PR DESCRIPTION
- Update `DownloadAvailableUpdateWorker` to rename `tempFile` to `partFile`
- Adjust rename/delete failure logs to reference `partFile`