### PR TITLE
refactor: Remove Hilt worker annotations and assisted params

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -2,7 +2,6 @@ package org.strigate.ferrot.work
 
 import android.content.Context
 import android.util.Log
-import androidx.hilt.work.HiltWorker
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -12,8 +11,6 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -46,10 +43,9 @@ import java.time.ZonedDateTime
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-@HiltWorker
-class DownloadAvailableUpdateWorker @AssistedInject constructor(
-    @Assisted private val appContext: Context,
-    @Assisted workerParameters: WorkerParameters,
+class DownloadAvailableUpdateWorker(
+    private val appContext: Context,
+    workerParameters: WorkerParameters,
     private val stateUseCase: StateUseCase,
     private val updatePathProvider: UpdatePathProvider,
     private val notificationService: NotificationService,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -3,7 +3,6 @@ package org.strigate.ferrot.work
 import android.content.Context
 import android.os.Build
 import android.util.Log
-import androidx.hilt.work.HiltWorker
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.Data
@@ -14,8 +13,6 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.yausername.youtubedl_android.YoutubeDL
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.coroutineScope
@@ -49,10 +46,9 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.max
 
-@HiltWorker
-class DownloadWorker @AssistedInject constructor(
-    @Assisted private val appContext: Context,
-    @Assisted workerParameters: WorkerParameters,
+class DownloadWorker(
+    private val appContext: Context,
+    workerParameters: WorkerParameters,
     private val analyticsLogger: AnalyticsLogger,
     private val downloadPathProvider: DownloadPathProvider,
     private val notificationService: NotificationService,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/RequeuePendingDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/RequeuePendingDownloadsWorker.kt
@@ -2,20 +2,17 @@ package org.strigate.ferrot.work
 
 import android.content.Context
 import android.util.Log
-import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
-import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.domain.usecase.combined.GetPendingDownloadsCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 
-@HiltWorker
-class RequeuePendingDownloadsWorker @AssistedInject constructor(
+class RequeuePendingDownloadsWorker(
     appContext: Context,
     workerParameters: WorkerParameters,
     private val getPendingDownloadsCombinedUseCase: GetPendingDownloadsCombinedUseCase,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -2,7 +2,6 @@ package org.strigate.ferrot.work
 
 import android.content.Context
 import android.util.Log
-import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -10,8 +9,6 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.yausername.youtubedl_android.YoutubeDL
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedInject
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
@@ -19,10 +16,9 @@ import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.StateUseCase
 import java.util.concurrent.TimeUnit
 
-@HiltWorker
-class UpdateDependenciesWorker @AssistedInject constructor(
-    @Assisted private val appContext: Context,
-    @Assisted workerParameters: WorkerParameters,
+class UpdateDependenciesWorker(
+    private val appContext: Context,
+    workerParameters: WorkerParameters,
     private val stateUseCase: StateUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result {
@@ -34,11 +30,11 @@ class UpdateDependenciesWorker @AssistedInject constructor(
                 stateUseCase.saveLastDependencyUpdateCheckMillisUseCase(System.currentTimeMillis())
             }
             Log.d(LOG_TAG, "Updating YoutubeDL")
-            val status = YoutubeDL.getInstance().updateYoutubeDL(
+            val updateStatus = YoutubeDL.getInstance().updateYoutubeDL(
                 updateChannel = YoutubeDL.UpdateChannel.STABLE,
                 appContext = appContext,
             )
-            Log.d(LOG_TAG, "YoutubeDL update completed: status=$status")
+            Log.d(LOG_TAG, "YoutubeDL update completed: status=$updateStatus")
             Result.success()
         } catch (throwable: Throwable) {
             Log.wtf(LOG_TAG, "An error occurred while updating dependencies", throwable)


### PR DESCRIPTION
- Drop `@HiltWorker` and `@AssistedInject` from `DownloadWorker`, `DownloadAvailableUpdateWorker`, `UpdateDependenciesWorker`, `RequeuePendingDownloadsWorker`
- Remove `@Assisted` on constructor params and switch to plain constructors with `Context` and `WorkerParameters`
- Tidy logs and naming: rename `status` to `updateStatus` in `UpdateDependenciesWorker`
- Keep existing enqueuing and constraints logic unchanged for periodic and one-time requests