### PR TITLE
feat: Use `Dimens` across download-related screens

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
@@ -72,6 +71,7 @@ import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
+import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.viewmodel.DownloadViewModel
 import java.io.File
 
@@ -197,12 +197,13 @@ private fun DownloadContent(
     onPlayClick: () -> Unit,
     onRetryClick: () -> Unit,
 ) {
+    val dimens = LocalDimens.current
     with(data) {
         Column(
             Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = dimens.spacingMedium),
             verticalArrangement = Arrangement.Top,
         ) {
             Text(
@@ -211,7 +212,7 @@ private fun DownloadContent(
                 maxLines = 2,
                 text = title,
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
             DownloadProgressSection(
                 status = status,
                 progressFraction = progressFraction,
@@ -219,7 +220,7 @@ private fun DownloadContent(
                 bytesDownloaded = bytesDownloaded,
                 forcePrimaryBar = status == DownloadStatusUiData.COMPLETED,
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingMedium))
             ThumbnailCard(
                 thumbnailFilePath = thumbnailFilePath,
                 showPlay = status == DownloadStatusUiData.COMPLETED && !filePath.isNullOrBlank(),
@@ -227,9 +228,9 @@ private fun DownloadContent(
                 onPlayClick = onPlayClick,
                 onRetryClick = onRetryClick,
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingMedium))
             HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingSmall))
             Column {
                 MetaItem(
                     label = stringResource(R.string.download_url),
@@ -256,6 +257,7 @@ private fun ThumbnailCard(
     onPlayClick: () -> Unit,
     onRetryClick: () -> Unit,
 ) {
+    val dimens = LocalDimens.current
     val thumbnailFile = thumbnailFilePath
         ?.let { File(it) }
         ?.takeIf { it.exists() && it.length() > 0 }
@@ -271,9 +273,9 @@ private fun ThumbnailCard(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(240.dp),
+            .height(dimens.thumbnailHeight),
         shape = MaterialTheme.shapes.medium,
-        tonalElevation = 1.dp,
+        tonalElevation = dimens.tonalElevationLow,
     ) {
         val modifier = Modifier.fillMaxSize()
         val clickableModifier = if (onClick != null) {
@@ -314,7 +316,7 @@ private fun ThumbnailCard(
                     ) {
                         Icon(
                             modifier = Modifier
-                                .size(48.dp),
+                                .size(dimens.overlayIconSize),
                             imageVector = Icons.Filled.Image,
                             contentDescription = thumbnailContentDescription,
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -336,7 +338,7 @@ private fun ThumbnailCard(
                 Box(
                     modifier = Modifier
                         .align(Alignment.Center)
-                        .size(56.dp)
+                        .size(dimens.overlayButtonSize)
                         .clip(CircleShape)
                         .background(Color.Black.copy(alpha = 0.35f)),
                     contentAlignment = Alignment.Center,
@@ -360,6 +362,7 @@ private fun MetaItem(
     isCopyable: Boolean = false,
     isUrl: Boolean = false,
 ) {
+    val dimens = LocalDimens.current
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     Row(
@@ -370,15 +373,15 @@ private fun MetaItem(
         Column(
             modifier = Modifier
                 .weight(1f)
-                .padding(end = 4.dp),
+                .padding(end = dimens.spacingXSmall),
         ) {
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingXSmall))
             Text(
                 color = MaterialTheme.colorScheme.primary,
                 style = MaterialTheme.typography.labelLarge,
                 text = label,
             )
-            Spacer(modifier = Modifier.height(2.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingXXSmall))
             if (isUrl) {
                 Text(
                     modifier = Modifier.clickable(
@@ -398,14 +401,14 @@ private fun MetaItem(
                     style = MaterialTheme.typography.bodySmall,
                 )
             }
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(dimens.spacingSmall))
         }
         if (isCopyable) {
             ActionIconButton(
                 modifier = Modifier
-                    .padding(0.dp)
+                    .padding(dimens.zero)
                     .align(Alignment.CenterVertically),
-                iconSize = 38.dp,
+                iconSize = dimens.actionIconSize,
                 enabled = true,
                 imageVector = Icons.Filled.ContentCopy,
                 onClick = {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -79,6 +78,7 @@ import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.model.DownloadItemUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.state.DownloadsUiState
+import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.LifecycleEffect
 import org.strigate.ferrot.presentation.viewmodel.DownloadsViewModel
 import kotlin.math.abs
@@ -90,6 +90,7 @@ fun DownloadsScreen(
     modifier: Modifier = Modifier,
     viewModel: DownloadsViewModel = hiltViewModel(),
 ) {
+    val dimens = LocalDimens.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -105,7 +106,7 @@ fun DownloadsScreen(
                 navigationIcon = {
                     IconButton(
                         modifier = Modifier
-                            .padding(4.dp),
+                            .padding(dimens.spacingXSmall),
                         onClick = {},
                     ) {
                         Icon(
@@ -179,8 +180,8 @@ fun DownloadsScreen(
                                     AvailableUpdateBanner(
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .padding(horizontal = 12.dp)
-                                            .padding(bottom = 8.dp),
+                                            .padding(horizontal = dimens.spacingMediumAlt)
+                                            .padding(bottom = dimens.spacingSmall),
                                         tag = it.tag,
                                         localFilePath = it.localFilePath,
                                         onClick = { filePath ->
@@ -247,21 +248,25 @@ private fun AvailableUpdateBanner(
     onClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val dimens = LocalDimens.current
     if (!localFilePath.isNullOrBlank()) {
         Surface(
             modifier = modifier
                 .clickable {
                     onClick(localFilePath)
                 },
-            tonalElevation = 3.dp,
-            shadowElevation = 1.dp,
+            tonalElevation = dimens.tonalElevationHigh,
+            shadowElevation = dimens.shadowElevationLow,
             shape = MaterialTheme.shapes.medium,
             color = MaterialTheme.colorScheme.secondaryContainer,
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(
+                        horizontal = dimens.spacingMedium,
+                        vertical = dimens.spacingMediumAlt,
+                    ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
@@ -269,7 +274,7 @@ private fun AvailableUpdateBanner(
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
-                Spacer(Modifier.width(12.dp))
+                Spacer(Modifier.width(dimens.spacingMediumAlt))
                 Text(
                     text = stringResource(R.string.available_update_ready, tag ?: ""),
                     style = MaterialTheme.typography.bodyMedium,
@@ -291,6 +296,8 @@ private fun DownloadsList(
     onDelete: (Long) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
+    val dimens = LocalDimens.current
+
     val listState = rememberLazyListState()
     var activeSwipeId by rememberSaveable { mutableStateOf<Long?>(null) }
     var pendingDeleteIds by rememberSaveable { mutableStateOf(setOf<Long>()) }
@@ -395,7 +402,7 @@ private fun DownloadsList(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 12.dp),
+                .padding(horizontal = dimens.spacingMediumAlt),
             state = listState,
         ) {
             items(
@@ -462,7 +469,7 @@ private fun DownloadsList(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = 8.dp)
+                            .padding(bottom = dimens.spacingSmall)
                             .onGloballyPositioned { layoutCoordinates ->
                                 rowWidthPx = layoutCoordinates.size.width.toFloat()
                             },
@@ -484,7 +491,7 @@ private fun DownloadsList(
                                         Row(
                                             modifier = Modifier
                                                 .align(Alignment.CenterEnd)
-                                                .padding(horizontal = 16.dp),
+                                                .padding(horizontal = dimens.spacingMedium),
                                             verticalAlignment = Alignment.CenterVertically,
                                         ) {
                                             Icon(
@@ -527,16 +534,17 @@ private fun DownloadItem(
     onPauseResume: () -> Unit,
     onOpen: () -> Unit,
 ) {
+    val dimens = LocalDimens.current
     Surface(
         shape = MaterialTheme.shapes.medium,
-        tonalElevation = 4.dp,
-        shadowElevation = 1.dp,
+        tonalElevation = dimens.tonalElevationHigh,
+        shadowElevation = dimens.shadowElevationLow,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable(onClick = onClick)
-                .padding(12.dp),
+                .padding(dimens.spacingMediumAlt),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start,
         ) {
@@ -547,7 +555,7 @@ private fun DownloadItem(
             )
             Column(
                 modifier = Modifier
-                    .padding(start = 12.dp)
+                    .padding(start = dimens.spacingMediumAlt)
                     .weight(1f),
             ) {
                 Text(
@@ -557,7 +565,7 @@ private fun DownloadItem(
                     maxLines = 1,
                     text = item.title,
                 )
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
                 DownloadProgressSection(
                     status = item.status,
                     progressFraction = item.progressFraction,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import org.strigate.ferrot.R
@@ -33,6 +32,7 @@ import org.strigate.ferrot.presentation.component.settings.TextNavigateSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.state.SettingsUiState
+import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.viewmodel.SettingsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,6 +42,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
+    val dimens = LocalDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
 
@@ -83,7 +84,7 @@ fun SettingsScreen(
                         with(state.data) {
                             Column(
                                 modifier = Modifier
-                                    .padding(horizontal = 12.dp)
+                                    .padding(horizontal = dimens.spacingMediumAlt)
                                     .verticalScroll(rememberScrollState()),
                             ) {
                                 ExpandableSettingsSection(
@@ -99,25 +100,25 @@ fun SettingsScreen(
                                         },
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(8.dp))
+                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 TextNavigateSetting(
                                     text = stringResource(R.string.settings_navigate_title_updates),
                                 ) {
                                     navController.navigate(Screen.Updates.route)
                                 }
-                                Spacer(modifier = Modifier.height(8.dp))
+                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 TextNavigateSetting(
                                     text = stringResource(R.string.settings_navigate_title_about),
                                 ) {
                                     navController.navigate(Screen.About.route)
                                 }
-                                Spacer(modifier = Modifier.height(16.dp))
+                                Spacer(modifier = Modifier.height(dimens.spacingMedium))
                             }
                         }
                     }
                 }
             }
-        }
+        },
     )
 }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.unit.dp
 data class Dimens(
     val zero: Dp = 0.dp,
 
+    val spacingXXSmall: Dp = 2.dp,
+    val spacingXSmall: Dp = 4.dp,
     val spacingSmall: Dp = 8.dp,
     val spacingMediumAlt: Dp = 12.dp,
     val spacingMedium: Dp = 16.dp,
@@ -24,9 +26,17 @@ data class Dimens(
     val radiusMedium: Dp = 8.dp,
     val radiusLarge: Dp = 16.dp,
 
-    val stroke: Dp = 1.dp,
+    val tonalElevationLow: Dp = 1.dp,
+    val tonalElevationHigh: Dp = 4.dp,
+
+    val shadowElevationLow: Dp = 1.dp,
 
     val contentMaxWidth: Dp = 320.dp,
+
+    val thumbnailHeight: Dp = 240.dp,
+    val overlayButtonSize: Dp = 56.dp,
+    val overlayIconSize: Dp = 48.dp,
+    val actionIconSize: Dp = 38.dp
 )
 
 val LocalDimens = staticCompositionLocalOf<Dimens> {


### PR DESCRIPTION
- Add `spacingXXSmall`, `spacingXSmall`, and new spacing presets to `Dimens`
- Add `tonalElevationLow`, `tonalElevationHigh`, and `shadowElevationLow` to `Dimens`
- Add media/ui sizes to `Dimens` (`thumbnailHeight`, `overlayButtonSize`, `overlayIconSize`, `actionIconSize`)
- Update `DownloadScreen` to use `LocalDimens` for padding, spacing, and thumbnail/card layout
- Update `DownloadsScreen` to use `LocalDimens` for list padding, banner elevation, and item spacing
- Update `SettingsScreen` to use `LocalDimens` for horizontal padding and section spacing