### PR TITLE
feat: Localize download action content descriptions

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -11,24 +11,27 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
+import org.strigate.ferrot.presentation.theme.LocalDimens
 
 @Composable
 fun DownloadPrimaryActionButton(
     status: DownloadStatusUiData,
+    modifier: Modifier = Modifier,
     onPauseResume: () -> Unit,
     onOpen: () -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    val actionConfig: ActionConfig = when (status) {
+    val dimens = LocalDimens.current
+    val actionConfig = when (status) {
         DownloadStatusUiData.QUEUED,
         DownloadStatusUiData.WAITING_FOR_NETWORK,
         DownloadStatusUiData.WAITING_FOR_WIFI,
         DownloadStatusUiData.METADATA,
         DownloadStatusUiData.DOWNLOADING -> ActionConfig(
             icon = Icons.Filled.Stop,
-            contentDescription = "Stop download",
+            contentDescription = stringResource(R.string.content_description_stop_download),
             usePrimaryTint = true,
             onClick = onPauseResume,
         )
@@ -37,14 +40,14 @@ fun DownloadPrimaryActionButton(
         DownloadStatusUiData.STOPPED,
         DownloadStatusUiData.FAILED -> ActionConfig(
             icon = Icons.Filled.Refresh,
-            contentDescription = "Resume download",
+            contentDescription = stringResource(R.string.content_description_resume_download),
             usePrimaryTint = true,
             onClick = onPauseResume,
         )
 
         DownloadStatusUiData.COMPLETED -> ActionConfig(
             icon = Icons.Filled.DownloadDone,
-            contentDescription = "Open",
+            contentDescription = stringResource(R.string.content_description_open_download),
             usePrimaryTint = false,
             onClick = onOpen,
         )
@@ -52,7 +55,7 @@ fun DownloadPrimaryActionButton(
     Surface(
         modifier = modifier,
         shape = MaterialTheme.shapes.medium,
-        tonalElevation = 1.dp,
+        tonalElevation = dimens.tonalElevationLow,
     ) {
         with(actionConfig) {
             IconButton(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -122,7 +122,7 @@ fun DownloadScreen(
                                 }
                             },
                             enabled = canSaveOrShare,
-                            contentDescription = stringResource(R.string.content_description_download),
+                            contentDescription = stringResource(R.string.content_description_save_to_device),
                             imageVector = Icons.Filled.Save,
                         )
                         ActionIconButton(
@@ -132,7 +132,7 @@ fun DownloadScreen(
                                 }
                             },
                             enabled = canSaveOrShare,
-                            contentDescription = stringResource(R.string.content_description_share),
+                            contentDescription = stringResource(R.string.content_description_share_download),
                             imageVector = Icons.Filled.Share,
                         )
                         ActionIconButton(
@@ -140,7 +140,7 @@ fun DownloadScreen(
                                 showConfirmDeleteDialog = true
                             },
                             enabled = true,
-                            contentDescription = stringResource(R.string.content_description_delete),
+                            contentDescription = stringResource(R.string.content_description_delete_download),
                             imageVector = Icons.Filled.Delete,
                         )
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,17 +84,20 @@
     <string name="settings_description_privacy">View Privacy Policy</string>
     <string name="settings_description_license">GNU General Public License v3.0</string>
 
-    <string name="content_description_back">Back</string>
-    <string name="content_description_thumbnail">Preview</string>
-    <string name="content_description_retry">Retry</string>
-    <string name="content_description_play">Play</string>
-    <string name="content_description_download">Save to device</string>
-    <string name="content_description_delete">Delete download</string>
-    <string name="content_description_share">Share download</string>
-    <string name="content_description_copy_to_clipboard">Copy to clipboard</string>
-
     <string name="error_failed_to_load_downloads">Failed to load downloads</string>
     <string name="error_failed_to_load_download">Failed to load download</string>
     <string name="error_failed_to_load_settings">Failed to load settings</string>
     <string name="error_failed_to_load_update_settings">Failed to load update settings</string>
+
+    <string name="content_description_back">Back</string>
+    <string name="content_description_thumbnail">Preview</string>
+    <string name="content_description_retry">Retry</string>
+    <string name="content_description_play">Play</string>
+    <string name="content_description_stop_download">Stop download</string>
+    <string name="content_description_resume_download">Resume download</string>
+    <string name="content_description_open_download">Open download</string>
+    <string name="content_description_save_to_device">Save to device</string>
+    <string name="content_description_delete_download">Delete download</string>
+    <string name="content_description_share_download">Share download</string>
+    <string name="content_description_copy_to_clipboard">Copy to clipboard</string>
 </resources>


### PR DESCRIPTION
- Add download-related error strings (`error_failed_to_load_downloads`, `error_failed_to_load_download`, `error_failed_to_load_settings`, `error_failed_to_load_update_settings`)
- Add content descriptions for download actions (`content_description_stop_download`, `content_description_resume_download`, `content_description_open_download`)
- Replace generic content descriptions in `DownloadScreen` with more explicit ones (`content_description_save_to_device`, `content_description_share_download`, `content_description_delete_download`)
- Update `DownloadPrimaryActionButton` to use `stringResource(...)` and `LocalDimens` for tonal elevation