### PR TITLE
feat: Add Updates screen with automatic update settings

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/Ferrot.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/Ferrot.kt
@@ -9,10 +9,13 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.di.WorkerFactory
 import org.strigate.ferrot.app.receiver.AirplaneModeReceiver
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
 import org.strigate.ferrot.work.UpdateDependenciesWorker
 import javax.inject.Inject
@@ -27,6 +30,9 @@ class Ferrot : Application(), Configuration.Provider, DefaultLifecycleObserver {
 
     @Inject
     lateinit var notificationService: NotificationService
+
+    @Inject
+    lateinit var settingsUseCase: SettingsUseCase
 
     override val workManagerConfiguration: Configuration
         get() {
@@ -53,8 +59,25 @@ class Ferrot : Application(), Configuration.Provider, DefaultLifecycleObserver {
         )
     }
 
-    private fun enqueueWork() {
-        DownloadAvailableUpdateWorker.enqueuePeriodicKeep(this)
-        UpdateDependenciesWorker.enqueuePeriodicKeep(this)
+    private fun enqueueWork() = runBlocking {
+        val appContext = this@Ferrot
+
+        val automaticUpdatesSetting = settingsUseCase
+            .getAutomaticUpdatesSettingAsFlowUseCase()
+            .first()
+        val automaticDependencyUpdatesSetting = settingsUseCase
+            .getAutomaticDependencyUpdatesSettingAsFlowUseCase()
+            .first()
+
+        if (automaticUpdatesSetting) {
+            DownloadAvailableUpdateWorker.enqueuePeriodicKeep(appContext)
+        } else {
+            DownloadAvailableUpdateWorker.cancelPeriodic(appContext)
+        }
+        if (automaticDependencyUpdatesSetting) {
+            UpdateDependenciesWorker.enqueuePeriodicKeep(appContext)
+        } else {
+            UpdateDependenciesWorker.cancelPeriodic(appContext)
+        }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/analytics/AnalyticsEvents.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/analytics/AnalyticsEvents.kt
@@ -9,6 +9,7 @@ object AnalyticsEvents {
         const val DOWNLOADS = "downloads_screen"
         const val DOWNLOAD = "download_screen"
         const val SETTINGS = "settings_screen"
+        const val UPDATES = "updates_screen"
         const val ABOUT = "about_screen"
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -21,6 +21,10 @@ object Constants {
     object Settings {
         const val KEY_DOWNLOAD_WIFI_ONLY = "download_wifi_only"
         const val DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY = true
+        const val KEY_AUTOMATIC_UPDATES = "automatic_updates"
+        const val DEFAULT_VALUE_AUTOMATIC_UPDATES = true
+        const val KEY_AUTOMATIC_DEPENDENCY_UPDATES = "automatic_dependency_updates"
+        const val DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES = true
     }
 
     object Notifications {

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImpl.kt
@@ -6,7 +6,11 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY
+import org.strigate.ferrot.app.Constants.Settings.KEY_AUTOMATIC_DEPENDENCY_UPDATES
+import org.strigate.ferrot.app.Constants.Settings.KEY_AUTOMATIC_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.KEY_DOWNLOAD_WIFI_ONLY
 import org.strigate.ferrot.domain.repository.SettingsRepository
 import javax.inject.Inject
@@ -16,7 +20,12 @@ import javax.inject.Singleton
 class SettingsRepositoryImpl @Inject constructor(
     private val preferencesDataStore: DataStore<Preferences>,
 ) : SettingsRepository {
-    private val downloadWifiOnlyKey = booleanPreferencesKey(KEY_DOWNLOAD_WIFI_ONLY)
+    private val downloadWifiOnlyKey =
+        booleanPreferencesKey(KEY_DOWNLOAD_WIFI_ONLY)
+    private val automaticUpdatesKey =
+        booleanPreferencesKey(KEY_AUTOMATIC_UPDATES)
+    private val automaticDependencyUpdatesKey =
+        booleanPreferencesKey(KEY_AUTOMATIC_DEPENDENCY_UPDATES)
 
     override fun getDownloadWifiOnlyAsFlow(): Flow<Boolean> {
         return preferencesDataStore.data.map {
@@ -25,6 +34,32 @@ class SettingsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveDownloadWifiOnly(enabled: Boolean) {
-        preferencesDataStore.edit { it[downloadWifiOnlyKey] = enabled }
+        preferencesDataStore.edit {
+            it[downloadWifiOnlyKey] = enabled
+        }
+    }
+
+    override fun getAutomaticUpdatesAsFlow(): Flow<Boolean> {
+        return preferencesDataStore.data.map {
+            it[automaticUpdatesKey] ?: DEFAULT_VALUE_AUTOMATIC_UPDATES
+        }
+    }
+
+    override suspend fun saveAutomaticUpdates(enabled: Boolean) {
+        preferencesDataStore.edit {
+            it[automaticUpdatesKey] = enabled
+        }
+    }
+
+    override fun getAutomaticDependencyUpdatesAsFlow(): Flow<Boolean> {
+        return preferencesDataStore.data.map {
+            it[automaticDependencyUpdatesKey] ?: DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES
+        }
+    }
+
+    override suspend fun saveAutomaticDependencyUpdates(enabled: Boolean) {
+        preferencesDataStore.edit {
+            it[automaticDependencyUpdatesKey] = enabled
+        }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/repository/SettingsRepository.kt
@@ -5,4 +5,8 @@ import kotlinx.coroutines.flow.Flow
 interface SettingsRepository {
     fun getDownloadWifiOnlyAsFlow(): Flow<Boolean>
     suspend fun saveDownloadWifiOnly(enabled: Boolean)
+    fun getAutomaticUpdatesAsFlow(): Flow<Boolean>
+    suspend fun saveAutomaticUpdates(enabled: Boolean)
+    fun getAutomaticDependencyUpdatesAsFlow(): Flow<Boolean>
+    suspend fun saveAutomaticDependencyUpdates(enabled: Boolean)
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/SettingsUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/SettingsUseCase.kt
@@ -1,10 +1,18 @@
 package org.strigate.ferrot.domain.usecase
 
+import org.strigate.ferrot.domain.usecase.settings.GetAutomaticDependencyUpdatesSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetAutomaticUpdatesSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticDependencyUpdatesSettingUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticUpdatesSettingUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveDownloadWifiOnlySettingUseCase
 import javax.inject.Inject
 
 class SettingsUseCase @Inject constructor(
     val getDownloadWifiOnlySettingAsFlowUseCase: GetDownloadWifiOnlySettingAsFlowUseCase,
     val saveDownloadWifiOnlySettingUseCase: SaveDownloadWifiOnlySettingUseCase,
+    val getAutomaticUpdatesSettingAsFlowUseCase: GetAutomaticUpdatesSettingAsFlowUseCase,
+    val saveAutomaticUpdatesSettingUseCase: SaveAutomaticUpdatesSettingUseCase,
+    val getAutomaticDependencyUpdatesSettingAsFlowUseCase: GetAutomaticDependencyUpdatesSettingAsFlowUseCase,
+    val saveAutomaticDependencyUpdatesSettingAsFlowUseCase: SaveAutomaticDependencyUpdatesSettingUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetAutomaticDependencyUpdatesSettingAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetAutomaticDependencyUpdatesSettingAsFlowUseCase.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class GetAutomaticDependencyUpdatesSettingAsFlowUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    operator fun invoke(): Flow<Boolean> {
+        return settingsRepository.getAutomaticDependencyUpdatesAsFlow()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetAutomaticUpdatesSettingAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetAutomaticUpdatesSettingAsFlowUseCase.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class GetAutomaticUpdatesSettingAsFlowUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    operator fun invoke(): Flow<Boolean> {
+        return settingsRepository.getAutomaticUpdatesAsFlow()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveAutomaticDependencyUpdatesSettingUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveAutomaticDependencyUpdatesSettingUseCase.kt
@@ -1,0 +1,12 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class SaveAutomaticDependencyUpdatesSettingUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(enabled: Boolean) {
+        settingsRepository.saveAutomaticDependencyUpdates(enabled)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveAutomaticUpdatesSettingUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveAutomaticUpdatesSettingUseCase.kt
@@ -1,0 +1,12 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class SaveAutomaticUpdatesSettingUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(enabled: Boolean) {
+        settingsRepository.saveAutomaticUpdates(enabled)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
@@ -14,6 +14,7 @@ import org.strigate.ferrot.presentation.screen.AboutScreen
 import org.strigate.ferrot.presentation.screen.DownloadScreen
 import org.strigate.ferrot.presentation.screen.DownloadsScreen
 import org.strigate.ferrot.presentation.screen.SettingsScreen
+import org.strigate.ferrot.presentation.screen.UpdatesScreen
 
 @Composable
 fun MainNavHost(
@@ -49,6 +50,9 @@ fun MainNavHost(
                 navController = navController,
             )
         }
+        composable(Screen.Updates.route) {
+            UpdatesScreen()
+        }
         composable(Screen.About.route) {
             AboutScreen()
         }
@@ -63,5 +67,6 @@ sealed class Screen(val route: String) {
     }
 
     data object Settings : Screen("settings")
+    data object Updates : Screen("updates")
     data object About : Screen("about")
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
@@ -1,0 +1,6 @@
+package org.strigate.ferrot.presentation.model
+
+data class UpdatesUiData(
+    val automaticUpdates: Boolean,
+    val automaticDependencyUpdates: Boolean,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -3,6 +3,7 @@ package org.strigate.ferrot.presentation.screen
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -22,26 +23,24 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.navigation.NavController
 import org.strigate.ferrot.R
-import org.strigate.ferrot.presentation.Screen
-import org.strigate.ferrot.presentation.component.settings.ExpandableSettingsSection
+import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
 import org.strigate.ferrot.presentation.component.settings.SwitchSetting
-import org.strigate.ferrot.presentation.component.settings.TextNavigateSetting
+import org.strigate.ferrot.presentation.component.settings.TextSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
-import org.strigate.ferrot.presentation.state.SettingsUiState
-import org.strigate.ferrot.presentation.viewmodel.SettingsViewModel
+import org.strigate.ferrot.presentation.state.UpdatesUiState
+import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.ferrot.presentation.viewmodel.UpdatesViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(
-    navController: NavController,
+fun UpdatesScreen(
     modifier: Modifier = Modifier,
-    viewModel: SettingsViewModel = hiltViewModel(),
+    viewModel: UpdatesViewModel = hiltViewModel(),
 ) {
+    val dimens = LocalDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
 
@@ -54,9 +53,7 @@ fun SettingsScreen(
             TopAppBar(
                 navigationIcon = {
                     IconButton(
-                        onClick = {
-                            backDispatcher?.onBackPressed()
-                        },
+                        onClick = { backDispatcher?.onBackPressed() },
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -65,68 +62,74 @@ fun SettingsScreen(
                     }
                 },
                 title = {
-                    Text(
-                        text = stringResource(R.string.screen_title_settings),
-                    )
+                    Text(text = stringResource(R.string.screen_title_updates))
                 },
             )
         },
         content = { contentPadding ->
             Surface(
                 modifier = modifier
+                    .fillMaxSize()
                     .padding(contentPadding),
             ) {
                 when (val state = uiState) {
-                    is SettingsUiState.Loading -> LoadingState()
-                    is SettingsUiState.Error -> SettingsError()
-                    is SettingsUiState.Data -> {
+                    is UpdatesUiState.Loading -> LoadingState()
+                    is UpdatesUiState.Error -> UpdatesError()
+                    is UpdatesUiState.Data -> {
                         with(state.data) {
                             Column(
                                 modifier = Modifier
-                                    .padding(horizontal = 12.dp)
+                                    .fillMaxSize()
+                                    .padding(horizontal = dimens.spacingMediumAlt)
                                     .verticalScroll(rememberScrollState()),
                             ) {
-                                ExpandableSettingsSection(
-                                    text = stringResource(id = R.string.settings_section_general),
-                                    initialExpanded = true,
+                                StaticSettingsSection(
+                                    text = stringResource(R.string.settings_section_app),
                                 ) {
                                     SwitchSetting(
-                                        text = stringResource(id = R.string.settings_title_download_wifi_only),
-                                        description = stringResource(id = R.string.settings_description_download_wifi_only),
-                                        checked = downloadWifiOnly,
+                                        text = stringResource(R.string.settings_title_automatic_updates),
+                                        description = stringResource(R.string.settings_description_automatic_updates),
+                                        checked = automaticUpdates,
                                         onCheckedChange = { checked ->
-                                            viewModel.setDownloadWifiOnly(checked)
+                                            viewModel.setAutomaticUpdates(checked)
+                                        },
+                                    )
+                                    TextSetting(
+                                        text = stringResource(R.string.settings_title_check_now),
+                                        description = stringResource(R.string.settings_description_check_now),
+                                    ) {
+                                        viewModel.checkNow()
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                StaticSettingsSection(
+                                    text = stringResource(R.string.settings_section_dependencies),
+                                ) {
+                                    SwitchSetting(
+                                        text = stringResource(R.string.settings_title_automatic_dependency_updates),
+                                        description = stringResource(R.string.settings_description_automatic_dependency_updates),
+                                        checked = automaticDependencyUpdates,
+                                        onCheckedChange = { checked ->
+                                            viewModel.setAutomaticDependencyUpdates(checked)
                                         },
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(8.dp))
-                                TextNavigateSetting(
-                                    text = stringResource(R.string.settings_navigate_title_updates),
-                                ) {
-                                    navController.navigate(Screen.Updates.route)
-                                }
-                                Spacer(modifier = Modifier.height(8.dp))
-                                TextNavigateSetting(
-                                    text = stringResource(R.string.settings_navigate_title_about),
-                                ) {
-                                    navController.navigate(Screen.About.route)
-                                }
-                                Spacer(modifier = Modifier.height(16.dp))
+                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
                             }
                         }
                     }
                 }
             }
-        }
+        },
     )
 }
 
 @Composable
-private fun SettingsError(
+private fun UpdatesError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
         modifier = modifier,
-        text = stringResource(R.string.error_failed_to_load_settings),
+        text = stringResource(R.string.error_failed_to_load_update_settings),
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/state/UpdatesUiState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/state/UpdatesUiState.kt
@@ -1,0 +1,9 @@
+package org.strigate.ferrot.presentation.state
+
+import org.strigate.ferrot.presentation.model.UpdatesUiData
+
+sealed interface UpdatesUiState {
+    object Loading : UpdatesUiState
+    data class Data(val data: UpdatesUiData) : UpdatesUiState
+    object Error : UpdatesUiState
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -1,0 +1,85 @@
+package org.strigate.ferrot.presentation.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.strigate.ferrot.R
+import org.strigate.ferrot.analytics.AnalyticsEvents
+import org.strigate.ferrot.analytics.AnalyticsLogger
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.presentation.model.UpdatesUiData
+import org.strigate.ferrot.presentation.state.UpdatesUiState
+import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
+import org.strigate.ferrot.work.UpdateDependenciesWorker
+import javax.inject.Inject
+
+@HiltViewModel
+class UpdatesViewModel @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
+    private val analyticsLogger: AnalyticsLogger,
+    private val settingsUseCase: SettingsUseCase,
+) : ViewModel() {
+    val uiState: StateFlow<UpdatesUiState> = getUiState().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+        initialValue = UpdatesUiState.Loading,
+    )
+
+    private fun getUiState(): Flow<UpdatesUiState> {
+        return combine(
+            settingsUseCase.getAutomaticUpdatesSettingAsFlowUseCase(),
+            settingsUseCase.getAutomaticDependencyUpdatesSettingAsFlowUseCase(),
+        ) { automaticUpdates, automaticDependencyUpdates ->
+            UpdatesUiState.Data(
+                UpdatesUiData(
+                    automaticUpdates = automaticUpdates,
+                    automaticDependencyUpdates = automaticDependencyUpdates,
+                ),
+            )
+        }
+    }
+
+    fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.UPDATES)
+
+    fun setAutomaticUpdates(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsUseCase.saveAutomaticUpdatesSettingUseCase(enabled)
+            if (enabled) {
+                DownloadAvailableUpdateWorker.enqueuePeriodicKeep(appContext)
+            } else {
+                DownloadAvailableUpdateWorker.cancelPeriodic(appContext)
+            }
+        }
+    }
+
+    fun checkNow() {
+        viewModelScope.launch {
+            appContext.toast(appContext.getString(R.string.toast_checking_for_updates))
+            DownloadAvailableUpdateWorker.enqueueOneTimeReplace(appContext)
+        }
+    }
+
+    fun setAutomaticDependencyUpdates(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsUseCase.saveAutomaticDependencyUpdatesSettingAsFlowUseCase(enabled)
+            if (enabled) {
+                UpdateDependenciesWorker.enqueuePeriodicKeep(appContext)
+            } else {
+                UpdateDependenciesWorker.cancelPeriodic(appContext)
+            }
+        }
+    }
+
+    companion object {
+        const val STOP_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -373,5 +373,9 @@ class DownloadAvailableUpdateWorker @AssistedInject constructor(
                 oneTimeWorkRequest,
             )
         }
+
+        fun cancelPeriodic(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_DOWNLOAD_AVAILABLE_UPDATE)
+        }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -66,5 +66,9 @@ class UpdateDependenciesWorker @AssistedInject constructor(
                 periodicWorkRequest,
             )
         }
+
+        fun cancelPeriodic(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_UPDATE_DEPENDENCIES)
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
 
     <string name="screen_title_download">Download</string>
     <string name="screen_title_settings">Settings</string>
+    <string name="screen_title_updates">Updates</string>
     <string name="screen_title_about">About</string>
 
     <string name="downloads_intro_title">Share to %1$s</string>
@@ -54,24 +55,32 @@
     <string name="snackbar_delete_deleted">Deleted</string>
     <string name="snackbar_delete_undo">Undo</string>
 
+    <string name="toast_checking_for_updates">Checking for updates</string>
     <string name="toast_saved_to">Saved to %1$s</string>
     <string name="toast_file_exists">File already exists in %1$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
 
     <string name="settings_section_general">General</string>
     <string name="settings_section_app_info">App info</string>
+    <string name="settings_section_app">App</string>
+    <string name="settings_section_dependencies">Dependencies</string>
 
+    <string name="settings_navigate_title_updates">Updates</string>
     <string name="settings_navigate_title_about">About</string>
 
     <string name="settings_title_download_wifi_only">Download over Wi-Fi only</string>
-    <string name="settings_title_app_update">App update</string>
+    <string name="settings_title_automatic_updates">Automatic updates</string>
+    <string name="settings_title_check_now">Check now</string>
+    <string name="settings_title_automatic_dependency_updates">Automatic dependency updates</string>
     <string name="settings_title_build">Build</string>
     <string name="settings_title_website">Website</string>
     <string name="settings_title_privacy">Privacy</string>
     <string name="settings_title_license">License</string>
 
     <string name="settings_description_download_wifi_only">Restrict downloads to Wi-Fi connections only</string>
-    <string name="settings_description_app_update">Download and install</string>
+    <string name="settings_description_automatic_updates">Automatically check for and download app updates, and notify when ready to install</string>
+    <string name="settings_description_check_now">Check for updates now</string>
+    <string name="settings_description_automatic_dependency_updates">Automatically download and apply updates for dependencies</string>
     <string name="settings_description_privacy">View Privacy Policy</string>
     <string name="settings_description_license">GNU General Public License v3.0</string>
 
@@ -87,4 +96,5 @@
     <string name="error_failed_to_load_downloads">Failed to load downloads</string>
     <string name="error_failed_to_load_download">Failed to load download</string>
     <string name="error_failed_to_load_settings">Failed to load settings</string>
+    <string name="error_failed_to_load_update_settings">Failed to load update settings</string>
 </resources>


### PR DESCRIPTION
- Add `UpdatesScreen` and `UpdatesViewModel` with toggles and manual check
- Add `UpdatesUiState` and `UpdatesUiData`
- Extend `SettingsRepository` and `SettingsUseCase` for automatic update options
- Add worker cancel methods and gate periodic work in `Ferrot`
- Add analytics event for `updates_screen`
- Update strings for new update settings and toast messages