### PR TITLE
feat: Split Video/Audio phases with weighted progress and throttled u…

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -14,6 +14,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.yausername.youtubedl_android.YoutubeDL
+import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -50,8 +51,8 @@ import kotlin.math.max
 
 @HiltWorker
 class DownloadWorker @AssistedInject constructor(
-    private val appContext: Context,
-    workerParameters: WorkerParameters,
+    @Assisted private val appContext: Context,
+    @Assisted workerParameters: WorkerParameters,
     private val analyticsLogger: AnalyticsLogger,
     private val downloadPathProvider: DownloadPathProvider,
     private val notificationService: NotificationService,
@@ -68,10 +69,17 @@ class DownloadWorker @AssistedInject constructor(
     private val qualityProfile: QualityProfile = QualityProfile.MAX
 
     override suspend fun doWork(): Result {
-        val downloadId = inputData.getLong(KEY_ID, -1L)
-        _downloadId = downloadId
+        _downloadId = inputData.getLong(KEY_ID, -1L)
 
-        if (runAttemptCount > 20 || downloadId <= 0L) return Result.failure()
+        val downloadId = _downloadId
+        val tag = "Download[$downloadId]:"
+
+        Log.d(LOG_TAG, "$tag Starting work")
+
+        if (runAttemptCount > 20 || downloadId <= 0L) {
+            Log.w(LOG_TAG, "$tag Attempts exhausted or download ID invalid")
+            return Result.failure()
+        }
 
         val download = downloadUseCase.getDownloadByIdUseCase(downloadId)
             ?: return handleDownloadFailedResult()
@@ -102,7 +110,10 @@ class DownloadWorker @AssistedInject constructor(
 
                     else -> false
                 }
-                if (!canStart) return@mainScope Result.failure()
+                if (!canStart) {
+                    Log.w(LOG_TAG, "$tag Cannot start in status: ${download.status}")
+                    return@mainScope Result.failure()
+                }
 
                 analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_STARTED)
 
@@ -118,10 +129,12 @@ class DownloadWorker @AssistedInject constructor(
                     return@mainScope Result.failure()
                 }
 
+                Log.d(LOG_TAG, "$tag Downloading metadata")
                 downloadUseCase.updateDownloadStatusByIdUseCase(downloadId, DownloadStatus.METADATA)
                 val videoInfo = withContext(Dispatchers.IO) {
                     youtubeDlAndroidUseCase.getVideoInfoUseCase(download.url)
                 }
+                Log.d(LOG_TAG, "$tag Downloaded metadata")
 
                 videoTitle = videoInfo.title?.takeIf { it.isNotBlank() } ?: download.url
                 updateForeground(
@@ -130,6 +143,8 @@ class DownloadWorker @AssistedInject constructor(
                     contentText = videoTitle,
                     extras = notificationExtras,
                 )
+
+                Log.d(LOG_TAG, "$tag Downloading thumbnail")
                 withContext(Dispatchers.IO) {
                     val thumbnailFilePath = youtubeDlAndroidUseCase.downloadThumbnailUseCase(
                         url = download.url,
@@ -148,6 +163,7 @@ class DownloadWorker @AssistedInject constructor(
                         )
                     )
                 }
+                Log.d(LOG_TAG, "$tag Downloaded thumbnail")
 
                 val expectedBytes = when {
                     videoInfo.fileSize > 0L -> videoInfo.fileSize
@@ -169,152 +185,113 @@ class DownloadWorker @AssistedInject constructor(
                     id = downloadId,
                 )
 
-                val processId = "dl-$downloadId-${System.nanoTime()}"
+                val weights = decideWeights(
+                    videoBytes = videoInfo.fileSize.takeIf { it > 0L }
+                        ?: videoInfo.fileSizeApproximate.takeIf { it > 0L },
+                    audioBytes = audioByteEstimateFromDuration(videoInfo.duration),
+                )
+
+                val baseProcessId = "dl-$downloadId-${System.nanoTime()}"
+                val videoProcessId = "${baseProcessId}_video"
+                val audioProcessId = "${baseProcessId}_audio"
+
+                Log.d(LOG_TAG, "$tag Decided weights: v=${weights.video}, a=${weights.audio}")
+                Log.d(LOG_TAG, "$tag videoProcessId: $videoProcessId")
+                Log.d(LOG_TAG, "$tag audioProcessId: $audioProcessId")
+
                 var maxBytes = 0L
-                val bytesProvider = {
+                val bytesProviderRaw = {
                     maxBytes = max(maxBytes, directoryBytesSum(uidDir))
                     maxBytes
                 }
+                val template = "${uidDir.absolutePath}/%(id)s.%(ext)s"
+
+                val phaseContext = PhaseContext(
+                    phase = DownloadMediaType.VIDEO,
+                    weights = weights,
+                    title = videoTitle ?: download.url,
+                    notificationExtras = notificationExtras,
+                )
+
+                Log.d(LOG_TAG, "$tag Downloading video")
                 withContext(Dispatchers.IO) {
-                    val template = "${uidDir.absolutePath}/%(id)s.%(ext)s"
-                    val downloadTickFlow = youtubeDlAndroidUseCase.downloadWithProgressUseCase(
+                    collectPhase(
+                        processId = videoProcessId,
                         url = download.url,
                         template = template,
-                        profile = qualityProfile,
-                        processId = processId,
-                        bytesProvider = bytesProvider,
-                        downloadMediaType = DownloadMediaType.VIDEO,
+                        qualityProfile = qualityProfile,
+                        bytesProviderRaw = bytesProviderRaw,
+                        phaseContext = phaseContext.copy(phase = DownloadMediaType.VIDEO),
+                        initialVideoPercent = 0f,
+                        onCanceled = { wasDownloadDeleted = true },
+                        onCombined = {},
                     )
-                    try {
-                        downloadTickFlow.collect { downloadTick ->
-                            if (downloadUseCase.getDownloadByIdUseCase(downloadId) == null) {
-                                wasDownloadDeleted = true
-                                destroyYoutubeDlProcess(processId)
-                                throw CancellationException()
-                            }
-                            val downloadStatus = downloadUseCase
-                                .getDownloadByIdUseCase(downloadId)
-                                ?.status
-
-                            if (downloadStatus == DownloadStatus.STOPPED) {
-                                destroyYoutubeDlProcess(processId)
-                                throw CancellationException()
-                            }
-                            if (downloadStatus != DownloadStatus.COMPLETED && downloadStatus != DownloadStatus.FAILED) {
-                                downloadProgressUseCase.updateDownloadProgressUseCase(
-                                    id = downloadId,
-                                    progressPercent = downloadTick.percent,
-                                    etaSeconds = downloadTick.etaSeconds,
-                                    bytesDownloaded = downloadTick.bytesDownloaded,
-                                )
-
-                                val percentInt = downloadTick.percent.toInt().coerceIn(0, 100)
-                                if (lastForegroundProgress == -1 && percentInt > 0) {
-                                    val eta = downloadTick.etaSeconds
-                                        ?.takeIf { it > 0 }
-                                        ?.let { total ->
-                                            val minutes = total / 60
-                                            val seconds = total % 60
-                                            buildString {
-                                                if (minutes > 0) append("${minutes}m")
-                                                append("${seconds}s")
-                                            }
-                                        } ?: ""
-
-                                    val parts = mutableListOf<String>()
-                                    parts += "$percentInt%"
-                                    if (eta.isNotEmpty()) {
-                                        parts += eta
-                                    }
-                                    parts += (videoTitle ?: download.url)
-                                    val contentLine = parts.joinToString(" - ")
-
-                                    updateForeground(
-                                        notificationText = appContext.getString(
-                                            R.string.worker_notification_text_download_in_progress,
-                                        ),
-                                        progress = percentInt,
-                                        indeterminate = false,
-                                        contentText = contentLine,
-                                        extras = notificationExtras,
-                                    )
-                                    lastForegroundProgress = percentInt
-                                } else if (percentInt != lastForegroundProgress) {
-                                    lastForegroundProgress = percentInt
-
-                                    val eta = downloadTick.etaSeconds
-                                        ?.takeIf { it > 0 }
-                                        ?.let { total ->
-                                            val minutes = total / 60
-                                            val seconds = total % 60
-                                            buildString {
-                                                if (minutes > 0) append("${minutes}m")
-                                                append("${seconds}s")
-                                            }
-                                        } ?: ""
-
-                                    val parts = mutableListOf<String>()
-                                    parts += "$percentInt%"
-                                    if (eta.isNotEmpty()) {
-                                        parts += eta
-                                    }
-                                    parts += (videoTitle ?: download.url)
-                                    val contentLine = parts.joinToString(" - ")
-
-                                    updateForeground(
-                                        notificationText = appContext.getString(
-                                            R.string.worker_notification_text_download_in_progress,
-                                        ),
-                                        progress = percentInt,
-                                        indeterminate = false,
-                                        contentText = contentLine,
-                                        extras = notificationExtras,
-                                    )
-                                }
-                            }
-                        }
-                    } finally {
-                        destroyYoutubeDlProcess(processId)
-                    }
                 }
+                Log.d(LOG_TAG, "$tag Downloaded video")
 
                 if (downloadUseCase.getDownloadByIdUseCase(downloadId) == null) {
+                    Log.w(LOG_TAG, "$tag Download record was deleted during download")
                     wasDownloadDeleted = true
                     throw CancellationException()
                 }
-
-                val outputFile = locateOutputFileByInfoId(uidDir, videoInfo.id)
-                if (outputFile == null) {
-                    Log.d(LOG_TAG, "Output file could not be located after download")
+                val videoOutputFile = locateOutputFileByInfoId(uidDir, videoInfo.id)
+                if (videoOutputFile == null) {
+                    Log.w(LOG_TAG, "$tag Video output file could not be located")
                     return@mainScope handleDownloadFailedResult()
                 }
+
+                Log.d(LOG_TAG, "$tag Video output file located, saving path")
                 downloadUseCase.updateDownloadFilePathUseCase(
                     id = downloadId,
-                    fileName = outputFile.absolutePath,
+                    fileName = videoOutputFile.absolutePath,
                 )
 
                 withContext(Dispatchers.IO) {
                     val bytesDownloaded = directoryBytesSum(uidDir)
                     downloadProgressUseCase.updateDownloadProgressUseCase(
                         id = downloadId,
-                        progressPercent = 100f,
+                        progressPercent = combinedPercent(
+                            phase = DownloadMediaType.VIDEO,
+                            videoPhasePercent = 100f,
+                            audioPhasePercent = 0f,
+                            weights = weights,
+                        ),
                         bytesDownloaded = bytesDownloaded,
                         etaSeconds = null,
                     )
                 }
-                run {
-                    val parts = mutableListOf<String>()
-                    parts += "100%"
-                    parts += (videoTitle ?: download.url)
-                    val finalLine = parts.joinToString(" - ")
-                    updateForeground(
-                        notificationText = appContext.getString(R.string.download_complete),
-                        progress = 100,
-                        indeterminate = false,
-                        contentText = finalLine,
-                        extras = notificationExtras,
+
+                Log.d(LOG_TAG, "$tag Downloading audio")
+                withContext(Dispatchers.IO) {
+                    collectPhase(
+                        processId = audioProcessId,
+                        url = download.url,
+                        template = template,
+                        qualityProfile = qualityProfile,
+                        bytesProviderRaw = bytesProviderRaw,
+                        phaseContext = phaseContext.copy(phase = DownloadMediaType.AUDIO),
+                        initialVideoPercent = 100f,
+                        onCanceled = { wasDownloadDeleted = true },
+                        onCombined = {},
                     )
                 }
+                Log.d(LOG_TAG, "$tag Downloaded audio")
+
+                val audioOutputFile = locateOutputFileByInfoId(uidDir, videoInfo.id, audio = true)
+                if (audioOutputFile == null) {
+                    Log.w(LOG_TAG, "$tag Audio output file could not be located")
+                } else {
+                    Log.d(LOG_TAG, "$tag Audio output file located, saving path")
+                }
+
+                val finalPercent = 100
+                updateForeground(
+                    notificationText = appContext.getString(R.string.download_complete),
+                    progress = finalPercent,
+                    indeterminate = false,
+                    contentText = videoTitle ?: download.url,
+                    extras = notificationExtras,
+                )
 
                 downloadUseCase.updateDownloadErrorMessageUseCase(downloadId, null)
                 downloadUseCase.updateDownloadStatusByIdUseCase(
@@ -330,7 +307,7 @@ class DownloadWorker @AssistedInject constructor(
                 val downloadComplete = appContext.getString(R.string.download_complete)
                 val contentText = videoTitle ?: download.url
 
-                Log.d(LOG_TAG, downloadComplete)
+                Log.d(LOG_TAG, "$tag $downloadComplete")
                 appContext.toast("$downloadComplete: $contentText", true)
                 notificationService.notifyDownloaded(
                     contentText = contentText,
@@ -340,7 +317,7 @@ class DownloadWorker @AssistedInject constructor(
                 Result.success()
 
             } catch (throwable: Throwable) {
-                Log.w(LOG_TAG, "Caught throwable: $throwable", throwable)
+                Log.w(LOG_TAG, "$tag Caught throwable: $throwable", throwable)
 
                 suspend fun handleDownloadFailure() = handleDownloadFailure(
                     throwable = throwable,
@@ -361,11 +338,11 @@ class DownloadWorker @AssistedInject constructor(
                     return@mainScope handleDownloadFailure()
                 }
 
-                Log.w(LOG_TAG, "stopReason=$stopReason")
+                Log.w(LOG_TAG, "$tag stopReason=$stopReason")
                 return@mainScope when (stopReason) {
                     WorkInfo.STOP_REASON_CANCELLED_BY_APP,
                     WorkInfo.STOP_REASON_USER -> {
-                        Log.w(LOG_TAG, "Cancel came from app or user")
+                        Log.w(LOG_TAG, "$tag Cancel came from app or user")
                         handleDownloadStoppedResult()
                     }
 
@@ -485,19 +462,203 @@ class DownloadWorker @AssistedInject constructor(
         }
     }
 
-    private fun locateOutputFileByInfoId(dir: File, infoId: String?): File? {
-        if (infoId.isNullOrBlank() || !dir.exists()) {
-            return null
+    private fun locateOutputFileByInfoId(
+        dir: File,
+        infoId: String?,
+        audio: Boolean = false,
+    ): File? {
+        if (infoId.isNullOrBlank() || !dir.exists()) return null
+        val extensions = if (audio) {
+            listOf("mp3", "m4a", "opus")
+        } else {
+            listOf("mp4", "mkv", "webm")
         }
-        val preferredExtensions = listOf("mp4", "mkv", "webm", "mp3", "m4a", "opus")
-        preferredExtensions.map { File(dir, "$infoId.$it") }
+        extensions.map { File(dir, "$infoId.$it") }
             .firstOrNull { it.exists() && it.length() > 0L }
             ?.let { return it }
-        val file = dir.listFiles()
+        return dir.listFiles()
             ?.filter { it.isFile && it.name.startsWith("$infoId.") && it.length() > 0L }
             ?.maxByOrNull { it.lastModified() }
-        return file
     }
+
+    private fun decideWeights(videoBytes: Long?, audioBytes: Long?): Weights {
+        return if (videoBytes != null && audioBytes != null && videoBytes > 0 && audioBytes > 0) {
+            val total = videoBytes + audioBytes
+            Weights(
+                video = videoBytes.toDouble() / total.toDouble(),
+                audio = audioBytes.toDouble() / total.toDouble(),
+            )
+        } else {
+            Weights(video = 0.85, audio = 0.15)
+        }
+    }
+
+    private fun combinedPercent(
+        phase: DownloadMediaType,
+        videoPhasePercent: Float,
+        audioPhasePercent: Float,
+        weights: Weights,
+    ): Float {
+        return when (phase) {
+            DownloadMediaType.VIDEO -> (videoPhasePercent.coerceIn(
+                0f,
+                100f
+            ) * weights.video).toFloat()
+
+            DownloadMediaType.AUDIO -> ((100f * weights.video) + (audioPhasePercent.coerceIn(
+                0f,
+                100f,
+            ) * weights.audio)).toFloat()
+        }.coerceIn(0f, 100f)
+    }
+
+    private fun audioByteEstimateFromDuration(durationSeconds: Int): Long? {
+        if (durationSeconds <= 0) return null
+        return durationSeconds.toLong() * 24_000L
+    }
+
+    private fun formatEta(etaSeconds: Long?): String {
+        val eta = etaSeconds?.takeIf { it > 0 } ?: return ""
+        val minutes = eta / 60
+        val seconds = eta % 60
+        return buildString {
+            if (minutes > 0) append("${minutes}m")
+            append("${seconds}s")
+        }
+    }
+
+    private fun buildNotifLine(percentInt: Int, eta: String, title: String): String {
+        val parts = mutableListOf<String>()
+        parts += "$percentInt%"
+        if (eta.isNotEmpty()) parts += eta
+        parts += title
+        return parts.joinToString(" - ")
+    }
+
+    private suspend fun collectPhase(
+        processId: String,
+        url: String,
+        template: String,
+        qualityProfile: QualityProfile,
+        bytesProviderRaw: () -> Long,
+        phaseContext: PhaseContext,
+        initialVideoPercent: Float,
+        onCanceled: () -> Unit,
+        onCombined: (Float) -> Unit,
+    ) {
+        val throttle = ProgressThrottle()
+        val downloadTickFlow = youtubeDlAndroidUseCase.downloadWithProgressUseCase(
+            url = url,
+            template = template,
+            profile = qualityProfile,
+            processId = processId,
+            bytesProvider = { throttle.throttledBytes(bytesProviderRaw) },
+            downloadMediaType = phaseContext.phase,
+        )
+        try {
+            downloadTickFlow.collect { tick ->
+                val status = downloadUseCase.getDownloadByIdUseCase(_downloadId)?.status
+                if (status == null) {
+                    onCanceled()
+                    destroyYoutubeDlProcess(processId)
+                    throw CancellationException()
+                }
+                if (status == DownloadStatus.STOPPED) {
+                    destroyYoutubeDlProcess(processId)
+                    throw CancellationException()
+                }
+
+                val combined = when (phaseContext.phase) {
+                    DownloadMediaType.VIDEO -> combinedPercent(
+                        phase = DownloadMediaType.VIDEO,
+                        videoPhasePercent = tick.percent,
+                        audioPhasePercent = 0f,
+                        weights = phaseContext.weights,
+                    )
+
+                    DownloadMediaType.AUDIO -> combinedPercent(
+                        phase = DownloadMediaType.AUDIO,
+                        videoPhasePercent = initialVideoPercent,
+                        audioPhasePercent = tick.percent,
+                        weights = phaseContext.weights,
+                    )
+                }
+                onCombined(combined)
+
+                val percentInt = combined.toInt().coerceIn(0, 100)
+
+                if (throttle.shouldPersist(percentInt)) {
+                    downloadProgressUseCase.updateDownloadProgressUseCase(
+                        id = _downloadId,
+                        progressPercent = combined,
+                        etaSeconds = tick.etaSeconds,
+                        bytesDownloaded = throttle.throttledBytes(bytesProviderRaw),
+                    )
+                }
+
+                if (throttle.shouldNotify(percentInt)) {
+                    val etaLine = formatEta(tick.etaSeconds)
+                    val contentLine = buildNotifLine(percentInt, etaLine, phaseContext.title)
+                    updateForeground(
+                        notificationText = appContext.getString(R.string.worker_notification_text_download_in_progress),
+                        progress = percentInt,
+                        indeterminate = false,
+                        contentText = contentLine,
+                        extras = phaseContext.notificationExtras,
+                    )
+                    lastForegroundProgress = percentInt
+                }
+            }
+        } finally {
+            destroyYoutubeDlProcess(processId)
+        }
+    }
+
+    private data class PhaseContext(
+        val phase: DownloadMediaType,
+        val weights: Weights,
+        val title: String,
+        val notificationExtras: Map<String, String>,
+    )
+
+    private class ProgressThrottle(
+        private val minPercentDelta: Int = 1,
+        private val minDbMillis: Long = 200,
+        private val minFsMillis: Long = 300,
+    ) {
+        private var lastNotifPercent = -1
+        private var lastDbPercent = -1
+        private var lastDbAt = 0L
+        private var lastBytesAt = 0L
+        private var cachedBytes = 0L
+
+        fun shouldNotify(percentInt: Int): Boolean {
+            if (percentInt != lastNotifPercent) {
+                lastNotifPercent = percentInt
+                return true
+            }
+            return false
+        }
+
+        fun shouldPersist(percentInt: Int, now: Long = System.currentTimeMillis()): Boolean {
+            if (percentInt - lastDbPercent >= minPercentDelta || now - lastDbAt >= minDbMillis) {
+                lastDbPercent = percentInt
+                lastDbAt = now
+                return true
+            }
+            return false
+        }
+
+        fun throttledBytes(readDirBytes: () -> Long, now: Long = System.currentTimeMillis()): Long {
+            if (now - lastBytesAt >= minFsMillis) {
+                cachedBytes = readDirBytes()
+                lastBytesAt = now
+            }
+            return cachedBytes
+        }
+    }
+
+    private data class Weights(val video: Double, val audio: Double)
 
     companion object {
         fun enqueueOneTimeReplace(context: Context, id: Long, wifiOnly: Boolean) {


### PR DESCRIPTION
…pdates

- Annotate Hilt worker params with `@Assisted` in `DownloadWorker` constructor
- Add per-download log tag and richer logging for start, progress, and errors
- Extract phase handling into `collectPhase(...)` for `DownloadMediaType.VIDEO` and `AUDIO`
- Introduce `Weights` and `decideWeights(...)` to weight combined progress by bytes
- Add `combinedPercent(...)` to compute aggregate progress across phases
- Implement `ProgressThrottle` to limit DB writes and notification updates
- Persist `_downloadId` early and simplify `videoTitle`/`lastForegroundProgress` handling
- Extend `locateOutputFileByInfoId(...)` to support audio outputs via `audio` flag
- Add helpers `audioByteEstimateFromDuration(...)`, `formatEta(...)`, and `buildNotifLine(...)`
- Replace inline progress loop with `collectPhase(...)` and unified foreground updates
- Improve stop/failure paths with clearer `stopReason` logs and notifications