### PR TITLE
feat: Show last-checked timestamps and persist update checks

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -84,6 +84,12 @@ object Constants {
     object State {
         const val KEY_BOOT_TIME_MILLIS = "boot_time_millis"
         const val DEFAULT_VALUE_BOOT_TIME_MILLIS = 0L
+
+        const val KEY_LAST_AVAILABLE_UPDATE_CHECK_MILLIS = "last_available_update_check_millis"
+        const val DEFAULT_VALUE_LAST_AVAILABLE_UPDATE_CHECK_MILLIS = 0L
+
+        const val KEY_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS = "last_dependency_update_check_millis"
+        const val DEFAULT_VALUE_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS = 0L
     }
 
     object Extras {

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -13,6 +13,7 @@ import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.domain.usecase.combined.GetPendingDownloadsCombinedUseCase
@@ -28,6 +29,7 @@ import javax.inject.Singleton
 class WorkerFactory @Inject constructor(
     private val hiltWorkerFactory: HiltWorkerFactory,
     private val analyticsLogger: AnalyticsLogger,
+    private val stateUseCase: StateUseCase,
     private val notificationService: NotificationService,
     private val updatePathProvider: UpdatePathProvider,
     private val downloadPathProvider: DownloadPathProvider,
@@ -50,6 +52,7 @@ class WorkerFactory @Inject constructor(
                 DownloadAvailableUpdateWorker(
                     appContext = appContext,
                     workerParameters = workerParameters,
+                    stateUseCase = stateUseCase,
                     updatePathProvider = updatePathProvider,
                     notificationService = notificationService,
                     availableUpdateUseCase = availableUpdateUseCase,
@@ -60,6 +63,7 @@ class WorkerFactory @Inject constructor(
                 UpdateDependenciesWorker(
                     appContext = appContext,
                     workerParameters = workerParameters,
+                    stateUseCase = stateUseCase,
                 )
             }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImpl.kt
@@ -7,7 +7,11 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_BOOT_TIME_MILLIS
+import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_LAST_AVAILABLE_UPDATE_CHECK_MILLIS
+import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS
 import org.strigate.ferrot.app.Constants.State.KEY_BOOT_TIME_MILLIS
+import org.strigate.ferrot.app.Constants.State.KEY_LAST_AVAILABLE_UPDATE_CHECK_MILLIS
+import org.strigate.ferrot.app.Constants.State.KEY_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS
 import org.strigate.ferrot.domain.repository.StateRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,6 +22,10 @@ class StateRepositoryImpl @Inject constructor(
 ) : StateRepository {
     private val bootTimeMillisKey =
         longPreferencesKey(KEY_BOOT_TIME_MILLIS)
+    private val lastAvailableUpdateCheckMillisKey =
+        longPreferencesKey(KEY_LAST_AVAILABLE_UPDATE_CHECK_MILLIS)
+    private val lastDependencyUpdateCheckMillisKey =
+        longPreferencesKey(KEY_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS)
 
     override fun getBootTimeMillisAsFlow(): Flow<Long> {
         return preferencesDataStore.data.map {
@@ -28,6 +36,32 @@ class StateRepositoryImpl @Inject constructor(
     override suspend fun saveBootTimeMillis(millis: Long) {
         preferencesDataStore.edit {
             it[bootTimeMillisKey] = millis
+        }
+    }
+
+    override fun getLastAvailableUpdateCheckMillisAsFlow(): Flow<Long> {
+        return preferencesDataStore.data.map {
+            it[lastAvailableUpdateCheckMillisKey]
+                ?: DEFAULT_VALUE_LAST_AVAILABLE_UPDATE_CHECK_MILLIS
+        }
+    }
+
+    override suspend fun saveLastAvailableUpdateCheckMillis(millis: Long) {
+        preferencesDataStore.edit {
+            it[lastAvailableUpdateCheckMillisKey] = millis
+        }
+    }
+
+    override fun getLastDependencyUpdateCheckMillisAsFlow(): Flow<Long> {
+        return preferencesDataStore.data.map {
+            it[lastDependencyUpdateCheckMillisKey]
+                ?: DEFAULT_VALUE_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS
+        }
+    }
+
+    override suspend fun saveLastDependencyUpdateCheckMillis(millis: Long) {
+        preferencesDataStore.edit {
+            it[lastDependencyUpdateCheckMillisKey] = millis
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/repository/StateRepository.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/repository/StateRepository.kt
@@ -5,4 +5,8 @@ import kotlinx.coroutines.flow.Flow
 interface StateRepository {
     fun getBootTimeMillisAsFlow(): Flow<Long>
     suspend fun saveBootTimeMillis(millis: Long)
+    fun getLastAvailableUpdateCheckMillisAsFlow(): Flow<Long>
+    suspend fun saveLastAvailableUpdateCheckMillis(millis: Long)
+    fun getLastDependencyUpdateCheckMillisAsFlow(): Flow<Long>
+    suspend fun saveLastDependencyUpdateCheckMillis(millis: Long)
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/StateUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/StateUseCase.kt
@@ -1,10 +1,18 @@
 package org.strigate.ferrot.domain.usecase
 
 import org.strigate.ferrot.domain.usecase.state.GetBootTimeMillisUseCase
+import org.strigate.ferrot.domain.usecase.state.GetLastAvailableUpdateCheckMillisUseCase
+import org.strigate.ferrot.domain.usecase.state.GetLastDependencyUpdateCheckMillisUseCase
 import org.strigate.ferrot.domain.usecase.state.SaveBootTimeMillisUseCase
+import org.strigate.ferrot.domain.usecase.state.SaveLastAvailableUpdateCheckMillisUseCase
+import org.strigate.ferrot.domain.usecase.state.SaveLastDependencyUpdateCheckMillisUseCase
 import javax.inject.Inject
 
 class StateUseCase @Inject constructor(
     val saveBootTimeMillisUseCase: SaveBootTimeMillisUseCase,
     val getBootTimeMillisUseCase: GetBootTimeMillisUseCase,
+    val saveLastAvailableUpdateCheckMillisUseCase: SaveLastAvailableUpdateCheckMillisUseCase,
+    val getLastAvailableUpdateCheckMillisUseCase: GetLastAvailableUpdateCheckMillisUseCase,
+    val saveLastDependencyUpdateCheckMillisUseCase: SaveLastDependencyUpdateCheckMillisUseCase,
+    val getLastDependencyUpdateCheckMillisUseCase: GetLastDependencyUpdateCheckMillisUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/GetLastAvailableUpdateCheckMillisUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/GetLastAvailableUpdateCheckMillisUseCase.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.domain.usecase.state
+
+import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.repository.StateRepository
+import javax.inject.Inject
+
+class GetLastAvailableUpdateCheckMillisUseCase @Inject constructor(
+    private val stateRepository: StateRepository,
+) {
+    operator fun invoke(): Flow<Long> {
+        return stateRepository.getLastAvailableUpdateCheckMillisAsFlow()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/GetLastDependencyUpdateCheckMillisUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/GetLastDependencyUpdateCheckMillisUseCase.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.domain.usecase.state
+
+import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.repository.StateRepository
+import javax.inject.Inject
+
+class GetLastDependencyUpdateCheckMillisUseCase @Inject constructor(
+    private val stateRepository: StateRepository,
+) {
+    operator fun invoke(): Flow<Long> {
+        return stateRepository.getLastDependencyUpdateCheckMillisAsFlow()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/SaveLastAvailableUpdateCheckMillisUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/SaveLastAvailableUpdateCheckMillisUseCase.kt
@@ -1,0 +1,12 @@
+package org.strigate.ferrot.domain.usecase.state
+
+import org.strigate.ferrot.domain.repository.StateRepository
+import javax.inject.Inject
+
+class SaveLastAvailableUpdateCheckMillisUseCase @Inject constructor(
+    private val stateRepository: StateRepository,
+) {
+    suspend operator fun invoke(millis: Long) {
+        stateRepository.saveLastAvailableUpdateCheckMillis(millis)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/SaveLastDependencyUpdateCheckMillisUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/state/SaveLastDependencyUpdateCheckMillisUseCase.kt
@@ -1,0 +1,12 @@
+package org.strigate.ferrot.domain.usecase.state
+
+import org.strigate.ferrot.domain.repository.StateRepository
+import javax.inject.Inject
+
+class SaveLastDependencyUpdateCheckMillisUseCase @Inject constructor(
+    private val stateRepository: StateRepository,
+) {
+    suspend operator fun invoke(millis: Long) {
+        stateRepository.saveLastDependencyUpdateCheckMillis(millis)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
@@ -1,7 +1,9 @@
 package org.strigate.ferrot.presentation.component.settings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -32,12 +34,12 @@ fun StaticSettingsSection(
             text?.let {
                 Text(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 2.dp, bottom = 8.dp),
+                        .fillMaxWidth(),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     text = it,
                 )
+                Spacer(modifier = Modifier.height(12.dp))
             }
             CompositionLocalProvider(
                 LocalContentColor provides MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
@@ -30,7 +30,7 @@ fun SwitchSetting(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = 8.dp, bottom = 4.dp),
+            .padding(vertical = 8.dp),
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
@@ -72,8 +72,8 @@ fun TextNavigateSetting(
                 }
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    contentDescription = null,
                 )
             }
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
@@ -27,10 +27,10 @@ fun TextSetting(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp)
+            .padding(vertical = 12.dp)
             .clickable(
-                indication = null,
                 interactionSource = remember { MutableInteractionSource() },
+                indication = null,
             ) {
                 onClick?.invoke()
             },
@@ -60,8 +60,6 @@ fun TextSetting(
                     )
                 } else {
                     Text(
-                        modifier = Modifier
-                            .padding(vertical = 2.dp),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                         text = text,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
@@ -3,4 +3,6 @@ package org.strigate.ferrot.presentation.model
 data class UpdatesUiData(
     val automaticUpdates: Boolean,
     val automaticDependencyUpdates: Boolean,
+    val lastAvailableUpdateCheckMillis: Long,
+    val lastDependencyUpdateCheckMillis: Long,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.strigate.ferrot.R
@@ -32,6 +33,7 @@ import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.state.UpdatesUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.ferrot.presentation.util.UiFormatter
 import org.strigate.ferrot.presentation.viewmodel.UpdatesViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -43,6 +45,7 @@ fun UpdatesScreen(
     val dimens = LocalDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -98,8 +101,15 @@ fun UpdatesScreen(
                                         text = stringResource(R.string.settings_title_check_now),
                                         description = stringResource(R.string.settings_description_check_now),
                                     ) {
-                                        viewModel.checkNow()
+                                        viewModel.checkForAvailableUpdate()
                                     }
+                                    TextSetting(
+                                        text = stringResource(R.string.settings_title_last_checked_for_updates),
+                                        description = UiFormatter.formatLastCheckedTime(
+                                            context,
+                                            lastAvailableUpdateCheckMillis,
+                                        ),
+                                    )
                                 }
                                 Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 StaticSettingsSection(
@@ -112,6 +122,13 @@ fun UpdatesScreen(
                                         onCheckedChange = { checked ->
                                             viewModel.setAutomaticDependencyUpdates(checked)
                                         },
+                                    )
+                                    TextSetting(
+                                        text = stringResource(R.string.settings_title_last_checked_for_dependency_updates),
+                                        description = UiFormatter.formatLastCheckedTime(
+                                            context,
+                                            lastDependencyUpdateCheckMillis,
+                                        ),
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(dimens.spacingSmall))

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/util/UiFormatter.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/util/UiFormatter.kt
@@ -1,5 +1,10 @@
 package org.strigate.ferrot.presentation.util
 
+import android.content.Context
+import android.text.format.DateFormat
+import android.text.format.DateUtils
+import org.strigate.ferrot.R
+import java.util.Date
 import java.util.Locale
 
 object UiFormatter {
@@ -29,5 +34,22 @@ object UiFormatter {
             minutes > 0 -> String.format(Locale.getDefault(), "%dm %ds", minutes, seconds)
             else -> String.format(Locale.getDefault(), "%ds", seconds)
         }
+    }
+
+    fun formatLastCheckedTime(context: Context, millis: Long): String {
+        if (millis <= 0L) {
+            return context.getString(R.string.never)
+        }
+        val relativeTime = DateUtils.getRelativeTimeSpanString(
+            millis,
+            System.currentTimeMillis(),
+            DateUtils.MINUTE_IN_MILLIS,
+            DateUtils.FORMAT_ABBREV_RELATIVE,
+        ).toString()
+
+        val dateFormat = DateFormat.getMediumDateFormat(context)
+        val timeFormat = DateFormat.getTimeFormat(context)
+        val exact = "${dateFormat.format(Date(millis))}, ${timeFormat.format(Date(millis))}"
+        return "$relativeTime ($exact)"
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -15,6 +15,7 @@ import org.strigate.ferrot.R
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.presentation.model.UpdatesUiData
 import org.strigate.ferrot.presentation.state.UpdatesUiState
@@ -27,6 +28,7 @@ class UpdatesViewModel @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
     private val analyticsLogger: AnalyticsLogger,
     private val settingsUseCase: SettingsUseCase,
+    private val stateUseCase: StateUseCase,
 ) : ViewModel() {
     val uiState: StateFlow<UpdatesUiState> = getUiState().stateIn(
         scope = viewModelScope,
@@ -38,11 +40,15 @@ class UpdatesViewModel @Inject constructor(
         return combine(
             settingsUseCase.getAutomaticUpdatesSettingAsFlowUseCase(),
             settingsUseCase.getAutomaticDependencyUpdatesSettingAsFlowUseCase(),
-        ) { automaticUpdates, automaticDependencyUpdates ->
+            stateUseCase.getLastAvailableUpdateCheckMillisUseCase(),
+            stateUseCase.getLastDependencyUpdateCheckMillisUseCase(),
+        ) { automaticUpdates, automaticDependencyUpdates, lastAppCheckMillis, lastDepsCheckMillis ->
             UpdatesUiState.Data(
                 UpdatesUiData(
                     automaticUpdates = automaticUpdates,
                     automaticDependencyUpdates = automaticDependencyUpdates,
+                    lastAvailableUpdateCheckMillis = lastAppCheckMillis,
+                    lastDependencyUpdateCheckMillis = lastDepsCheckMillis,
                 ),
             )
         }
@@ -61,9 +67,9 @@ class UpdatesViewModel @Inject constructor(
         }
     }
 
-    fun checkNow() {
+    fun checkForAvailableUpdate() {
         viewModelScope.launch {
-            appContext.toast(appContext.getString(R.string.toast_checking_for_updates))
+            appContext.toast(appContext.getString(R.string.toast_checking_for_available_update))
             DownloadAvailableUpdateWorker.enqueueOneTimeReplace(appContext)
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -33,6 +33,7 @@ import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.provider.UpdatePathProvider
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
+import org.strigate.ferrot.domain.usecase.StateUseCase
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -49,12 +50,16 @@ import java.util.concurrent.TimeUnit
 class DownloadAvailableUpdateWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParameters: WorkerParameters,
+    private val stateUseCase: StateUseCase,
     private val updatePathProvider: UpdatePathProvider,
     private val notificationService: NotificationService,
     private val availableUpdateUseCase: AvailableUpdateUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result {
         return try {
+            runCatching {
+                stateUseCase.saveLastAvailableUpdateCheckMillisUseCase(System.currentTimeMillis())
+            }
             val savedAvailableUpdate = runCatching {
                 availableUpdateUseCase.getAvailableUpdateAsFlowUseCase().first()
             }.getOrNull()

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -16,18 +16,23 @@ import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
+import org.strigate.ferrot.domain.usecase.StateUseCase
 import java.util.concurrent.TimeUnit
 
 @HiltWorker
 class UpdateDependenciesWorker @AssistedInject constructor(
     @Assisted private val appContext: Context,
     @Assisted workerParameters: WorkerParameters,
+    private val stateUseCase: StateUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result {
-        enableForeground(
-            notificationText = appContext.getString(R.string.worker_notification_text_updating_dependencies),
-        )
         return try {
+            enableForeground(
+                notificationText = appContext.getString(R.string.worker_notification_text_updating_dependencies),
+            )
+            runCatching {
+                stateUseCase.saveLastDependencyUpdateCheckMillisUseCase(System.currentTimeMillis())
+            }
             Log.d(LOG_TAG, "Updating YoutubeDL")
             val status = YoutubeDL.getInstance().updateYoutubeDL(
                 updateChannel = YoutubeDL.UpdateChannel.STABLE,
@@ -45,7 +50,7 @@ class UpdateDependenciesWorker @AssistedInject constructor(
         fun enqueuePeriodicKeep(
             context: Context,
             repeatIntervalDays: Long = 7,
-            flexHours: Long = 12,
+            flexHours: Long = 3,
         ) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="percent_0">0%</string>
     <string name="percent_100">100%</string>
     <string name="share_to">Share to…</string>
+    <string name="never">Never</string>
 
     <string name="confirm_dialog_delete_download_title">Delete download</string>
     <string name="confirm_dialog_delete_download_description">Are you sure you want to delete this download?</string>
@@ -55,7 +56,7 @@
     <string name="snackbar_delete_deleted">Deleted</string>
     <string name="snackbar_delete_undo">Undo</string>
 
-    <string name="toast_checking_for_updates">Checking for updates</string>
+    <string name="toast_checking_for_available_update">Checking for available update</string>
     <string name="toast_saved_to">Saved to %1$s</string>
     <string name="toast_file_exists">File already exists in %1$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
@@ -71,7 +72,9 @@
     <string name="settings_title_download_wifi_only">Download over Wi-Fi only</string>
     <string name="settings_title_automatic_updates">Automatic updates</string>
     <string name="settings_title_check_now">Check now</string>
+    <string name="settings_title_last_checked_for_updates">Last checked for updates</string>
     <string name="settings_title_automatic_dependency_updates">Automatic dependency updates</string>
+    <string name="settings_title_last_checked_for_dependency_updates">Last checked for dependency updates</string>
     <string name="settings_title_build">Build</string>
     <string name="settings_title_website">Website</string>
     <string name="settings_title_privacy">Privacy</string>


### PR DESCRIPTION
- Add `UiFormatter.formatLastCheckedTime` and `never` string
- Display "Last checked" rows in `UpdatesScreen` via `TextSetting` for app and dependency checks
- Inject `StateUseCase` into `UpdatesViewModel`, `WorkerFactory`, `DownloadAvailableUpdateWorker`, and `UpdateDependenciesWorker`
- Add `GetLastAvailableUpdateCheckMillisUseCase`, `SaveLastAvailableUpdateCheckMillisUseCase`
- Add `GetLastDependencyUpdateCheckMillisUseCase`, `SaveLastDependencyUpdateCheckMillisUseCase`
- Extend `StateRepository` and `StateRepositoryImpl` with `lastAvailableUpdateCheckMillis` and `lastDependencyUpdateCheckMillis`; add keys and defaults in `Constants.State`
- Rename `checkNow()` to `checkForAvailableUpdate()` and update toast to `toast_checking_for_available_update`
- Persist last-check timestamps at worker start via `stateUseCase`
- Adjust spacing and ordering in `TextSetting`, `SwitchSetting`, `StaticSettingsSection`, and `TextNavigateSetting`
- Reduce `UpdateDependenciesWorker.enqueuePeriodicKeep` `flexHours` to `3`