### PR TITLE
Enable device-to-device transfer for app data

### DIFF
--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -18,20 +18,14 @@
             path="." />
     </cloud-backup>
     <device-transfer>
-        <exclude
+        <include
             domain="file"
             path="." />
-        <exclude
+        <include
             domain="database"
             path="." />
-        <exclude
+        <include
             domain="sharedpref"
-            path="." />
-        <exclude
-            domain="external"
-            path="." />
-        <exclude
-            domain="root"
             path="." />
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
- Include `file` for internal storage migration
- Include `database` to transfer Room DB
- Include `sharedpref` for app preferences
- Remove unnecessary excludes under `device-transfer`