### PR TITLE
feat: Add app update install intent and manual trigger

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/Ferrot.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/Ferrot.kt
@@ -54,7 +54,7 @@ class Ferrot : Application(), Configuration.Provider, DefaultLifecycleObserver {
     }
 
     private fun enqueueWork() {
-        DownloadAvailableUpdateWorker.enqueuePeriodic(this)
-        UpdateDependenciesWorker.enqueuePeriodic(this)
+        DownloadAvailableUpdateWorker.enqueuePeriodicKeep(this)
+        UpdateDependenciesWorker.enqueuePeriodicKeep(this)
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -58,16 +58,22 @@ object Constants {
         object Name {
             private const val NAME = "$APP_ID.work"
             private const val KEY = "$APP_ID.key"
-
             private const val ONETIME = "$NAME.onetime"
-            const val DOWNLOAD = "$ONETIME.DOWNLOAD"
-
             private const val PERIODIC = "$NAME.periodic"
-            const val DOWNLOAD_AVAILABLE_UPDATE = "$PERIODIC.DOWNLOAD_AVAILABLE_UPDATE"
-            const val UPDATE_DEPENDENCIES = "$PERIODIC.UPDATE_DEPENDENCIES"
+
+            const val ONETIME_DOWNLOAD = "$ONETIME.DOWNLOAD"
+            const val ONETIME_DOWNLOAD_AVAILABLE_UPDATE = "$ONETIME.DOWNLOAD_AVAILABLE_UPDATE"
+
+            const val PERIODIC_DOWNLOAD_AVAILABLE_UPDATE = "$PERIODIC.DOWNLOAD_AVAILABLE_UPDATE"
+            const val PERIODIC_UPDATE_DEPENDENCIES = "$PERIODIC.UPDATE_DEPENDENCIES"
 
             const val KEY_ID = "$KEY.ID"
             const val KEY_WIFI_ONLY = "$KEY.wifi_only"
+        }
+
+        object Tag {
+            private const val TAG = "$APP_ID.tag"
+            const val DOWNLOAD_AVAILABLE_UPDATE = "$TAG.DOWNLOAD_AVAILABLE_UPDATE"
         }
     }
 
@@ -78,15 +84,22 @@ object Constants {
 
     object Extras {
         private const val EXTRA = "$APP_ID.intent.extra"
+
         const val EXTRA_ACTION = "$EXTRA.ACTION"
+        const val EXTRA_AVAILABLE_UPDATE_APK_FILE_PATH = "$EXTRA.AVAILABLE_UPDATE_APK_FILE_PATH"
+        const val EXTRA_AVAILABLE_UPDATE_VERSION_TAG = "$EXTRA.AVAILABLE_UPDATE_VERSION_TAG"
+
         const val EXTRA_SHARED_URL_UID = "$EXTRA.SHARED_URL_UID"
         const val EXTRA_SHARED_URL = "$EXTRA.SHARED_URL"
-        const val EXTRA_DOWNLOAD_ID = "$EXTRA.download.DOWNLOAD_ID"
+
+        const val EXTRA_DOWNLOAD_ID = "$EXTRA.DOWNLOAD_ID"
     }
 
     object Action {
         private const val ACTION = "$APP_ID.intent.action"
+
+        const val ACTION_INSTALL_AVAILABLE_UPDATE = "$ACTION.INSTALL_AVAILABLE_UPDATE"
         const val ACTION_START_DOWNLOAD_FROM_SHARE = "$ACTION.START_DOWNLOAD_FROM_SHARE"
-        const val ACTION_NAVIGATE_DOWNLOAD = "$ACTION.navigate.DOWNLOAD"
+        const val ACTION_NAVIGATE_DOWNLOAD = "$ACTION.NAVIGATE_DOWNLOAD"
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
@@ -76,6 +76,8 @@ class NotificationService @Inject constructor(
     fun notifyAvailableUpdate(
         contentTitle: String,
         contentText: String,
+        extras: Map<String, String> = emptyMap(),
+        tag: String? = "update_available",
     ) {
         notify(
             context = appContext,
@@ -88,7 +90,8 @@ class NotificationService @Inject constructor(
             iconResource = R.drawable.ic_logo,
             largeIcon = null,
             priority = NotificationCompat.PRIORITY_HIGH,
-            tag = "update_available"
+            tag = tag,
+            extras = extras,
         )
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/helper/InstallHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/InstallHelper.kt
@@ -31,6 +31,8 @@ object InstallHelper {
             true
         } catch (_: ActivityNotFoundException) {
             false
+        } catch (_: SecurityException) {
+            false
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
@@ -20,13 +20,16 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
+import org.strigate.ferrot.app.Constants.Action.ACTION_INSTALL_AVAILABLE_UPDATE
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
 import org.strigate.ferrot.app.Constants.Action.ACTION_START_DOWNLOAD_FROM_SHARE
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_AVAILABLE_UPDATE_APK_FILE_PATH
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL_UID
 import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.helper.InstallHelper
 import org.strigate.ferrot.presentation.theme.FerrotTheme
 import org.strigate.ferrot.util.isAtLeastTiramisu
 
@@ -35,7 +38,7 @@ class MainActivity : ComponentActivity() {
     private val viewModel: MainViewModel by viewModels()
 
     private val notificationsPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
+        ActivityResultContracts.RequestPermission(),
     ) { _ -> }
 
     override fun onNewIntent(intent: Intent) {
@@ -81,6 +84,16 @@ class MainActivity : ComponentActivity() {
                     viewModel.navigateToDownload(downloadId)
                     return
                 }
+            }
+
+            ACTION_INSTALL_AVAILABLE_UPDATE -> {
+                val apkFilePath = intent.getStringExtra(EXTRA_AVAILABLE_UPDATE_APK_FILE_PATH)
+                InstallHelper.requestInstallApkIfExists(this, apkFilePath)
+                viewModel.navigateTo(
+                    route = Screen.Downloads.route,
+                    popUpToDownloads = true,
+                )
+                return
             }
         }
     }
@@ -149,7 +162,7 @@ class MainActivity : ComponentActivity() {
             return
         }
         val granted = ContextCompat.checkSelfPermission(
-            this, Manifest.permission.POST_NOTIFICATIONS
+            this, Manifest.permission.POST_NOTIFICATIONS,
         ) == PackageManager.PERMISSION_GRANTED
         if (!granted) {
             notificationsPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
@@ -68,6 +69,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.strigate.ferrot.R
+import org.strigate.ferrot.helper.InstallHelper
 import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.component.DownloadPrimaryActionButton
 import org.strigate.ferrot.presentation.component.DownloadProgressSection
@@ -173,6 +175,7 @@ fun DownloadsScreen(
                                     .fillMaxSize(),
                             ) {
                                 availableUpdate?.let {
+                                    val context = LocalContext.current
                                     AvailableUpdateBanner(
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -181,7 +184,10 @@ fun DownloadsScreen(
                                         tag = it.tag,
                                         localFilePath = it.localFilePath,
                                         onClick = { filePath ->
-                                            viewModel.requestInstallAvailableUpdate(filePath)
+                                            InstallHelper.requestInstallApkIfExists(
+                                                context,
+                                                filePath
+                                            )
                                         },
                                     )
                                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -28,12 +29,15 @@ import androidx.navigation.NavController
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.component.settings.ExpandableSettingsSection
+import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
 import org.strigate.ferrot.presentation.component.settings.SwitchSetting
 import org.strigate.ferrot.presentation.component.settings.TextNavigateSetting
+import org.strigate.ferrot.presentation.component.settings.TextSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import org.strigate.ferrot.presentation.viewmodel.SettingsViewModel
+import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -42,6 +46,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
 
@@ -98,6 +103,15 @@ fun SettingsScreen(
                                             viewModel.setDownloadWifiOnly(checked)
                                         },
                                     )
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                                StaticSettingsSection {
+                                    TextSetting(
+                                        text = stringResource(R.string.settings_title_app_update),
+                                        description = stringResource(R.string.settings_description_app_update),
+                                    ) {
+                                        DownloadAvailableUpdateWorker.enqueueOneTimeReplace(context)
+                                    }
                                 }
                                 Spacer(modifier = Modifier.height(8.dp))
                                 TextNavigateSetting(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -1,10 +1,8 @@
 package org.strigate.ferrot.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -23,7 +21,6 @@ import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombi
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataUseCase
-import org.strigate.ferrot.helper.InstallHelper
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
@@ -33,7 +30,6 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class DownloadsViewModel @Inject constructor(
-    @param:ApplicationContext private val appContext: Context,
     private val analyticsLogger: AnalyticsLogger,
     private val downloadUseCase: DownloadUseCase,
     private val downloadProgressUseCase: DownloadProgressUseCase,
@@ -99,12 +95,6 @@ class DownloadsViewModel @Inject constructor(
     fun deleteDownload(downloadId: Long) {
         viewModelScope.launch {
             deleteDownloadAndRelatedCombinedUseCase(downloadId)
-        }
-    }
-
-    fun requestInstallAvailableUpdate(filePath: String) {
-        viewModelScope.launch {
-            InstallHelper.requestInstallApkIfExists(appContext, filePath)
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -5,7 +5,9 @@ import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -19,8 +21,13 @@ import org.json.JSONObject
 import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants
+import org.strigate.ferrot.app.Constants.Action.ACTION_INSTALL_AVAILABLE_UPDATE
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_AVAILABLE_UPDATE_APK_FILE_PATH
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_AVAILABLE_UPDATE_VERSION_TAG
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.app.Constants.Work.Name.DOWNLOAD_AVAILABLE_UPDATE
+import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD_AVAILABLE_UPDATE
+import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_DOWNLOAD_AVAILABLE_UPDATE
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.provider.UpdatePathProvider
@@ -30,6 +37,9 @@ import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
+import java.time.Duration.between
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -42,9 +52,6 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
     private val availableUpdateUseCase: AvailableUpdateUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result {
-        enableForeground(
-            notificationText = appContext.getString(R.string.worker_notification_text_downloading_update),
-        )
         return try {
             val savedAvailableUpdate = runCatching {
                 availableUpdateUseCase.getAvailableUpdateAsFlowUseCase().first()
@@ -101,7 +108,7 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
                         if (validateSha256(apkFile, expectedDigest)) {
                             Log.d(LOG_TAG, "Update already downloaded & verified: ${apkFile.name}")
                             saveAvailableUpdate(latestTag, apkFile.absolutePath)
-                            notifyAvailableUpdate(latestTag)
+                            notifyAvailableUpdate(latestTag, apkFile.absolutePath)
                             return Result.success()
                         }
                         Log.w(LOG_TAG, "Existing file sha256 mismatch. Re-downloading")
@@ -112,7 +119,7 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
                     apkFile.length() > 0L -> {
                         Log.d(LOG_TAG, "Update file already present: ${apkFile.name}")
                         saveAvailableUpdate(latestTag, apkFile.absolutePath)
-                        notifyAvailableUpdate(latestTag)
+                        notifyAvailableUpdate(latestTag, apkFile.absolutePath)
                         return Result.success()
                     }
 
@@ -126,6 +133,11 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
 
             val partFile = File(apkFile.parentFile, apkFile.name + ".part")
             Log.d(LOG_TAG, "Downloading update to ${partFile.absolutePath}")
+
+            enableForeground(
+                notificationText = appContext.getString(R.string.worker_notification_text_downloading_app_update),
+            )
+
             try {
                 downloadFile(downloadUrl, partFile)
                 if (expectedDigest.startsWith("sha256:", true)) {
@@ -145,7 +157,7 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
 
                 Log.d(LOG_TAG, "Update downloaded successfully: ${apkFile.name}")
                 saveAvailableUpdate(latestTag, apkFile.absolutePath)
-                notifyAvailableUpdate(latestTag)
+                notifyAvailableUpdate(latestTag, apkFile.absolutePath)
                 Result.success()
 
             } catch (throwable: Throwable) {
@@ -161,12 +173,17 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
         }
     }
 
-    private fun notifyAvailableUpdate(versionTag: String) {
-        val contentTitle = appContext.getString(R.string.notification_update_title)
+    private fun notifyAvailableUpdate(versionTag: String, apkFilePath: String) {
+        val contentTitle = appContext.getString(R.string.notification_app_update_title)
         val contentText = appContext.getString(R.string.available_update_ready, versionTag)
         notificationService.notifyAvailableUpdate(
             contentTitle = contentTitle,
             contentText = contentText,
+            extras = mapOf(
+                EXTRA_ACTION to ACTION_INSTALL_AVAILABLE_UPDATE,
+                EXTRA_AVAILABLE_UPDATE_APK_FILE_PATH to apkFilePath,
+                EXTRA_AVAILABLE_UPDATE_VERSION_TAG to versionTag,
+            ),
         )
     }
 
@@ -293,33 +310,67 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
     }
 
     companion object {
-        fun enqueuePeriodic(
+        fun enqueuePeriodicKeep(
             context: Context,
-            repeatIntervalDays: Long = 1,
+            targetHour: Int = 3,
             flexHours: Long = 3,
-            requireUnmetered: Boolean = true,
         ) {
+            val defaultZoneId = ZoneId.systemDefault()
+            val now = ZonedDateTime.now(defaultZoneId)
+            val targetDateTime = now
+                .withHour(targetHour)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0)
+
+            val firstRun = if (now.isBefore(targetDateTime)) {
+                targetDateTime
+            } else {
+                targetDateTime.plusDays(1)
+            }
+            val initialDelayMillis = between(now, firstRun).toMillis()
             val constraints = Constraints.Builder()
-                .setRequiredNetworkType(
-                    if (requireUnmetered) {
-                        NetworkType.UNMETERED
-                    } else {
-                        NetworkType.CONNECTED
-                    },
-                )
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .setRequiresCharging(false)
+                .setRequiresBatteryNotLow(false)
                 .build()
 
             val periodicWorkRequest = PeriodicWorkRequestBuilder<DownloadAvailableUpdateWorker>(
-                repeatIntervalDays, TimeUnit.DAYS,
-                flexHours, TimeUnit.HOURS,
+                repeatInterval = 1,
+                repeatIntervalTimeUnit = TimeUnit.DAYS,
+                flexTimeInterval = flexHours,
+                flexTimeIntervalUnit = TimeUnit.HOURS,
             )
+                .setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
                 .setConstraints(constraints)
+                .addTag(Constants.Work.Tag.DOWNLOAD_AVAILABLE_UPDATE)
                 .build()
 
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                DOWNLOAD_AVAILABLE_UPDATE,
-                ExistingPeriodicWorkPolicy.UPDATE,
+                PERIODIC_DOWNLOAD_AVAILABLE_UPDATE,
+                ExistingPeriodicWorkPolicy.KEEP,
                 periodicWorkRequest,
+            )
+        }
+
+        fun enqueueOneTimeReplace(
+            context: Context,
+        ) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresCharging(false)
+                .setRequiresBatteryNotLow(false)
+                .build()
+
+            val oneTimeWorkRequest = OneTimeWorkRequestBuilder<DownloadAvailableUpdateWorker>()
+                .setConstraints(constraints)
+                .addTag(Constants.Work.Tag.DOWNLOAD_AVAILABLE_UPDATE)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                ONETIME_DOWNLOAD_AVAILABLE_UPDATE,
+                ExistingWorkPolicy.REPLACE,
+                oneTimeWorkRequest,
             )
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -26,9 +26,9 @@ import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.app.Constants.Work.Name.DOWNLOAD
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_WIFI_ONLY
+import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.provider.DownloadPathProvider
@@ -422,10 +422,9 @@ class DownloadWorker @AssistedInject constructor(
         }
 
         fun cancelUnique(context: Context, id: Long) {
-            WorkManager.getInstance(context)
-                .cancelUniqueWork(uniqueWorkName(id))
+            WorkManager.getInstance(context).cancelUniqueWork(uniqueWorkName(id))
         }
 
-        private fun uniqueWorkName(downloadId: Long): String = "$DOWNLOAD-$downloadId"
+        private fun uniqueWorkName(downloadId: Long): String = "$ONETIME_DOWNLOAD-$downloadId"
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -14,7 +14,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.app.Constants.Work.Name.UPDATE_DEPENDENCIES
+import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import java.util.concurrent.TimeUnit
 
@@ -42,32 +42,27 @@ class UpdateDependenciesWorker @AssistedInject constructor(
     }
 
     companion object {
-        fun enqueuePeriodic(
+        fun enqueuePeriodicKeep(
             context: Context,
             repeatIntervalDays: Long = 7,
             flexHours: Long = 12,
-            requireUnmetered: Boolean = false,
         ) {
             val constraints = Constraints.Builder()
-                .setRequiredNetworkType(
-                    if (requireUnmetered) {
-                        NetworkType.UNMETERED
-                    } else {
-                        NetworkType.CONNECTED
-                    },
-                )
+                .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
 
             val periodicWorkRequest = PeriodicWorkRequestBuilder<UpdateDependenciesWorker>(
-                repeatIntervalDays, TimeUnit.DAYS,
-                flexHours, TimeUnit.HOURS,
+                repeatInterval = repeatIntervalDays,
+                repeatIntervalTimeUnit = TimeUnit.DAYS,
+                flexTimeInterval = flexHours,
+                flexTimeIntervalUnit = TimeUnit.HOURS,
             )
                 .setConstraints(constraints)
                 .build()
 
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                UPDATE_DEPENDENCIES,
-                ExistingPeriodicWorkPolicy.UPDATE,
+                PERIODIC_UPDATE_DEPENDENCIES,
+                ExistingPeriodicWorkPolicy.KEEP,
                 periodicWorkRequest,
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,10 +10,10 @@
 
     <string name="notification_summary_title">You have new notifications</string>
     <string name="notification_download_title">Downloading</string>
-    <string name="notification_update_title">Update</string>
+    <string name="notification_app_update_title">App update</string>
 
     <string name="worker_notification_text_updating_dependencies">Updating dependencies</string>
-    <string name="worker_notification_text_downloading_update">Downloading update</string>
+    <string name="worker_notification_text_downloading_app_update">Downloading app update</string>
     <string name="worker_notification_text_download_in_progress">Download in progress</string>
 
     <string name="screen_title_download">Download</string>
@@ -64,12 +64,14 @@
     <string name="settings_navigate_title_about">About</string>
 
     <string name="settings_title_download_wifi_only">Download over Wi-Fi only</string>
+    <string name="settings_title_app_update">App update</string>
     <string name="settings_title_build">Build</string>
     <string name="settings_title_website">Website</string>
     <string name="settings_title_privacy">Privacy</string>
     <string name="settings_title_license">License</string>
 
     <string name="settings_description_download_wifi_only">Restrict downloads to Wi-Fi connections only</string>
+    <string name="settings_description_app_update">Download and install</string>
     <string name="settings_description_privacy">View Privacy Policy</string>
     <string name="settings_description_license">GNU General Public License v3.0</string>
 


### PR DESCRIPTION
- Add `ACTION_INSTALL_AVAILABLE_UPDATE` handling in `MainActivity`
- Move APK install to `InstallHelper` with exception handling
- Update `DownloadAvailableUpdateWorker` to include extras in notification
- Add `enqueueOneTimeReplace` and `enqueuePeriodicKeep` for update worker
- Add “App update” setting to trigger one-time check
- Clean up constants, strings, and work names for consistency