### PR TITLE
refactor: Split download UI metadata and progress

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
@@ -9,6 +9,8 @@ import org.strigate.ferrot.extensions.extractFileExtension
 import org.strigate.ferrot.extensions.extractFileName
 import org.strigate.ferrot.extensions.stripFileExtension
 import org.strigate.ferrot.presentation.model.DownloadAudioUiData
+import org.strigate.ferrot.presentation.model.DownloadMetadataUiData
+import org.strigate.ferrot.presentation.model.DownloadProgressUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.model.DownloadVideoUiData
 
@@ -60,22 +62,34 @@ fun Download.toUiData(
         ?: derivedTitleFromAudio
         ?: url
 
-    val fraction = progress?.progressPercent
-        ?.let { it.coerceIn(0f, 100f) / 100f }
-        ?.takeIf { it.isFinite() }
+    val metadataUiData = DownloadMetadataUiData(
+        title = titleValue,
+        thumbnailFilePath = metadata?.thumbnailFilePath,
+        durationSeconds = metadata?.durationSeconds,
+    )
+
+    val progressUiData = progress?.let {
+        val fraction = it.progressPercent
+            .coerceIn(0f, 100f)
+            .div(100f)
+            .takeIf { value -> value.isFinite() }
+            ?: 0f
+
+        DownloadProgressUiData(
+            progressFraction = fraction,
+            bytesDownloaded = it.bytesDownloaded,
+            etaSeconds = it.etaSeconds,
+            expectedBytes = it.expectedBytes,
+        )
+    }
 
     return DownloadUiData(
-        title = titleValue,
         url = url,
         status = status.toUiData(),
-        durationSeconds = metadata?.durationSeconds,
+        metadata = metadataUiData,
         video = downloadVideoUiData,
         audio = downloadAudioUiData,
+        progress = progressUiData,
         errorMessage = errorMessage,
-        progressFraction = fraction,
-        bytesDownloaded = progress?.bytesDownloaded ?: 0L,
-        etaSeconds = progress?.etaSeconds,
-        expectedBytes = progress?.expectedBytes,
-        thumbnailFilePath = metadata?.thumbnailFilePath,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadMetadataUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadMetadataUiData.kt
@@ -1,0 +1,7 @@
+package org.strigate.ferrot.presentation.model
+
+data class DownloadMetadataUiData(
+    val title: String?,
+    val thumbnailFilePath: String?,
+    val durationSeconds: Int?,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadProgressUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadProgressUiData.kt
@@ -1,0 +1,8 @@
+package org.strigate.ferrot.presentation.model
+
+data class DownloadProgressUiData(
+    val progressFraction: Float,
+    val bytesDownloaded: Long,
+    val etaSeconds: Long?,
+    val expectedBytes: Long?,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadUiData.kt
@@ -1,16 +1,11 @@
 package org.strigate.ferrot.presentation.model
 
 data class DownloadUiData(
-    val title: String,
     val url: String,
     val status: DownloadStatusUiData,
-    val durationSeconds: Int?,
+    val metadata: DownloadMetadataUiData?,
     val video: DownloadVideoUiData?,
     val audio: DownloadAudioUiData?,
+    val progress: DownloadProgressUiData?,
     val errorMessage: String?,
-    val progressFraction: Float?,
-    val bytesDownloaded: Long,
-    val etaSeconds: Long?,
-    val expectedBytes: Long?,
-    val thumbnailFilePath: String?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -85,6 +85,7 @@ fun DownloadScreen(
     viewModel: DownloadViewModel = hiltViewModel(),
 ) {
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val selectedMedia by viewModel.selectedMediaFlow.collectAsStateWithLifecycle(initialValue = DownloadMediaType.VIDEO)
     val showConfirmDeleteDialog = remember { mutableStateOf(false) }
@@ -199,18 +200,18 @@ private fun DownloadContent(
                 style = MaterialTheme.typography.titleLarge,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 2,
-                text = title,
+                text = metadata?.title ?: url,
             )
             Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
             DownloadProgressSection(
                 status = status,
-                progressFraction = progressFraction,
-                etaSeconds = etaSeconds,
-                bytesDownloaded = bytesDownloaded,
+                progressFraction = progress?.progressFraction,
+                etaSeconds = progress?.etaSeconds,
+                bytesDownloaded = progress?.bytesDownloaded ?: 0L,
                 forcePrimaryBar = status == DownloadStatusUiData.COMPLETED,
             )
             Spacer(modifier = Modifier.height(dimens.spacingXSmall))
-            MediaSwitcherSegmented(
+            MediaSwitcherSegmentedButtonRow(
                 modifier = Modifier
                     .fillMaxWidth(),
                 selected = selectedMedia,
@@ -224,11 +225,11 @@ private fun DownloadContent(
                 DownloadMediaType.VIDEO -> video?.filePath
                 DownloadMediaType.AUDIO -> audio?.filePath
             }
-            val canActOnSelected =
-                status == DownloadStatusUiData.COMPLETED && !selectedPath.isNullOrBlank()
+            val canActOnSelected = status == DownloadStatusUiData.COMPLETED
+                    && !selectedPath.isNullOrBlank()
 
             ThumbnailCard(
-                thumbnailFilePath = thumbnailFilePath,
+                thumbnailFilePath = metadata?.thumbnailFilePath,
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
                 showPlay = canActOnSelected,
                 onPlayClick = onPlayClick,
@@ -300,7 +301,7 @@ private fun DownloadContent(
 }
 
 @Composable
-private fun MediaSwitcherSegmented(
+private fun MediaSwitcherSegmentedButtonRow(
     selected: DownloadMediaType,
     modifier: Modifier = Modifier,
     enableVideo: Boolean,


### PR DESCRIPTION
- Introduce `DownloadMetadataUiData` and `DownloadProgressUiData`
- Update `DownloadUiData` to reference nested metadata and progress
- Adjust `DownloadMappers` to build the new UI models
- Update `DownloadScreen` to consume `metadata` and `progress` fields