### PR TITLE
feat: Align download progress with `LocalDimens`

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
@@ -1,7 +1,9 @@
 package org.strigate.ferrot.presentation.component
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -11,9 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
+import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
 
 @Composable
@@ -25,6 +27,7 @@ fun DownloadProgressSection(
     modifier: Modifier = Modifier,
     forcePrimaryBar: Boolean = false,
 ) {
+    val dimens = LocalDimens.current
     val running = when (status) {
         DownloadStatusUiData.QUEUED,
         DownloadStatusUiData.METADATA,
@@ -38,27 +41,30 @@ fun DownloadProgressSection(
         DownloadStatusUiData.STOPPED -> 0f
         else -> null
     }
-    DownloadProgressBar(
+    Column(
         modifier = modifier,
-        progress = progress,
-        running = running,
-        forcePrimary = forcePrimaryBar,
-    )
-    Box(
-        modifier = Modifier
-            .padding(top = 4.dp)
-            .height(20.dp),
     ) {
-        StatusSizeEtaRow(
-            status = status,
-            progressFraction = when (status) {
-                DownloadStatusUiData.COMPLETED -> 1f
-                DownloadStatusUiData.STOPPED -> 0f
-                else -> progressFraction
-            },
-            bytesDownloaded = bytesDownloaded,
-            etaSeconds = etaSeconds,
+        DownloadProgressBar(
+            progress = progress,
+            running = running,
+            forcePrimary = forcePrimaryBar,
         )
+        Spacer(modifier = Modifier.height(dimens.spacingXSmall))
+        Box(
+            modifier = Modifier
+                .height(dimens.spacingLarge),
+        ) {
+            StatusSizeEtaRow(
+                status = status,
+                progressFraction = when (status) {
+                    DownloadStatusUiData.COMPLETED -> 1f
+                    DownloadStatusUiData.STOPPED -> 0f
+                    else -> progressFraction
+                },
+                bytesDownloaded = bytesDownloaded,
+                etaSeconds = etaSeconds,
+            )
+        }
     }
 }
 
@@ -109,10 +115,11 @@ private fun InfoLine(
     modifier: Modifier = Modifier,
     isError: Boolean = false,
 ) {
+    val dimens = LocalDimens.current
     Row(
         modifier = modifier
-            .fillMaxWidth()
-            .padding(top = 6.dp),
+            .padding(top = dimens.spacingSmall)
+            .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (!leftText.isNullOrBlank()) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -548,30 +549,33 @@ private fun DownloadItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Start,
         ) {
-            DownloadPrimaryActionButton(
-                status = item.status,
-                onPauseResume = onPauseResume,
-                onOpen = onOpen,
-            )
-            Column(
-                modifier = Modifier
-                    .padding(start = dimens.spacingMediumAlt)
-                    .weight(1f),
-            ) {
-                Text(
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                    text = item.title,
+            with(item) {
+                DownloadPrimaryActionButton(
+                    onPauseResume = onPauseResume,
+                    onOpen = onOpen,
+                    status = status,
                 )
-                Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
-                DownloadProgressSection(
-                    status = item.status,
-                    progressFraction = item.progressFraction,
-                    etaSeconds = item.etaSeconds,
-                    bytesDownloaded = item.bytesDownloaded,
-                )
+                Spacer(modifier = Modifier.width(dimens.spacingMediumAlt))
+                Column(
+                    modifier = Modifier
+                        .wrapContentHeight()
+                        .weight(1f),
+                ) {
+                    Text(
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        text = title,
+                    )
+                    Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
+                    DownloadProgressSection(
+                        status = status,
+                        progressFraction = progressFraction,
+                        etaSeconds = etaSeconds,
+                        bytesDownloaded = bytesDownloaded,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
- Wrap `DownloadProgressSection` in `Column` to stack progress bar and status
- Use `LocalDimens` for vertical spacing instead of hardcoded `dp`
- Adjust `StatusSizeEtaRow` padding to use `dimens.spacingSmall`
- Make downloads list item use `wrapContentHeight()` and spacing between button and content
- Keep progress row height consistent with `dimens.spacingLarge`