### PR TITLE
feat: Show media file extension pill on Download screen

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadAudioDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadAudioDao.kt
@@ -9,7 +9,6 @@ import org.strigate.ferrot.data.local.entity.DownloadAudioEntity
 
 @Dao
 interface DownloadAudioDao {
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrReplace(entity: DownloadAudioEntity): Long
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
@@ -8,6 +8,7 @@ import org.strigate.ferrot.domain.model.DownloadVideo
 import org.strigate.ferrot.presentation.model.DownloadAudioUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.model.DownloadVideoUiData
+import java.util.Locale
 
 fun Download.toUiData(
     video: DownloadVideo?,
@@ -17,31 +18,29 @@ fun Download.toUiData(
 ): DownloadUiData {
     val downloadVideoUiData = video?.filePath
         ?.takeIf { it.isNotBlank() }
-        ?.let { path ->
+        ?.let { filePath ->
             DownloadVideoUiData(
-                filePath = path,
-                fileName = path
-                    .substringAfterLast("/", missingDelimiterValue = "")
-                    .takeIf { it.isNotBlank() },
-            )
-        }
-    val downloadAudioUiData = audio?.filePath
-        ?.takeIf { it.isNotBlank() }
-        ?.let { path ->
-            DownloadAudioUiData(
-                filePath = path,
-                fileName = path
-                    .substringAfterLast("/", missingDelimiterValue = "")
-                    .takeIf { it.isNotBlank() },
+                filePath = filePath,
+                fileName = filePath.extractFileName(),
+                extension = filePath.extractFileExtension(),
             )
         }
 
-    val derivedTitleFromVideo = downloadVideoUiData?.fileName
-        ?.substringBeforeLast('.', missingDelimiterValue = downloadVideoUiData.fileName)
+    val downloadAudioUiData = audio?.filePath
         ?.takeIf { it.isNotBlank() }
-    val derivedTitleFromAudio = downloadAudioUiData?.fileName
-        ?.substringBeforeLast('.', missingDelimiterValue = downloadAudioUiData.fileName)
+        ?.let { filePath ->
+            DownloadAudioUiData(
+                filePath = filePath,
+                fileName = filePath.extractFileName(),
+                extension = filePath.extractFileExtension(),
+            )
+        }
+
+    val derivedTitleFromVideo = downloadVideoUiData?.fileName?.stripFileExtension()
         ?.takeIf { it.isNotBlank() }
+    val derivedTitleFromAudio = downloadAudioUiData?.fileName?.stripFileExtension()
+        ?.takeIf { it.isNotBlank() }
+
     val titleValue = metadata?.title
         ?.takeIf { it.isNotBlank() }
         ?: derivedTitleFromVideo
@@ -65,3 +64,13 @@ fun Download.toUiData(
         thumbnailFilePath = metadata?.thumbnailFilePath,
     )
 }
+
+private fun String.extractFileName() = substringAfterLast('/', missingDelimiterValue = "")
+    .takeIf { it.isNotBlank() }
+
+private fun String.stripFileExtension() = substringBeforeLast('.', missingDelimiterValue = this)
+
+private fun String.extractFileExtension() = extractFileName()
+    ?.substringAfterLast('.', missingDelimiterValue = "")
+    ?.takeIf { it.isNotBlank() }
+    ?.uppercase(Locale.ROOT)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadAudioUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadAudioUiData.kt
@@ -3,4 +3,5 @@ package org.strigate.ferrot.presentation.model
 data class DownloadAudioUiData(
     val filePath: String,
     val fileName: String?,
+    val extension: String?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadVideoUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadVideoUiData.kt
@@ -3,4 +3,5 @@ package org.strigate.ferrot.presentation.model
 data class DownloadVideoUiData(
     val filePath: String,
     val fileName: String?,
+    val extension: String?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -239,6 +239,17 @@ private fun DownloadContent(
                 horizontalArrangement = Arrangement.spacedBy(dimens.spacingSmall),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                val selectedExtension = when (selectedMedia) {
+                    DownloadMediaType.VIDEO -> video?.extension
+                    DownloadMediaType.AUDIO -> audio?.extension
+                }?.takeIf {
+                    it.isNotBlank()
+                }
+                selectedExtension?.let { extension ->
+                    ExtensionPill(
+                        text = extension.uppercase(),
+                    )
+                }
                 Spacer(modifier = Modifier.weight(1f))
                 ActionIconButton(
                     enabled = canActOnSelected,
@@ -418,6 +429,32 @@ private fun ThumbnailCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ExtensionPill(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    val dimens = LocalDimens.current
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shadowElevation = dimens.shadowElevationLow,
+        tonalElevation = dimens.tonalElevationHigh,
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(
+                    horizontal = dimens.spacingSmall,
+                    vertical = dimens.spacingXXSmall,
+                ),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.titleMedium,
+            text = text,
+        )
     }
 }
 


### PR DESCRIPTION
- Add `extension` to `DownloadVideoUiData` and `DownloadAudioUiData`
- Derive `extension` and `fileName` via `extractFileName`, `extractFileExtension`, `stripFileExtension`
- Update `DownloadMappers` to use private helpers and simplify title derivation
- Render `ExtensionPill` on `DownloadScreen` using themed colors (`secondaryContainer` / `onSecondaryContainer`) and `MaterialTheme.shapes.small`
- Display pill for selected media by reading `video.extension` or `audio.extension`