### PR TITLE
chore: Update Kotlin and KSP versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ firebaseBom = "34.4.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-kotlin = "2.2.20"
-ksp = "2.2.20-2.0.3"
+kotlin = "2.2.21"
+ksp = "2.2.21-2.0.4"
 
 [libraries]
 # Core


### PR DESCRIPTION
- Bump `kotlin` to `2.2.21`
- Bump `ksp` to `2.2.21-2.0.4`