### PR TITLE
refactor: Update mock data bootstrap to split media files

### DIFF
--- a/app/src/debug/kotlin/org/strigate/ferrot/callback/MockDataBootstrapCallback.kt
+++ b/app/src/debug/kotlin/org/strigate/ferrot/callback/MockDataBootstrapCallback.kt
@@ -29,13 +29,45 @@ class MockDataBootstrapCallback(
             return outputFile.absolutePath
         }
 
+        fun insertVideoFile(
+            downloadId: Long,
+            filePath: String,
+        ) {
+            db.execSQL(
+                """
+                INSERT INTO download_video (
+                    downloadId, filePath
+                ) VALUES (?, ?)
+                """.trimIndent(),
+                arrayOf<Any?>(
+                    downloadId,
+                    filePath,
+                ),
+            )
+        }
+
+        fun insertAudioFile(
+            downloadId: Long,
+            filePath: String,
+        ) {
+            db.execSQL(
+                """
+                INSERT INTO download_audio (
+                    downloadId, filePath
+                ) VALUES (?, ?)
+                """.trimIndent(),
+                arrayOf<Any?>(
+                    downloadId,
+                    filePath,
+                ),
+            )
+        }
+
         fun insertDownload(
             id: Long,
             uid: String,
             url: String,
             status: String,
-            videoFilePath: String?,
-            audioFilePath: String?,
             errorMessage: String?,
             enqueuedAt: Long,
             startedAt: Long?,
@@ -44,17 +76,15 @@ class MockDataBootstrapCallback(
             db.execSQL(
                 """
                 INSERT INTO download (
-                    id, uid, url, status, videoFilePath, audioFilePath, errorMessage,
+                    id, uid, url, status, errorMessage,
                     enqueuedAtMillis, startedAtMillis, completedAtMillis
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """.trimIndent(),
                 arrayOf<Any?>(
                     id,
                     uid,
                     url,
                     status,
-                    videoFilePath,
-                    audioFilePath,
                     errorMessage,
                     enqueuedAt,
                     startedAt,
@@ -115,12 +145,18 @@ class MockDataBootstrapCallback(
             uid = "example-001",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "COMPLETED",
-            videoFilePath = "downloads/example.mp4",
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 60 * 60 * 1000,
             startedAt = now - 55 * 60 * 1000,
             completedAt = now - 52 * 60 * 1000,
+        )
+        insertVideoFile(
+            downloadId = 1L,
+            filePath = "downloads/example.V,mp4",
+        )
+        insertAudioFile(
+            downloadId = 1L,
+            filePath = "downloads/example.A.mp3",
         )
         insertMetadata(
             downloadId = 1L,
@@ -142,12 +178,14 @@ class MockDataBootstrapCallback(
             uid = "example-002",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "DOWNLOADING",
-            videoFilePath = "downloads/example.mp4",
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 25 * 60 * 1000,
             startedAt = now - 24 * 60 * 1000,
             completedAt = null,
+        )
+        insertVideoFile(
+            downloadId = 2L,
+            filePath = "downloads/example.V.mp4",
         )
         insertMetadata(
             downloadId = 2L,
@@ -169,8 +207,6 @@ class MockDataBootstrapCallback(
             uid = "example-003",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "QUEUED",
-            videoFilePath = null,
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 10 * 60 * 1000,
             startedAt = null,
@@ -196,8 +232,6 @@ class MockDataBootstrapCallback(
             uid = "example-004",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "FAILED",
-            videoFilePath = null,
-            audioFilePath = null,
             errorMessage = "Network timeout",
             enqueuedAt = now - 40 * 60 * 1000,
             startedAt = now - 39 * 60 * 1000,
@@ -223,12 +257,14 @@ class MockDataBootstrapCallback(
             uid = "example-005",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "STOPPED",
-            videoFilePath = "downloads/example.mp4",
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 90 * 60 * 1000,
             startedAt = now - 85 * 60 * 1000,
             completedAt = null,
+        )
+        insertVideoFile(
+            downloadId = 5L,
+            filePath = "downloads/example.V.mp4",
         )
         insertMetadata(
             downloadId = 5L,
@@ -250,8 +286,6 @@ class MockDataBootstrapCallback(
             uid = "example-006",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "WAITING_FOR_WIFI",
-            videoFilePath = null,
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 15 * 60 * 1000,
             startedAt = null,
@@ -277,8 +311,6 @@ class MockDataBootstrapCallback(
             uid = "example-007",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "METADATA",
-            videoFilePath = null,
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 2 * 60 * 1000,
             startedAt = now - 90 * 1000,
@@ -304,8 +336,6 @@ class MockDataBootstrapCallback(
             uid = "example-008",
             url = "https://example.com/watch?v=dQw4w9WgXcQ",
             status = "WAITING_FOR_NETWORK",
-            videoFilePath = null,
-            audioFilePath = null,
             errorMessage = null,
             enqueuedAt = now - 5 * 60 * 1000,
             startedAt = null,


### PR DESCRIPTION
- Add `insertVideoFile` and `insertAudioFile` helpers
- Remove `videoFilePath` and `audioFilePath` from `insertDownload` and its SQL
- Insert sample rows into `download_video` and `download_audio` for ids `1`, `2`, and `5`
- Adjust example file paths to `"downloads/example.V.mp4"` and `"downloads/example.A.mp3"`
- Keep existing metadata inserts and timestamps unchanged