### PR TITLE
refactor: Standardize dimens usage and icon scale across About and st…

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
@@ -38,7 +38,7 @@ fun EmptyState(
         icon?.let {
             Icon(
                 modifier = Modifier
-                    .size(dimens.iconXLarge),
+                    .size(dimens.iconXXLarge),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 imageVector = it,
                 contentDescription = iconContentDescription,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
@@ -36,7 +36,7 @@ fun ErrorState(
         ) {
             Icon(
                 modifier = Modifier
-                    .size(dimens.iconXLarge),
+                    .size(dimens.iconXXLarge),
                 tint = MaterialTheme.colorScheme.error,
                 imageVector = Icons.Outlined.ErrorOutline,
                 contentDescription = null,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -28,8 +29,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -40,6 +39,7 @@ import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.copyToClipboard
 import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
 import org.strigate.ferrot.presentation.component.settings.TextSetting
+import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.viewmodel.AboutViewModel
 import java.util.Calendar
 
@@ -49,6 +49,7 @@ fun AboutScreen(
     modifier: Modifier = Modifier,
     viewModel: AboutViewModel = hiltViewModel(),
 ) {
+    val dimens = LocalDimens.current
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
@@ -89,11 +90,13 @@ fun AboutScreen(
         content = { contentPadding ->
             Surface(
                 modifier = modifier
+                    .fillMaxSize()
                     .padding(contentPadding),
             ) {
                 Column(
                     modifier = Modifier
-                        .padding(horizontal = 12.dp)
+                        .fillMaxSize()
+                        .padding(horizontal = dimens.spacingMediumAlt)
                         .verticalScroll(rememberScrollState()),
                 ) {
                     StaticSettingsSection(
@@ -106,7 +109,7 @@ fun AboutScreen(
                             context.copyToClipboard(BuildConfig.VERSION_NAME)
                         }
                     }
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(dimens.spacingSmall))
                     StaticSettingsSection {
                         val urlWebsite = stringResource(R.string.url_website)
                         val urlPrivacy = stringResource(R.string.url_privacy)
@@ -130,28 +133,27 @@ fun AboutScreen(
                             viewModel.onUrlClicked(urlLicense)
                         }
                     }
-                    Spacer(modifier = Modifier.height(24.dp))
                     Column(
                         modifier = Modifier
                             .fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.Center,
                     ) {
+                        Spacer(modifier = Modifier.height(dimens.spacingLarge))
                         Icon(
                             modifier = Modifier
-                                .height(80.dp),
+                                .height(dimens.iconXLarge),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                alpha = 0.9f,
+                                alpha = 0.8f,
                             ),
                             painter = painterResource(R.drawable.strigate_logo),
                             contentDescription = stringResource(R.string.content_description_strigate_logo),
                         )
                         Text(
-                            style = MaterialTheme.typography.bodySmall.copy(
+                            style = MaterialTheme.typography.labelSmall.copy(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
                                     alpha = 0.75f,
                                 ),
-                                fontSize = 11.sp,
                             ),
                             textAlign = TextAlign.Center,
                             text = stringResource(
@@ -159,8 +161,8 @@ fun AboutScreen(
                                 Calendar.getInstance().get(Calendar.YEAR),
                             ),
                         )
+                        Spacer(modifier = Modifier.height(dimens.spacingLarge))
                     }
-                    Spacer(modifier = Modifier.height(24.dp))
                 }
             }
         },

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
@@ -10,13 +10,15 @@ data class Dimens(
     val zero: Dp = 0.dp,
 
     val spacingSmall: Dp = 8.dp,
+    val spacingMediumAlt: Dp = 12.dp,
     val spacingMedium: Dp = 16.dp,
     val spacingLarge: Dp = 24.dp,
 
     val iconSmall: Dp = 24.dp,
     val iconLarge: Dp = 32.dp,
-    val iconXLarge: Dp = 96.dp,
-    val iconXXLarge: Dp = 128.dp,
+    val iconXLarge: Dp = 72.dp,
+    val iconXXLarge: Dp = 96.dp,
+    val iconXXXLarge: Dp = 128.dp,
 
     val radiusSmall: Dp = 4.dp,
     val radiusMedium: Dp = 8.dp,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
@@ -7,6 +7,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 val Typography = Typography(
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp,
+    ),
     bodyMedium = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,


### PR DESCRIPTION
…ates

- Update `AboutScreen` to use `LocalDimens`, replacing hardcoded `dp` with `spacingMediumAlt`, `spacingSmall`, and `spacingLarge`
- Add `.fillMaxSize()` to `Surface` and root `Column` in `AboutScreen`; set logo height to `dimens.iconXLarge` and adjust tint alpha to `0.8f`
- Extend `Dimens`: add `spacingMediumAlt`, set `iconXLarge` to `72.dp`, introduce `iconXXLarge` (`96.dp`) and `iconXXXLarge` (`128.dp`)
- Switch `EmptyState` and `ErrorState` icon size to `dimens.iconXXLarge`
- Add `bodySmall` `TextStyle` (12.sp, 16.sp line height, 0.4.sp letter spacing) to `Typography`