### PR TITLE
refactor: Split update UI models into dedicated files

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
@@ -13,11 +13,9 @@ fun Download.toUiData(
     val title = metadata?.title ?: filePathNonNull
         .substringBeforeLast('.', missingDelimiterValue = filePathNonNull)
         .ifBlank { url }
-
     val fileName = filePathNonNull
         .substringAfterLast("/", missingDelimiterValue = "")
         .takeIf { it.isNotBlank() }
-
     val fraction = progress?.progressPercent
         ?.let { it.coerceIn(0f, 100f) / 100f }
         ?.takeIf { it.isFinite() }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/AvailableUpdateUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/AvailableUpdateUiData.kt
@@ -1,0 +1,6 @@
+package org.strigate.ferrot.presentation.model
+
+data class AvailableUpdateUiData(
+    val tag: String,
+    val localFilePath: String?,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadsUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadsUiData.kt
@@ -4,8 +4,3 @@ data class DownloadsUiData(
     val downloads: List<DownloadItemUiData>,
     val availableUpdate: AvailableUpdateUiData?,
 )
-
-data class AvailableUpdateUiData(
-    val tag: String,
-    val localFilePath: String?,
-)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesInfoUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesInfoUiData.kt
@@ -1,0 +1,6 @@
+package org.strigate.ferrot.presentation.model
+
+data class UpdatesInfoUiData(
+    val lastAvailableUpdateCheckMillis: Long,
+    val lastDependencyUpdateCheckMillis: Long,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesSettingsUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesSettingsUiData.kt
@@ -1,0 +1,6 @@
+package org.strigate.ferrot.presentation.model
+
+data class UpdatesSettingsUiData(
+    val automaticUpdates: Boolean,
+    val automaticDependencyUpdates: Boolean,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/UpdatesUiData.kt
@@ -1,16 +1,6 @@
 package org.strigate.ferrot.presentation.model
 
 data class UpdatesUiData(
-    val settings: UpdatesSettings,
-    val info: UpdatesInfo,
-)
-
-data class UpdatesSettings(
-    val automaticUpdates: Boolean,
-    val automaticDependencyUpdates: Boolean,
-)
-
-data class UpdatesInfo(
-    val lastAvailableUpdateCheckMillis: Long,
-    val lastDependencyUpdateCheckMillis: Long,
+    val settings: UpdatesSettingsUiData,
+    val info: UpdatesInfoUiData,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -17,8 +17,8 @@ import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.extensions.toast
-import org.strigate.ferrot.presentation.model.UpdatesInfo
-import org.strigate.ferrot.presentation.model.UpdatesSettings
+import org.strigate.ferrot.presentation.model.UpdatesInfoUiData
+import org.strigate.ferrot.presentation.model.UpdatesSettingsUiData
 import org.strigate.ferrot.presentation.model.UpdatesUiData
 import org.strigate.ferrot.presentation.state.UpdatesUiState
 import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
@@ -47,11 +47,11 @@ class UpdatesViewModel @Inject constructor(
         ) { automaticUpdates, automaticDependencyUpdates, lastAvailableUpdateCheckMillis, lastDependencyUpdateCheckMillis ->
             UpdatesUiState.Data(
                 UpdatesUiData(
-                    settings = UpdatesSettings(
+                    settings = UpdatesSettingsUiData(
                         automaticUpdates = automaticUpdates,
                         automaticDependencyUpdates = automaticDependencyUpdates,
                     ),
-                    info = UpdatesInfo(
+                    info = UpdatesInfoUiData(
                         lastAvailableUpdateCheckMillis = lastAvailableUpdateCheckMillis,
                         lastDependencyUpdateCheckMillis = lastDependencyUpdateCheckMillis,
                     ),


### PR DESCRIPTION
- Moved `AvailableUpdateUiData` into its own file
- Created new files for `UpdatesSettingsUiData` and `UpdatesInfoUiData`
- Updated `UpdatesUiData` to reference new UI data classes
- Adjusted imports in `UpdatesViewModel`
- Removed inline `AvailableUpdateUiData` from `DownloadsUiData`