### PR TITLE
refactor: Replace magic numbers with `Dimens` in `ErrorState`

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material3.Icon
@@ -16,13 +17,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
+import org.strigate.ferrot.presentation.theme.LocalDimens
 
 @Composable
 fun ErrorState(
     modifier: Modifier = Modifier,
     text: String? = null,
 ) {
+    val dimens = LocalDimens.current
     Box(
         modifier = modifier
             .fillMaxSize(),
@@ -34,19 +36,25 @@ fun ErrorState(
         ) {
             Icon(
                 modifier = Modifier
-                    .size(96.dp),
+                    .size(dimens.iconXLarge),
                 tint = MaterialTheme.colorScheme.error,
                 imageVector = Icons.Outlined.ErrorOutline,
                 contentDescription = null,
             )
             text?.let {
-                Spacer(modifier = Modifier.height(12.dp))
-                Text(
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.error,
-                    textAlign = TextAlign.Center,
-                    text = it,
-                )
+                Spacer(modifier = Modifier.height(dimens.spacingMedium))
+                Column(
+                    modifier = Modifier
+                        .widthIn(max = dimens.contentMaxWidth),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                        text = it,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
@@ -15,7 +15,8 @@ data class Dimens(
 
     val iconSmall: Dp = 24.dp,
     val iconLarge: Dp = 32.dp,
-    val iconXLarge: Dp = 128.dp,
+    val iconXLarge: Dp = 96.dp,
+    val iconXXLarge: Dp = 128.dp,
 
     val radiusSmall: Dp = 4.dp,
     val radiusMedium: Dp = 8.dp,
@@ -23,7 +24,7 @@ data class Dimens(
 
     val stroke: Dp = 1.dp,
 
-    val contentMaxWidth: Dp = 320.dp
+    val contentMaxWidth: Dp = 320.dp,
 )
 
 val LocalDimens = staticCompositionLocalOf<Dimens> {


### PR DESCRIPTION
- Use `LocalDimens` for sizes and spacing in `ErrorState`
- Replace `96.dp` and `12.dp` with `iconXLarge` and `spacingMedium`
- Constrain text width using `contentMaxWidth` via `widthIn`
- Update `Dimens` to add `iconXXLarge` and set `iconXLarge` to `96.dp`
- Remove direct `dp` literals and align with theme tokens