### PR TITLE
refactor: Rename downloads view, add timestamp sorting, and migrate t…

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
@@ -19,6 +19,7 @@ import org.strigate.ferrot.data.local.entity.DownloadMetadataEntity
 import org.strigate.ferrot.data.local.entity.DownloadProgressEntity
 import org.strigate.ferrot.data.local.entity.DownloadVideoEntity
 import org.strigate.ferrot.data.local.migration.MIGRATION_1_2
+import org.strigate.ferrot.data.local.migration.MIGRATION_2_3
 import org.strigate.ferrot.data.local.typeconverter.DownloadStatusTypeConverter
 import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
 
@@ -35,7 +36,7 @@ import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
         DownloadWithMetadataView::class,
     ],
     exportSchema = false,
-    version = 2,
+    version = 3,
 )
 @TypeConverters(
     DownloadStatusTypeConverter::class,
@@ -81,5 +82,6 @@ abstract class Database : RoomDatabase() {
 private fun <T : RoomDatabase> RoomDatabase.Builder<T>.applyMigrations(): RoomDatabase.Builder<T> {
     return addMigrations(
         MIGRATION_1_2,
+        MIGRATION_2_3,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadWithMetadataViewDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadWithMetadataViewDao.kt
@@ -9,22 +9,28 @@ import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
 interface DownloadWithMetadataViewDao {
     @Query(
         """
-        SELECT * FROM DownloadWithMetadataView
-        ORDER BY
-          CASE status
-            WHEN 'QUEUED' THEN 0
-            WHEN 'WAITING_FOR_NETWORK' THEN 1
-            WHEN 'WAITING_FOR_WIFI' THEN 2
-            WHEN 'METADATA' THEN 3
-            WHEN 'PAUSED' THEN 4
-            WHEN 'DOWNLOADING' THEN 5
-            WHEN 'COMPLETED' THEN 6
-            WHEN 'FAILED' THEN 7
-            WHEN 'STOPPED' THEN 8
-            ELSE 9
-          END,
-          id DESC
-        """
+    SELECT * FROM downloads_with_metadata_view
+    ORDER BY
+      CASE status
+        WHEN 'QUEUED' THEN 0
+        WHEN 'WAITING_FOR_NETWORK' THEN 1
+        WHEN 'WAITING_FOR_WIFI' THEN 2
+        WHEN 'METADATA' THEN 3
+        WHEN 'PAUSED' THEN 4
+        WHEN 'DOWNLOADING' THEN 5
+        WHEN 'COMPLETED' THEN 6
+        WHEN 'FAILED' THEN 7
+        WHEN 'STOPPED' THEN 8
+        ELSE 9
+      END,
+      CASE
+        WHEN status = 'COMPLETED' THEN completedAtMillis
+        WHEN status IN ('DOWNLOADING','PAUSED','METADATA') THEN startedAtMillis
+        WHEN status IN ('QUEUED','WAITING_FOR_NETWORK','WAITING_FOR_WIFI','FAILED','STOPPED') THEN enqueuedAtMillis
+        ELSE enqueuedAtMillis
+      END DESC,
+      id DESC
+    """
     )
     fun getAllAsFlow(): Flow<List<DownloadWithMetadataView>>
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/migration/Migration2To3.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/migration/Migration2To3.kt
@@ -1,0 +1,27 @@
+package org.strigate.ferrot.data.local.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DROP VIEW IF EXISTS `DownloadWithMetadataView`")
+        db.execSQL(
+            "CREATE VIEW `downloads_with_metadata_view` AS SELECT\n" +
+                    "        download.id AS id,\n" +
+                    "        download.url AS url,\n" +
+                    "        download.status AS status,\n" +
+                    "        COALESCE(download_metadata.title, download.url) AS resolvedTitle,\n" +
+                    "        COALESCE(download_progress.progressPercent, 0) AS progressPercent,\n" +
+                    "        download_progress.etaSeconds AS etaSeconds,\n" +
+                    "        download_progress.bytesDownloaded AS bytesDownloaded,\n" +
+                    "        download_progress.expectedBytes AS expectedBytes,\n" +
+                    "        download.enqueuedAtMillis AS enqueuedAtMillis,\n" +
+                    "        download.startedAtMillis AS startedAtMillis,\n" +
+                    "        download.completedAtMillis AS completedAtMillis\n" +
+                    "    FROM download\n" +
+                    "    LEFT JOIN download_metadata ON download_metadata.downloadId = download.id\n" +
+                    "    LEFT JOIN download_progress ON download_progress.downloadId = download.id"
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/view/DownloadWithMetadataView.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/view/DownloadWithMetadataView.kt
@@ -4,7 +4,8 @@ import androidx.room.DatabaseView
 import org.strigate.ferrot.data.local.entity.DownloadStatus
 
 @DatabaseView(
-    """
+    viewName = "downloads_with_metadata_view",
+    value = """
     SELECT
         download.id AS id,
         download.url AS url,
@@ -13,7 +14,10 @@ import org.strigate.ferrot.data.local.entity.DownloadStatus
         COALESCE(download_progress.progressPercent, 0) AS progressPercent,
         download_progress.etaSeconds AS etaSeconds,
         download_progress.bytesDownloaded AS bytesDownloaded,
-        download_progress.expectedBytes AS expectedBytes
+        download_progress.expectedBytes AS expectedBytes,
+        download.enqueuedAtMillis AS enqueuedAtMillis,
+        download.startedAtMillis AS startedAtMillis,
+        download.completedAtMillis AS completedAtMillis
     FROM download
     LEFT JOIN download_metadata ON download_metadata.downloadId = download.id
     LEFT JOIN download_progress ON download_progress.downloadId = download.id
@@ -28,4 +32,7 @@ data class DownloadWithMetadataView(
     val etaSeconds: Long?,
     val bytesDownloaded: Long,
     val expectedBytes: Long?,
+    val enqueuedAtMillis: Long,
+    val startedAtMillis: Long?,
+    val completedAtMillis: Long?,
 )


### PR DESCRIPTION
…o v3

- Update `version` to `3` in `Database`
- Import `MIGRATION_2_3` and register it in `applyMigrations`
- Rename SQL view from `DownloadWithMetadataView` to `downloads_with_metadata_view` via `viewName`
- Extend `DownloadWithMetadataView` with `enqueuedAtMillis`, `startedAtMillis`, `completedAtMillis`
- Update `DownloadWithMetadataViewDao.getAllAsFlow` to query `downloads_with_metadata_view` and order by status-specific timestamps then `id`
- Add `Migration2To3` to drop the old view and create `downloads_with_metadata_view` with timestamp columns