### PR TITLE
refactor: Apply dimens and clean up redundant params

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/ActionIconButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/ActionIconButton.kt
@@ -15,21 +15,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import org.strigate.ferrot.presentation.theme.LocalDimens
 
 @Composable
 fun ActionIconButton(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     onClick: () -> Unit,
     imageVector: ImageVector,
     contentDescription: String,
-    modifier: Modifier = Modifier,
-    iconSize: Dp = 40.dp,
-    enabled: Boolean = true,
 ) {
+    val dimens = LocalDimens.current
     Box(
         modifier = modifier
-            .size(iconSize)
+            .size(dimens.actionIconSize)
             .clip(CircleShape)
             .clickable(
                 enabled = enabled,
@@ -37,7 +36,7 @@ fun ActionIconButton(
                 indication = LocalIndication.current,
                 onClick = onClick,
             )
-            .padding(8.dp),
+            .padding(dimens.spacingSmall),
         contentAlignment = Alignment.Center,
     ) {
         Icon(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressBar.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressBar.kt
@@ -8,15 +8,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import org.strigate.ferrot.presentation.theme.LocalDimens
 
 @Composable
 fun DownloadProgressBar(
-    progress: Float?,
-    running: Boolean,
     modifier: Modifier = Modifier,
+    running: Boolean,
+    progress: Float?,
     forcePrimary: Boolean = false,
 ) {
+    val dimens = LocalDimens.current
     val barColor = when {
         forcePrimary -> MaterialTheme.colorScheme.primary
         running -> MaterialTheme.colorScheme.primary
@@ -26,7 +27,7 @@ fun DownloadProgressBar(
         LinearProgressIndicator(
             modifier = modifier
                 .fillMaxWidth()
-                .height(4.dp),
+                .height(dimens.spacingXSmall),
             color = barColor,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )
@@ -43,7 +44,7 @@ fun DownloadProgressBar(
             },
             modifier = modifier
                 .fillMaxWidth()
-                .height(4.dp),
+                .height(dimens.spacingXSmall),
             color = barColor,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -408,7 +408,6 @@ private fun MetaItem(
                 modifier = Modifier
                     .padding(dimens.zero)
                     .align(Alignment.CenterVertically),
-                iconSize = dimens.actionIconSize,
                 enabled = true,
                 imageVector = Icons.Filled.ContentCopy,
                 onClick = {


### PR DESCRIPTION
- Remove explicit `iconSize` param usage in `DownloadScreen`
- Use `LocalDimens` for `ActionIconButton` sizing and padding
- Apply `LocalDimens` to `DownloadProgressBar` height
- Reorder parameters for consistency and composable guidelines