### PR TITLE
feat: Add `Dimens` system and integrate consistent typography and lay…

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
@@ -2,9 +2,11 @@ package org.strigate.ferrot.presentation.component.state
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -15,8 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import org.strigate.ferrot.presentation.theme.LocalDimens
 
 @Composable
 fun EmptyState(
@@ -26,39 +27,42 @@ fun EmptyState(
     icon: ImageVector? = null,
     iconContentDescription: String? = null,
 ) {
+    val dimens = LocalDimens.current
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 48.dp),
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         icon?.let {
             Icon(
                 modifier = Modifier
-                    .size(128.dp),
+                    .size(dimens.iconXLarge),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                contentDescription = iconContentDescription,
                 imageVector = it,
+                contentDescription = iconContentDescription,
             )
         }
-        Text(
+        Spacer(modifier = Modifier.height(dimens.spacingMedium))
+        Column(
             modifier = Modifier
-                .padding(top = 16.dp),
-            style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            text = title,
-        )
-        Text(
-            modifier = Modifier
-                .padding(top = 8.dp),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            lineHeight = 20.sp,
-            text = body,
-        )
+                .widthIn(max = dimens.contentMaxWidth),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                text = title,
+            )
+            Spacer(modifier = Modifier.height(dimens.spacingSmall))
+            Text(
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                text = body,
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
@@ -1,0 +1,31 @@
+package org.strigate.ferrot.presentation.theme
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Stable
+data class Dimens(
+    val zero: Dp = 0.dp,
+
+    val spacingSmall: Dp = 8.dp,
+    val spacingMedium: Dp = 16.dp,
+    val spacingLarge: Dp = 24.dp,
+
+    val iconSmall: Dp = 24.dp,
+    val iconLarge: Dp = 32.dp,
+    val iconXLarge: Dp = 128.dp,
+
+    val radiusSmall: Dp = 4.dp,
+    val radiusMedium: Dp = 8.dp,
+    val radiusLarge: Dp = 16.dp,
+
+    val stroke: Dp = 1.dp,
+
+    val contentMaxWidth: Dp = 320.dp
+)
+
+val LocalDimens = staticCompositionLocalOf<Dimens> {
+    error("Dimens not provided")
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Theme.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Theme.kt
@@ -74,11 +74,11 @@ private val DarkColorScheme = darkColorScheme(
 
 @Composable
 fun FerrotTheme(
-//    dimens: Dimens = Dimens(),
+    dimens: Dimens = Dimens(),
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
-//        LocalDimens provides dimens,
+        LocalDimens provides dimens,
     ) {
         MaterialTheme(
             colorScheme = if (isSystemInDarkTheme()) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
@@ -7,6 +7,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 val Typography = Typography(
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp,
+    ),
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,


### PR DESCRIPTION
…out spacing

- Added new `Dimens` data class with `spacing`, `icon`, `radius`, `stroke`, and `contentMaxWidth` values
- Registered `LocalDimens` using `staticCompositionLocalOf` for global access in Compose
- Updated `FerrotTheme` to provide `LocalDimens` by default
- Added `bodyMedium` text style in `Typography` with `lineHeight` and `letterSpacing`
- Refactored `EmptyState` composable to use `LocalDimens` for sizes, spacing, and width constraints
- Removed hardcoded padding, dp, and sp values from `EmptyState`