### PR TITLE
chore: Update Android Gradle Plugin to 8.13.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.0"
+agp = "8.13.1"
 coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 startupRuntime = "1.2.0"


### PR DESCRIPTION
- Bump `agp` version from `8.13.0` to `8.13.1`