### PR TITLE
feat: Add media switcher and selection handling for downloads

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadMappers.kt
@@ -9,6 +9,7 @@ internal fun DownloadEntity.toDomain() = Download(
     url = url,
     status = status.toDomain(),
     videoFilePath = videoFilePath,
+    audioFilePath = audioFilePath,
     errorMessage = errorMessage,
 )
 
@@ -18,5 +19,6 @@ internal fun Download.toEntity() = DownloadEntity(
     url = url,
     status = status.toEntity(),
     videoFilePath = videoFilePath,
+    audioFilePath = audioFilePath,
     errorMessage = errorMessage,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/Download.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/Download.kt
@@ -5,6 +5,7 @@ data class Download(
     val uid: String,
     val url: String,
     val videoFilePath: String? = null,
+    val audioFilePath: String? = null,
     val status: DownloadStatus,
     val errorMessage: String? = null,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
@@ -17,7 +17,6 @@ class BuildAudioDownloadRequestUseCase @Inject constructor() {
             addOption("--extract-audio")
             addOption("--audio-format", "mp3")
             addOption("--audio-quality", "0")
-            addOption("--keep-video")
             addOption("--no-overwrites")
             addOption("--no-post-overwrites")
             if (noProgress) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
@@ -16,6 +16,12 @@ fun Download.toUiData(
     val videoFileName = videoFilePathNonNull
         .substringAfterLast("/", missingDelimiterValue = "")
         .takeIf { it.isNotBlank() }
+
+    val audioFilePathNonNull = audioFilePath.orEmpty()
+    val audioFileName = audioFilePathNonNull
+        .substringAfterLast("/", missingDelimiterValue = "")
+        .takeIf { it.isNotBlank() }
+
     val fraction = progress?.progressPercent
         ?.let { it.coerceIn(0f, 100f) / 100f }
         ?.takeIf { it.isFinite() }
@@ -25,6 +31,8 @@ fun Download.toUiData(
         url = url,
         videoFilePath = videoFilePath,
         videoFileName = videoFileName,
+        audioFilePath = audioFilePath,
+        audioFileName = audioFileName,
         status = status.toUiData(),
         errorMessage = errorMessage,
         progressFraction = fraction,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadUiData.kt
@@ -5,6 +5,8 @@ data class DownloadUiData(
     val url: String,
     val videoFilePath: String?,
     val videoFileName: String?,
+    val audioFilePath: String?,
+    val audioFileName: String?,
     val status: DownloadStatusUiData,
     val errorMessage: String?,
     val progressFraction: Float?,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -33,6 +33,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -61,6 +64,7 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import org.strigate.ferrot.R
+import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.extensions.copyToClipboard
 import org.strigate.ferrot.presentation.component.ActionIconButton
 import org.strigate.ferrot.presentation.component.ConfirmDialog
@@ -82,6 +86,7 @@ fun DownloadScreen(
 ) {
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val selectedMedia by viewModel.selectedMediaFlow.collectAsStateWithLifecycle(initialValue = DownloadMediaType.VIDEO)
     val showConfirmDeleteDialog = remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
@@ -90,23 +95,20 @@ fun DownloadScreen(
 
     if (showConfirmDeleteDialog.value) {
         ConfirmDialog(
+            title = stringResource(R.string.confirm_dialog_delete_download_title),
+            message = stringResource(R.string.confirm_dialog_delete_download_description),
+            positiveButtonText = stringResource(R.string.yes),
             onPositiveClick = {
                 viewModel.deleteDownload()
                 backDispatcher?.onBackPressed()
                 showConfirmDeleteDialog.value = false
             },
-            onNegativeClick = {
-                showConfirmDeleteDialog.value = false
-            },
-            onDismissRequest = {
-                showConfirmDeleteDialog.value = false
-            },
-            title = stringResource(R.string.confirm_dialog_delete_download_title),
-            message = stringResource(R.string.confirm_dialog_delete_download_description),
-            positiveButtonText = stringResource(R.string.yes),
             negativeButtonText = stringResource(R.string.no),
+            onNegativeClick = { showConfirmDeleteDialog.value = false },
+            onDismissRequest = { showConfirmDeleteDialog.value = false },
         )
     }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -117,8 +119,8 @@ fun DownloadScreen(
                         },
                     ) {
                         Icon(
-                            contentDescription = stringResource(R.string.content_description_back),
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.content_description_back),
                         )
                     }
                 },
@@ -128,40 +130,14 @@ fun DownloadScreen(
                     )
                 },
                 actions = {
-                    val canSaveOrShare = (uiState as? DownloadUiState.Data)
-                        ?.data
-                        ?.status == DownloadStatusUiData.COMPLETED
-
-                    Row {
-                        ActionIconButton(
-                            onClick = {
-                                if (canSaveOrShare) {
-                                    viewModel.saveDownload()
-                                }
-                            },
-                            enabled = canSaveOrShare,
-                            contentDescription = stringResource(R.string.content_description_save_to_device),
-                            imageVector = Icons.Filled.Save,
-                        )
-                        ActionIconButton(
-                            onClick = {
-                                if (canSaveOrShare) {
-                                    viewModel.shareDownload()
-                                }
-                            },
-                            enabled = canSaveOrShare,
-                            contentDescription = stringResource(R.string.content_description_share_download),
-                            imageVector = Icons.Filled.Share,
-                        )
-                        ActionIconButton(
-                            onClick = {
-                                showConfirmDeleteDialog.value = true
-                            },
-                            enabled = true,
-                            contentDescription = stringResource(R.string.content_description_delete_download),
-                            imageVector = Icons.Filled.Delete,
-                        )
-                    }
+                    ActionIconButton(
+                        enabled = true,
+                        onClick = {
+                            showConfirmDeleteDialog.value = true
+                        },
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = stringResource(R.string.content_description_delete_download),
+                    )
                 },
             )
         },
@@ -177,12 +153,13 @@ fun DownloadScreen(
                     is DownloadUiState.Data -> {
                         DownloadContent(
                             data = state.data,
-                            onPlayClick = {
-                                viewModel.playDownload()
-                            },
-                            onRetryClick = {
-                                viewModel.retryDownload()
-                            },
+                            selectedMedia = selectedMedia,
+                            onMediaChange = { viewModel.setSelectedMedia(it) },
+                            onEnsureValidSelection = { viewModel.setSelectedMedia(it) },
+                            onPlayClick = { viewModel.playDownload() },
+                            onSaveClick = { viewModel.saveDownload() },
+                            onShareClick = { viewModel.shareDownload() },
+                            onRetryClick = { viewModel.retryDownload() },
                         )
                     }
                 }
@@ -194,11 +171,21 @@ fun DownloadScreen(
 @Composable
 private fun DownloadContent(
     data: DownloadUiData,
+    selectedMedia: DownloadMediaType,
+    onMediaChange: (DownloadMediaType) -> Unit,
+    onEnsureValidSelection: (DownloadMediaType) -> Unit,
     onPlayClick: () -> Unit,
+    onSaveClick: () -> Unit,
+    onShareClick: () -> Unit,
     onRetryClick: () -> Unit,
 ) {
     val dimens = LocalDimens.current
     with(data) {
+        LaunchedEffect(audioFilePath, selectedMedia) {
+            if (selectedMedia == DownloadMediaType.AUDIO && audioFilePath.isNullOrBlank()) {
+                onEnsureValidSelection(DownloadMediaType.VIDEO)
+            }
+        }
         Column(
             Modifier
                 .fillMaxSize()
@@ -220,15 +207,61 @@ private fun DownloadContent(
                 bytesDownloaded = bytesDownloaded,
                 forcePrimaryBar = status == DownloadStatusUiData.COMPLETED,
             )
-            Spacer(modifier = Modifier.height(dimens.spacingMedium))
+            Spacer(modifier = Modifier.height(dimens.spacingXSmall))
+            MediaSwitcherSegmented(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                selected = selectedMedia,
+                enableVideo = !videoFilePath.isNullOrBlank(),
+                enableAudio = !audioFilePath.isNullOrBlank(),
+                onSelect = onMediaChange,
+            )
+            Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
+
+            val selectedPath = when (selectedMedia) {
+                DownloadMediaType.VIDEO -> videoFilePath
+                DownloadMediaType.AUDIO -> audioFilePath
+            }
+            val canActOnSelected =
+                status == DownloadStatusUiData.COMPLETED && !selectedPath.isNullOrBlank()
+
             ThumbnailCard(
                 thumbnailFilePath = thumbnailFilePath,
-                showPlay = status == DownloadStatusUiData.COMPLETED && !videoFilePath.isNullOrBlank(),
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
+                showPlay = canActOnSelected,
                 onPlayClick = onPlayClick,
                 onRetryClick = onRetryClick,
             )
-            Spacer(modifier = Modifier.height(dimens.spacingMedium))
+            Spacer(modifier = Modifier.height(dimens.spacingSmall))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(dimens.spacingSmall),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                ActionIconButton(
+                    enabled = canActOnSelected,
+                    onClick = {
+                        if (canActOnSelected) {
+                            onSaveClick()
+                        }
+                    },
+                    imageVector = Icons.Filled.Save,
+                    contentDescription = stringResource(R.string.content_description_save_to_device),
+                )
+                ActionIconButton(
+                    enabled = canActOnSelected,
+                    onClick = {
+                        if (canActOnSelected) {
+                            onShareClick()
+                        }
+                    },
+                    imageVector = Icons.Filled.Share,
+                    contentDescription = stringResource(R.string.content_description_share_download),
+                )
+            }
+            Spacer(modifier = Modifier.height(dimens.spacingSmall))
             HorizontalDivider()
             Spacer(modifier = Modifier.height(dimens.spacingSmall))
             Column {
@@ -238,7 +271,11 @@ private fun DownloadContent(
                     isUrl = true,
                     value = url,
                 )
-                videoFileName?.let {
+                val selectedName = when (selectedMedia) {
+                    DownloadMediaType.VIDEO -> videoFileName
+                    DownloadMediaType.AUDIO -> audioFileName
+                }
+                selectedName?.let {
                     MetaItem(stringResource(R.string.download_filename), it)
                 }
                 errorMessage?.let {
@@ -250,10 +287,46 @@ private fun DownloadContent(
 }
 
 @Composable
+private fun MediaSwitcherSegmented(
+    selected: DownloadMediaType,
+    modifier: Modifier = Modifier,
+    enableVideo: Boolean,
+    enableAudio: Boolean,
+    onSelect: (DownloadMediaType) -> Unit,
+) {
+    SingleChoiceSegmentedButtonRow(
+        modifier = modifier,
+    ) {
+        SegmentedButton(
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+            selected = selected == DownloadMediaType.VIDEO,
+            onClick = {
+                onSelect(DownloadMediaType.VIDEO)
+            },
+            enabled = enableVideo,
+            label = {
+                Text(text = stringResource(R.string.video))
+            },
+        )
+        SegmentedButton(
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+            selected = selected == DownloadMediaType.AUDIO,
+            onClick = {
+                onSelect(DownloadMediaType.AUDIO)
+            },
+            enabled = enableAudio,
+            label = {
+                Text(text = stringResource(R.string.audio))
+            },
+        )
+    }
+}
+
+@Composable
 private fun ThumbnailCard(
     thumbnailFilePath: String?,
-    showPlay: Boolean,
     showRetry: Boolean,
+    showPlay: Boolean,
     onPlayClick: () -> Unit,
     onRetryClick: () -> Unit,
 ) {
@@ -307,29 +380,23 @@ private fun ThumbnailCard(
                     contentDescription = thumbnailContentDescription,
                     model = request,
                 )
-            } else {
-                if (!showRetry) {
-                    Box(
+            } else if (!showRetry) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
                         modifier = Modifier
-                            .fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
-                            modifier = Modifier
-                                .size(dimens.overlayIconSize),
-                            imageVector = Icons.Filled.Image,
-                            contentDescription = thumbnailContentDescription,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
+                            .size(dimens.overlayIconSize),
+                        imageVector = Icons.Filled.Image,
+                        contentDescription = thumbnailContentDescription,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
             if (showOverlay) {
-                val overlayIcon = if (showRetry) {
-                    Icons.Filled.Refresh
-                } else {
-                    Icons.Filled.PlayArrow
-                }
+                val overlayIcon = if (showRetry) Icons.Filled.Refresh else Icons.Filled.PlayArrow
                 val overlayContentDescription = if (showRetry) {
                     stringResource(R.string.content_description_retry)
                 } else {
@@ -384,12 +451,13 @@ private fun MetaItem(
             Spacer(modifier = Modifier.height(dimens.spacingXXSmall))
             if (isUrl) {
                 Text(
-                    modifier = Modifier.clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = LocalIndication.current,
-                    ) {
-                        uriHandler.openUri(value)
-                    },
+                    modifier = Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = LocalIndication.current,
+                        ) {
+                            uriHandler.openUri(value)
+                        },
                     style = MaterialTheme.typography.bodySmall.copy(
                         textDecoration = TextDecoration.Underline,
                     ),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
@@ -15,6 +16,7 @@ import kotlinx.coroutines.launch
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
@@ -43,6 +45,9 @@ class DownloadViewModel @Inject constructor(
 ) : ViewModel() {
     private val downloadId: Long = checkNotNull(savedStateHandle[Screen.Download.ARG_DOWNLOAD_ID])
 
+    private val selectedMedia = MutableStateFlow(DownloadMediaType.VIDEO)
+    val selectedMediaFlow: Flow<DownloadMediaType> = selectedMedia
+
     val uiState = getUiState().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
@@ -55,26 +60,28 @@ class DownloadViewModel @Inject constructor(
         }
     }
 
-    private fun getUiState(id: Long = downloadId): Flow<DownloadUiState> {
-        return combine(
-            downloadUseCase.getDownloadByIdAsFlowUseCase(id),
-            downloadMetadataUseCase.getDownloadMetadataByIdAsFlowUseCase(id),
-            downloadProgressUseCase.getDownloadProgressByDownloadIdAsFlowUseCase(id),
-        ) { download, metadata, progress ->
-            if (download == null) {
-                DownloadUiState.Error
-            } else {
-                DownloadUiState.Data(
-                    data = download.toUiData(
-                        metadata = metadata,
-                        progress = progress,
-                    ),
-                )
-            }
+    private fun getUiState(id: Long = downloadId) = combine(
+        downloadUseCase.getDownloadByIdAsFlowUseCase(id),
+        downloadMetadataUseCase.getDownloadMetadataByIdAsFlowUseCase(id),
+        downloadProgressUseCase.getDownloadProgressByDownloadIdAsFlowUseCase(id),
+    ) { download, metadata, progress ->
+        if (download == null) {
+            DownloadUiState.Error
+        } else {
+            DownloadUiState.Data(
+                data = download.toUiData(
+                    metadata = metadata,
+                    progress = progress,
+                ),
+            )
         }
     }
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.DOWNLOAD)
+
+    fun setSelectedMedia(type: DownloadMediaType) {
+        selectedMedia.value = type
+    }
 
     fun deleteDownload() {
         viewModelScope.launch {
@@ -83,31 +90,35 @@ class DownloadViewModel @Inject constructor(
         }
     }
 
-    fun shareDownload() {
-        viewModelScope.launch {
-            val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
-            ShareHelper.shareFileIfExists(appContext, download.videoFilePath)
+    fun shareDownload() = viewModelScope.launch {
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
+        val path = when (selectedMedia.value) {
+            DownloadMediaType.VIDEO -> download.videoFilePath
+            DownloadMediaType.AUDIO -> download.audioFilePath
         }
+        ShareHelper.shareFileIfExists(appContext, path)
     }
 
-    fun saveDownload() {
-        viewModelScope.launch {
-            val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
-            SaveHelper.saveToDownloads(appContext, download.videoFilePath)
+    fun saveDownload() = viewModelScope.launch {
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
+        val path = when (selectedMedia.value) {
+            DownloadMediaType.VIDEO -> download.videoFilePath
+            DownloadMediaType.AUDIO -> download.audioFilePath
         }
+        SaveHelper.saveToDownloads(appContext, path)
     }
 
-    fun playDownload() {
-        viewModelScope.launch {
-            val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
-            PlayHelper.playFileIfExists(appContext, download.videoFilePath)
+    fun playDownload() = viewModelScope.launch {
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
+        val path = when (selectedMedia.value) {
+            DownloadMediaType.VIDEO -> download.videoFilePath
+            DownloadMediaType.AUDIO -> download.audioFilePath
         }
+        PlayHelper.playFileIfExists(appContext, path)
     }
 
-    fun retryDownload() {
-        viewModelScope.launch {
-            startDownloadUseCase(downloadId)
-        }
+    fun retryDownload() = viewModelScope.launch {
+        startDownloadUseCase(downloadId)
     }
 
     companion object {

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -200,8 +200,8 @@ class DownloadWorker(
                     maxBytes = max(maxBytes, directoryBytesSum(uidDir))
                     maxBytes
                 }
-                val videoTemplate = "${uidDir.absolutePath}/%(id)s.%(ext)s"
-                val audioTemplate = "${uidDir.absolutePath}/%(id)s.audio.%(ext)s"
+                val videoTemplate = "${uidDir.absolutePath}/%(id)s.V.%(ext)s"
+                val audioTemplate = "${uidDir.absolutePath}/%(id)s.A.%(ext)s"
 
                 val phaseContext = PhaseContext(
                     phase = DownloadMediaType.VIDEO,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,8 @@
     <string name="percent_100">100%</string>
     <string name="share_to">Share to…</string>
     <string name="never">Never</string>
+    <string name="video">Video</string>
+    <string name="audio">Audio</string>
 
     <string name="confirm_dialog_delete_download_title">Delete download</string>
     <string name="confirm_dialog_delete_download_description">Are you sure you want to delete this download?</string>


### PR DESCRIPTION
- Add `selectedMedia` state with `selectedMediaFlow` and `setSelectedMedia` in `DownloadViewModel`
- Route `playDownload`, `saveDownload`, and `shareDownload` to selected path (`video` or `audio`)
- Update `DownloadScreen` to pass `selectedMedia`, `onMediaChange`, and `onEnsureValidSelection` to `DownloadContent`
- Add `MediaSwitcherSegmented` with `SegmentedButton` controls; enabled based on `videoFilePath`/`audioFilePath`
- Guard selection: if `audio` is selected but `audioFilePath` is absent, call `onEnsureValidSelection` with `DownloadMediaType.VIDEO`
- Show save/share actions only when selected media exists and `status` is `COMPLETED`
- Add strings `video` and `audio`
- Change download templates to `%(id)s.V.%(ext)s` and `%(id)s.A.%(ext)s`
- Remove `--keep-video` in `BuildAudioDownloadRequestUseCase`
- Extend models and mappers with `audioFilePath` and `audioFileName`
- Minor UI tidy ups in `ThumbnailCard`, spacing, and click handlers