### PR TITLE
feat: Add one-time dependency update trigger and split download templ…

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -70,6 +70,7 @@ object Constants {
 
             const val PERIODIC_DOWNLOAD_AVAILABLE_UPDATE = "$PERIODIC.DOWNLOAD_AVAILABLE_UPDATE"
             const val PERIODIC_UPDATE_DEPENDENCIES = "$PERIODIC.UPDATE_DEPENDENCIES"
+            const val ONETIME_UPDATE_DEPENDENCIES = "$ONETIME.UPDATE_DEPENDENCIES"
 
             const val KEY_ID = "$KEY.ID"
             const val KEY_WIFI_ONLY = "$KEY.wifi_only"

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/SettingsUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/SettingsUseCase.kt
@@ -14,5 +14,5 @@ class SettingsUseCase @Inject constructor(
     val getAutomaticUpdatesSettingAsFlowUseCase: GetAutomaticUpdatesSettingAsFlowUseCase,
     val saveAutomaticUpdatesSettingUseCase: SaveAutomaticUpdatesSettingUseCase,
     val getAutomaticDependencyUpdatesSettingAsFlowUseCase: GetAutomaticDependencyUpdatesSettingAsFlowUseCase,
-    val saveAutomaticDependencyUpdatesSettingAsFlowUseCase: SaveAutomaticDependencyUpdatesSettingUseCase,
+    val saveAutomaticDependencyUpdatesSettingUseCase: SaveAutomaticDependencyUpdatesSettingUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
@@ -17,6 +17,9 @@ class BuildAudioDownloadRequestUseCase @Inject constructor() {
             addOption("--extract-audio")
             addOption("--audio-format", "mp3")
             addOption("--audio-quality", "0")
+            addOption("--keep-video")
+            addOption("--no-overwrites")
+            addOption("--no-post-overwrites")
             if (noProgress) {
                 addOption("--no-progress")
                 if (printFilename) {

--- a/app/src/main/kotlin/org/strigate/ferrot/helper/PlayHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/PlayHelper.kt
@@ -5,16 +5,23 @@ import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.core.content.FileProvider
 import org.strigate.ferrot.R
+import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.extensions.guessMimeType
 import java.io.File
 
 object PlayHelper {
     fun playFileIfExists(context: Context, filePath: String?) {
-        if (filePath.isNullOrBlank()) return
+        if (filePath.isNullOrBlank()) {
+            return
+        }
         val file = File(filePath)
-        if (!file.exists() || file.length() <= 0L) return
+        if (!file.exists() || file.length() <= 0L) {
+            Log.w(LOG_TAG, "File does not exist: ${file.absolutePath}")
+            return
+        }
         val authority = "${context.packageName}.${context.getString(R.string.file_provider)}"
         val uri = FileProvider.getUriForFile(context, authority, file)
         val intent = Intent(Intent.ACTION_VIEW).apply {

--- a/app/src/main/kotlin/org/strigate/ferrot/helper/SaveHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/SaveHelper.kt
@@ -17,15 +17,16 @@ object SaveHelper {
         if (filePath.isNullOrBlank()) {
             return false
         }
-        val sourceFile = File(filePath)
-        if (!sourceFile.exists() || sourceFile.length() <= 0L) {
+        val file = File(filePath)
+        if (!file.exists() || file.length() <= 0L) {
+            Log.w(LOG_TAG, "File does not exist: ${file.absolutePath}")
             return false
         }
         val relativePath = Environment.DIRECTORY_DOWNLOADS + "/${Constants.NAME}"
         val relativePathWithSlash = ensureTrailingSlash(relativePath)
         val relativePathWithNoSlash = relativePathWithSlash.removeSuffix("/")
         val outputMimeType = filePath.guessMimeType()
-        val displayName = sourceFile.name
+        val displayName = file.name
 
         val existsInDownloads = existsInDownloads(
             context = context,
@@ -52,7 +53,7 @@ object SaveHelper {
 
         return try {
             contentResolver.openOutputStream(uri)?.use { out ->
-                sourceFile.inputStream().use { it.copyTo(out) }
+                file.inputStream().use { it.copyTo(out) }
             } ?: error("openOutputStream null")
 
             ContentValues().apply {

--- a/app/src/main/kotlin/org/strigate/ferrot/helper/ShareHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/ShareHelper.kt
@@ -6,8 +6,10 @@ import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.core.content.FileProvider
 import org.strigate.ferrot.R
+import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.extensions.guessMimeType
 import java.io.File
 
@@ -18,6 +20,7 @@ object ShareHelper {
         }
         val file = File(filePath)
         if (!file.exists() || file.length() <= 0L) {
+            Log.w(LOG_TAG, "File does not exist: ${file.absolutePath}")
             return false
         }
         val authority = "${context.packageName}.${context.getString(R.string.file_provider)}"

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -43,9 +43,9 @@ fun UpdatesScreen(
     viewModel: UpdatesViewModel = hiltViewModel(),
 ) {
     val dimens = LocalDimens.current
+    val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -123,6 +123,12 @@ fun UpdatesScreen(
                                             viewModel.setAutomaticDependencyUpdates(checked)
                                         },
                                     )
+                                    TextSetting(
+                                        text = stringResource(R.string.settings_title_check_dependencies_now),
+                                        description = stringResource(R.string.settings_description_check_dependencies_now),
+                                    ) {
+                                        viewModel.checkForDependencyUpdates()
+                                    }
                                     TextSetting(
                                         text = stringResource(R.string.settings_title_last_checked_for_dependency_updates),
                                         description = UiFormatter.formatLastCheckedTime(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -82,12 +82,19 @@ class UpdatesViewModel @Inject constructor(
 
     fun setAutomaticDependencyUpdates(enabled: Boolean) {
         viewModelScope.launch {
-            settingsUseCase.saveAutomaticDependencyUpdatesSettingAsFlowUseCase(enabled)
+            settingsUseCase.saveAutomaticDependencyUpdatesSettingUseCase(enabled)
             if (enabled) {
                 UpdateDependenciesWorker.enqueuePeriodicKeep(appContext)
             } else {
                 UpdateDependenciesWorker.cancelPeriodic(appContext)
             }
+        }
+    }
+
+    fun checkForDependencyUpdates() {
+        viewModelScope.launch {
+            appContext.toast(appContext.getString(R.string.toast_checking_for_dependency_updates))
+            UpdateDependenciesWorker.enqueueOneTimeReplace(appContext)
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -200,7 +200,8 @@ class DownloadWorker(
                     maxBytes = max(maxBytes, directoryBytesSum(uidDir))
                     maxBytes
                 }
-                val template = "${uidDir.absolutePath}/%(id)s.%(ext)s"
+                val videoTemplate = "${uidDir.absolutePath}/%(id)s.%(ext)s"
+                val audioTemplate = "${uidDir.absolutePath}/%(id)s.audio.%(ext)s"
 
                 val phaseContext = PhaseContext(
                     phase = DownloadMediaType.VIDEO,
@@ -214,7 +215,7 @@ class DownloadWorker(
                     collectPhase(
                         processId = videoProcessId,
                         url = download.url,
-                        template = template,
+                        template = videoTemplate,
                         qualityProfile = qualityProfile,
                         bytesProviderRaw = bytesProviderRaw,
                         phaseContext = phaseContext.copy(phase = DownloadMediaType.VIDEO),
@@ -236,11 +237,16 @@ class DownloadWorker(
                     return@mainScope handleDownloadFailedResult()
                 }
 
-                Log.d(LOG_TAG, "$tag Video output file located, saving path")
-                downloadUseCase.updateDownloadFilePathUseCase(
-                    id = downloadId,
-                    fileName = videoOutputFile.absolutePath,
-                )
+                if (videoOutputFile.exists()) {
+                    Log.d(LOG_TAG, "$tag Video output file exists, saving path")
+                    downloadUseCase.updateDownloadFilePathUseCase(
+                        fileName = videoOutputFile.absolutePath,
+                        id = downloadId,
+                    )
+                } else {
+                    Log.w(LOG_TAG, "$tag Video output file does not exist")
+                    return@mainScope handleDownloadFailedResult()
+                }
 
                 withContext(Dispatchers.IO) {
                     val bytesDownloaded = directoryBytesSum(uidDir)
@@ -262,7 +268,7 @@ class DownloadWorker(
                     collectPhase(
                         processId = audioProcessId,
                         url = download.url,
-                        template = template,
+                        template = audioTemplate,
                         qualityProfile = qualityProfile,
                         bytesProviderRaw = bytesProviderRaw,
                         phaseContext = phaseContext.copy(phase = DownloadMediaType.AUDIO),

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -2,18 +2,25 @@ package org.strigate.ferrot.work
 
 import android.content.Context
 import android.util.Log
+import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.yausername.youtubedl_android.YoutubeDL
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.StateUseCase
+import java.time.Duration.between
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 
 class UpdateDependenciesWorker(
@@ -45,11 +52,30 @@ class UpdateDependenciesWorker(
     companion object {
         fun enqueuePeriodicKeep(
             context: Context,
-            repeatIntervalDays: Long = 7,
-            flexHours: Long = 3,
+            repeatIntervalDays: Long = 3,
+            targetHour: Int = 4,
+            flexHours: Long = 2,
         ) {
+            val defaultZoneId = ZoneId.systemDefault()
+            val now = ZonedDateTime.now(defaultZoneId)
+            val targetDateTime = now
+                .withHour(targetHour)
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0)
+
+            val firstRun = if (now.isBefore(targetDateTime)) {
+                targetDateTime
+            } else {
+                targetDateTime.plusDays(1)
+            }
+            val initialDelayMillis = between(now, firstRun).toMillis()
+
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresCharging(false)
+                .setRequiresBatteryNotLow(false)
+                .setRequiresStorageNotLow(true)
                 .build()
 
             val periodicWorkRequest = PeriodicWorkRequestBuilder<UpdateDependenciesWorker>(
@@ -58,13 +84,37 @@ class UpdateDependenciesWorker(
                 flexTimeInterval = flexHours,
                 flexTimeIntervalUnit = TimeUnit.HOURS,
             )
+                .setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
                 .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
                 .build()
 
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(
                 PERIODIC_UPDATE_DEPENDENCIES,
                 ExistingPeriodicWorkPolicy.KEEP,
                 periodicWorkRequest,
+            )
+        }
+
+        fun enqueueOneTimeReplace(
+            context: Context,
+        ) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresCharging(false)
+                .setRequiresBatteryNotLow(false)
+                .setRequiresStorageNotLow(true)
+                .build()
+
+            val oneTimeWorkRequest = OneTimeWorkRequestBuilder<UpdateDependenciesWorker>()
+                .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                ONETIME_UPDATE_DEPENDENCIES,
+                ExistingWorkPolicy.REPLACE,
+                oneTimeWorkRequest,
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="snackbar_delete_undo">Undo</string>
 
     <string name="toast_checking_for_available_update">Checking for available update</string>
+    <string name="toast_checking_for_dependency_updates">Checking for dependency updates</string>
     <string name="toast_saved_to">Saved to %1$s</string>
     <string name="toast_file_exists">File already exists in %1$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
@@ -74,6 +75,7 @@
     <string name="settings_title_check_now">Check now</string>
     <string name="settings_title_last_checked_for_updates">Last checked for updates</string>
     <string name="settings_title_automatic_dependency_updates">Automatic dependency updates</string>
+    <string name="settings_title_check_dependencies_now">Check now</string>
     <string name="settings_title_last_checked_for_dependency_updates">Last checked for dependency updates</string>
     <string name="settings_title_build">Build</string>
     <string name="settings_title_website">Website</string>
@@ -84,6 +86,7 @@
     <string name="settings_description_automatic_updates">Automatically check for and download app updates, and notify when ready to install</string>
     <string name="settings_description_check_now">Check for updates now</string>
     <string name="settings_description_automatic_dependency_updates">Automatically download and apply updates for dependencies</string>
+    <string name="settings_description_check_dependencies_now">Check for dependency updates now</string>
     <string name="settings_description_privacy">View Privacy Policy</string>
     <string name="settings_description_license">GNU General Public License v3.0</string>
 


### PR DESCRIPTION
…ates

- Add `TextSetting` in `UpdatesScreen` to "Check now" for dependency updates
- Add `checkForDependencyUpdates()` in `UpdatesViewModel` and use `saveAutomaticDependencyUpdatesSettingUseCase`
- Introduce one-time work via `UpdateDependenciesWorker.enqueueOneTimeReplace()` with `ONETIME_UPDATE_DEPENDENCIES`
- Tweak `UpdateDependenciesWorker` periodic schedule to every 3 days at 04:00 with initial delay and exponential backoff
- Add `ONETIME_UPDATE_DEPENDENCIES` to `Constants.Work.Name`
- Add strings for dependency update "Check now" and toast: `toast_checking_for_dependency_updates`, `settings_title_check_dependencies_now`, `settings_description_check_dependencies_now`
- In `DownloadWorker`, split `videoTemplate` and `audioTemplate`, ensure video file exists before saving path, and use `audioTemplate` for audio phase
- In `BuildAudioDownloadRequestUseCase`, add `--keep-video`, `--no-overwrites`, and `--no-post-overwrites`
- Log missing file warnings in `PlayHelper`, `ShareHelper`, and `SaveHelper` using `LOG_TAG`; minor variable naming cleanup
- Rename `SettingsUseCase` field `saveAutomaticDependencyUpdatesSettingAsFlowUseCase` to `saveAutomaticDependencyUpdatesSettingUseCase`