### PR TITLE
refactor: Split updates UI data and size arrow icons**

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
@@ -64,6 +65,8 @@ fun ExpandableSettingsSection(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
                 Icon(
+                    modifier = Modifier
+                        .size(20.dp),
                     imageVector = if (expanded) {
                         Icons.Filled.KeyboardArrowUp
                     } else {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
@@ -39,7 +39,7 @@ fun StaticSettingsSection(
                     color = MaterialTheme.colorScheme.onSurface,
                     text = it,
                 )
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(8.dp))
             }
             CompositionLocalProvider(
                 LocalContentColor provides MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
@@ -30,14 +30,14 @@ fun SwitchSetting(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp),
+            .padding(vertical = 12.dp),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable(
-                    indication = null,
                     interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
                 ) {
                     onCheckedChange(!checked)
                 },
@@ -64,12 +64,14 @@ fun SwitchSetting(
                 }
             }
             Switch(
-                checked = checked,
-                onCheckedChange = onCheckedChange,
+                modifier = Modifier
+                    .height(24.dp),
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.primary,
                     checkedTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
                 ),
+                onCheckedChange = onCheckedChange,
+                checked = checked,
             )
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
@@ -38,8 +39,8 @@ fun TextNavigateSetting(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                    interactionSource = remember { MutableInteractionSource() }
                 ) {
                     onClick()
                 }
@@ -71,6 +72,8 @@ fun TextNavigateSetting(
                     }
                 }
                 Icon(
+                    modifier = Modifier
+                        .size(20.dp),
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     contentDescription = null,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
@@ -1,8 +1,16 @@
 package org.strigate.ferrot.presentation.model
 
 data class UpdatesUiData(
+    val settings: UpdatesSettings,
+    val info: UpdatesInfo,
+)
+
+data class UpdatesSettings(
     val automaticUpdates: Boolean,
     val automaticDependencyUpdates: Boolean,
+)
+
+data class UpdatesInfo(
     val lastAvailableUpdateCheckMillis: Long,
     val lastDependencyUpdateCheckMillis: Long,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -92,7 +92,7 @@ fun UpdatesScreen(
                                     SwitchSetting(
                                         text = stringResource(R.string.settings_title_automatic_updates),
                                         description = stringResource(R.string.settings_description_automatic_updates),
-                                        checked = automaticUpdates,
+                                        checked = settings.automaticUpdates,
                                         onCheckedChange = { checked ->
                                             viewModel.setAutomaticUpdates(checked)
                                         },
@@ -107,7 +107,7 @@ fun UpdatesScreen(
                                         text = stringResource(R.string.settings_title_last_checked_for_updates),
                                         description = UiFormatter.formatLastCheckedTime(
                                             context,
-                                            lastAvailableUpdateCheckMillis,
+                                            info.lastAvailableUpdateCheckMillis,
                                         ),
                                     )
                                 }
@@ -118,7 +118,7 @@ fun UpdatesScreen(
                                     SwitchSetting(
                                         text = stringResource(R.string.settings_title_automatic_dependency_updates),
                                         description = stringResource(R.string.settings_description_automatic_dependency_updates),
-                                        checked = automaticDependencyUpdates,
+                                        checked = settings.automaticDependencyUpdates,
                                         onCheckedChange = { checked ->
                                             viewModel.setAutomaticDependencyUpdates(checked)
                                         },
@@ -127,7 +127,7 @@ fun UpdatesScreen(
                                         text = stringResource(R.string.settings_title_last_checked_for_dependency_updates),
                                         description = UiFormatter.formatLastCheckedTime(
                                             context,
-                                            lastDependencyUpdateCheckMillis,
+                                            info.lastDependencyUpdateCheckMillis,
                                         ),
                                     )
                                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -17,6 +17,8 @@ import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.presentation.model.UpdatesInfo
+import org.strigate.ferrot.presentation.model.UpdatesSettings
 import org.strigate.ferrot.presentation.model.UpdatesUiData
 import org.strigate.ferrot.presentation.state.UpdatesUiState
 import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
@@ -42,13 +44,17 @@ class UpdatesViewModel @Inject constructor(
             settingsUseCase.getAutomaticDependencyUpdatesSettingAsFlowUseCase(),
             stateUseCase.getLastAvailableUpdateCheckMillisUseCase(),
             stateUseCase.getLastDependencyUpdateCheckMillisUseCase(),
-        ) { automaticUpdates, automaticDependencyUpdates, lastAppCheckMillis, lastDepsCheckMillis ->
+        ) { automaticUpdates, automaticDependencyUpdates, lastAvailableUpdateCheckMillis, lastDependencyUpdateCheckMillis ->
             UpdatesUiState.Data(
                 UpdatesUiData(
-                    automaticUpdates = automaticUpdates,
-                    automaticDependencyUpdates = automaticDependencyUpdates,
-                    lastAvailableUpdateCheckMillis = lastAppCheckMillis,
-                    lastDependencyUpdateCheckMillis = lastDepsCheckMillis,
+                    settings = UpdatesSettings(
+                        automaticUpdates = automaticUpdates,
+                        automaticDependencyUpdates = automaticDependencyUpdates,
+                    ),
+                    info = UpdatesInfo(
+                        lastAvailableUpdateCheckMillis = lastAvailableUpdateCheckMillis,
+                        lastDependencyUpdateCheckMillis = lastDependencyUpdateCheckMillis,
+                    ),
                 ),
             )
         }


### PR DESCRIPTION
- Replace `UpdatesData` with `UpdatesInfo` and add `UpdatesSettings`; update `UpdatesUiData` to hold `settings` and `info`
- Update `UpdatesViewModel.getUiState` to emit `UpdatesSettings` and `UpdatesInfo`
- Bind `UpdatesScreen` to `settings.automaticUpdates`, `settings.automaticDependencyUpdates`, and `info.*CheckMillis`
- Set arrow `Icon` size with `Modifier.size(20.dp)` in `ExpandableSettingsSection` and `TextNavigateSetting`
- Adjust `SwitchSetting` padding to `12.dp`, fix `clickable` param order, set `Switch` height to `24.dp`, and reorder `checked`/`onCheckedChange`
- Tweak spacing in `StaticSettingsSection` from `12.dp` to `8.dp`