### PR TITLE
fix: Improve duplicate file toast message

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/helper/SaveHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/SaveHelper.kt
@@ -35,7 +35,11 @@ object SaveHelper {
             displayName = displayName,
         )
         if (existsInDownloads) {
-            val message = context.getString(R.string.toast_file_exists, relativePathWithSlash)
+            val message = context.getString(
+                R.string.toast_already_saved,
+                displayName,
+                relativePathWithSlash,
+            )
             context.toast(message)
             return false
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="toast_checking_for_available_update">Checking for available update</string>
     <string name="toast_checking_for_dependency_updates">Checking for dependency updates</string>
     <string name="toast_saved_to">Saved to %1$s</string>
-    <string name="toast_file_exists">File already exists in %1$s</string>
+    <string name="toast_already_saved">%1$s already saved in %2$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
     <string name="toast_done">Done</string>
     <string name="toast_already_up_to_date">Already up to date</string>


### PR DESCRIPTION
- Rename string to `toast_already_saved`
- Use two placeholders to show both filename and destination path
- Update `SaveHelper` to call `context.getString(R.string.toast_already_saved, displayName, relativePathWithSlash)`
- Removes ambiguous "File already exists" wording