### PR TITLE
fix: Correct audio file extension extraction

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -296,7 +296,7 @@ class DownloadWorker(
                     Log.w(LOG_TAG, "$tag Audio output file could not be located or does not exist")
                 } else {
                     val audioOutputFilePath = audioOutputFile.absolutePath
-                    val audioOutputFileExtension = videoInfo.ext ?: audioOutputFilePath
+                    val audioOutputFileExtension = audioOutputFilePath
                         .extractFileExtension()
                         .orEmpty()
 


### PR DESCRIPTION
- Use `audioOutputFilePath` instead of `videoInfo.ext` when resolving audio extension