### PR TITLE
feat: Show media duration in download screen

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -75,6 +75,7 @@ import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.ferrot.presentation.util.UiFormatter
 import org.strigate.ferrot.presentation.viewmodel.DownloadViewModel
 import java.io.File
 
@@ -230,6 +231,7 @@ private fun DownloadContent(
 
             ThumbnailCard(
                 thumbnailFilePath = metadata?.thumbnailFilePath,
+                durationSeconds = metadata?.durationSeconds,
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
                 showPlay = canActOnSelected,
                 onPlayClick = onPlayClick,
@@ -290,10 +292,23 @@ private fun DownloadContent(
                     DownloadMediaType.AUDIO -> audio?.fileName
                 }
                 selectedName?.let {
-                    MetaItem(stringResource(R.string.download_filename), it)
+                    MetaItem(
+                        label = stringResource(R.string.download_filename),
+                        value = it,
+                    )
+                }
+                val formattedDuration = UiFormatter.formatDuration(metadata?.durationSeconds)
+                formattedDuration?.let {
+                    MetaItem(
+                        label = stringResource(R.string.download_duration),
+                        value = it,
+                    )
                 }
                 errorMessage?.let {
-                    MetaItem(stringResource(R.string.download_error_message), it)
+                    MetaItem(
+                        label = stringResource(R.string.download_error_message),
+                        value = it,
+                    )
                 }
             }
         }
@@ -339,6 +354,7 @@ private fun MediaSwitcherSegmentedButtonRow(
 @Composable
 private fun ThumbnailCard(
     thumbnailFilePath: String?,
+    durationSeconds: Int?,
     showRetry: Boolean,
     showPlay: Boolean,
     onPlayClick: () -> Unit,
@@ -357,6 +373,8 @@ private fun ThumbnailCard(
         showPlay -> onPlayClick
         else -> null
     }
+    val durationText = UiFormatter.formatDuration(durationSeconds)
+    val overlayBackgroundColor = Color.Black.copy(alpha = 0.35f)
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -421,13 +439,34 @@ private fun ThumbnailCard(
                         .align(Alignment.Center)
                         .size(dimens.overlayButtonSize)
                         .clip(CircleShape)
-                        .background(Color.Black.copy(alpha = 0.35f)),
+                        .background(overlayBackgroundColor),
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         tint = Color.White,
                         contentDescription = overlayContentDescription,
                         imageVector = overlayIcon,
+                    )
+                }
+            }
+            if (durationText != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(dimens.spacingSmall)
+                        .background(
+                            color = overlayBackgroundColor,
+                            shape = MaterialTheme.shapes.small,
+                        )
+                        .padding(
+                            horizontal = dimens.spacingSmall,
+                            vertical = dimens.spacingXXSmall,
+                        ),
+                ) {
+                    Text(
+                        style = MaterialTheme.typography.labelLarge,
+                        color = Color.White,
+                        text = durationText,
                     )
                 }
             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/util/UiFormatter.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/util/UiFormatter.kt
@@ -52,4 +52,18 @@ object UiFormatter {
         val exact = "${dateFormat.format(Date(millis))}, ${timeFormat.format(Date(millis))}"
         return "$relativeTime ($exact)"
     }
+
+    fun formatDuration(seconds: Int?): String? {
+        if (seconds == null || seconds <= 0) {
+            return null
+        }
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        val remainingSeconds = seconds % 60
+        return if (hours > 0) {
+            String.format(Locale.getDefault(), "%d:%02d:%02d", hours, minutes, remainingSeconds)
+        } else {
+            String.format(Locale.getDefault(), "%d:%02d", minutes, remainingSeconds)
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
 
     <string name="download_url">URL</string>
     <string name="download_filename">Filename</string>
+    <string name="download_duration">Duration</string>
     <string name="download_error_message">Failed error message</string>
 
     <string name="status_queued">Queued</string>


### PR DESCRIPTION
- Add `download_duration` string resource
- Add `formatDuration` to `UiFormatter`
- Display duration overlay in `ThumbnailCard`
- Show formatted duration as a meta item in `DownloadContent`