### PR TITLE
chore: Update mock bootstrap for split video/audio paths

### DIFF
--- a/app/src/debug/kotlin/org/strigate/ferrot/callback/MockDataBootstrapCallback.kt
+++ b/app/src/debug/kotlin/org/strigate/ferrot/callback/MockDataBootstrapCallback.kt
@@ -17,6 +17,7 @@ class MockDataBootstrapCallback(
             return
         }
         val now = System.currentTimeMillis()
+
         fun copyRawToFilesDir(resId: Int, relativePath: String): String {
             val outputFile = File(appContext.filesDir, relativePath)
             outputFile.parentFile?.mkdirs()
@@ -33,7 +34,8 @@ class MockDataBootstrapCallback(
             uid: String,
             url: String,
             status: String,
-            filePath: String?,
+            videoFilePath: String?,
+            audioFilePath: String?,
             errorMessage: String?,
             enqueuedAt: Long,
             startedAt: Long?,
@@ -42,16 +44,17 @@ class MockDataBootstrapCallback(
             db.execSQL(
                 """
                 INSERT INTO download (
-                    id, uid, url, status, filePath, errorMessage,
+                    id, uid, url, status, videoFilePath, audioFilePath, errorMessage,
                     enqueuedAtMillis, startedAtMillis, completedAtMillis
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent(),
                 arrayOf<Any?>(
                     id,
                     uid,
                     url,
                     status,
-                    filePath,
+                    videoFilePath,
+                    audioFilePath,
                     errorMessage,
                     enqueuedAt,
                     startedAt,
@@ -112,7 +115,8 @@ class MockDataBootstrapCallback(
             uid = "example-001",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "COMPLETED",
-            filePath = "downloads/example.mp4",
+            videoFilePath = "downloads/example.mp4",
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 60 * 60 * 1000,
             startedAt = now - 55 * 60 * 1000,
@@ -138,7 +142,8 @@ class MockDataBootstrapCallback(
             uid = "example-002",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "DOWNLOADING",
-            filePath = "downloads/example.mp4",
+            videoFilePath = "downloads/example.mp4",
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 25 * 60 * 1000,
             startedAt = now - 24 * 60 * 1000,
@@ -164,7 +169,8 @@ class MockDataBootstrapCallback(
             uid = "example-003",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "QUEUED",
-            filePath = null,
+            videoFilePath = null,
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 10 * 60 * 1000,
             startedAt = null,
@@ -190,7 +196,8 @@ class MockDataBootstrapCallback(
             uid = "example-004",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "FAILED",
-            filePath = null,
+            videoFilePath = null,
+            audioFilePath = null,
             errorMessage = "Network timeout",
             enqueuedAt = now - 40 * 60 * 1000,
             startedAt = now - 39 * 60 * 1000,
@@ -210,13 +217,14 @@ class MockDataBootstrapCallback(
             expectedBytes = 204_800_000L,
         )
 
-        // 5 - PAUSED
+        // 5 - STOPPED
         insertDownload(
             id = 5L,
             uid = "example-005",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "STOPPED",
-            filePath = "downloads/example.mp4",
+            videoFilePath = "downloads/example.mp4",
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 90 * 60 * 1000,
             startedAt = now - 85 * 60 * 1000,
@@ -242,7 +250,8 @@ class MockDataBootstrapCallback(
             uid = "example-006",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "WAITING_FOR_WIFI",
-            filePath = null,
+            videoFilePath = null,
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 15 * 60 * 1000,
             startedAt = null,
@@ -268,7 +277,8 @@ class MockDataBootstrapCallback(
             uid = "example-007",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "METADATA",
-            filePath = null,
+            videoFilePath = null,
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 2 * 60 * 1000,
             startedAt = now - 90 * 1000,
@@ -294,7 +304,8 @@ class MockDataBootstrapCallback(
             uid = "example-008",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "WAITING_FOR_NETWORK",
-            filePath = null,
+            videoFilePath = null,
+            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 5 * 60 * 1000,
             startedAt = null,


### PR DESCRIPTION
- Change `insertDownload` to accept `videoFilePath` and `audioFilePath`
- Update INSERT into `download` to use `videoFilePath` and `audioFilePath`
- Migrate all mock rows from `filePath` to `videoFilePath` (set `audioFilePath` where applicable)
- Tweak comments (PAUSED → STOPPED) to match `DownloadStatus`