### PR TITLE
fix: Chain dependency update and requeue work on package replace

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/MyPackageReplacedReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/MyPackageReplacedReceiver.kt
@@ -3,14 +3,25 @@ package org.strigate.ferrot.app.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.provider.UpdatePathProvider
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
+import org.strigate.ferrot.work.UpdateDependenciesWorker
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -22,15 +33,48 @@ class MyPackageReplacedReceiver : BroadcastReceiver() {
     lateinit var availableUpdateUseCase: AvailableUpdateUseCase
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) return
+        if (intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) {
+            return
+        }
         val pendingResult = goAsync()
+        val appContext = context.applicationContext
         CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
-            runCatching {
+            try {
                 availableUpdateUseCase.clearAvailableUpdateUseCase()
                 updatePathProvider.updatesDir().deleteRecursively()
-                RequeuePendingDownloadsWorker.enqueueOneItem(context)
+
+                val constraints = Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresStorageNotLow(true)
+                    .build()
+
+                val updateDependenciesOneTimeWorkRequest =
+                    OneTimeWorkRequestBuilder<UpdateDependenciesWorker>()
+                        .setConstraints(constraints)
+                        .setBackoffCriteria(
+                            BackoffPolicy.EXPONENTIAL,
+                            30,
+                            TimeUnit.SECONDS,
+                        )
+                        .build()
+                val requeuePendingDownloadsOneTimeWorkRequest =
+                    OneTimeWorkRequestBuilder<RequeuePendingDownloadsWorker>()
+                        .build()
+
+                WorkManager.getInstance(appContext)
+                    .beginUniqueWork(
+                        ONETIME_UPDATE_DEPENDENCIES,
+                        ExistingWorkPolicy.REPLACE,
+                        updateDependenciesOneTimeWorkRequest,
+                    )
+                    .then(requeuePendingDownloadsOneTimeWorkRequest)
+                    .enqueue()
+
+            } catch (throwable: Throwable) {
+                Log.w(LOG_TAG, throwable)
+            } finally {
+                pendingResult.finish()
             }
-            pendingResult.finish()
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -43,10 +43,10 @@ class UpdateDependenciesWorker(
 
             when (updateStatus) {
                 YoutubeDL.UpdateStatus.ALREADY_UP_TO_DATE ->
-                    appContext.toast(appContext.getString(R.string.toast_already_up_to_date))
+                    appContext.toast(appContext.getString(R.string.toast_dependencies_already_up_to_date))
 
                 YoutubeDL.UpdateStatus.DONE ->
-                    appContext.toast(appContext.getString(R.string.toast_done))
+                    appContext.toast(appContext.getString(R.string.toast_dependencies_update_complete))
 
                 else -> appContext.toast("$updateStatus")
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,8 +64,8 @@
     <string name="toast_saved_to">Saved to %1$s</string>
     <string name="toast_already_saved">%1$s already saved in %2$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
-    <string name="toast_done">Done</string>
-    <string name="toast_already_up_to_date">Already up to date</string>
+    <string name="toast_dependencies_update_complete">Dependencies update complete</string>
+    <string name="toast_dependencies_already_up_to_date">Dependencies already up to date</string>
 
     <string name="settings_section_general">General</string>
     <string name="settings_section_app_info">App info</string>


### PR DESCRIPTION
- Update `UpdateDependenciesWorker` to use dependency-specific toast strings
- Replace old strings with `toast_dependencies_update_complete` and `toast_dependencies_already_up_to_date`
- Update `MyPackageReplacedReceiver` to:
  - Clear available update state
  - Delete the `updatesDir`
  - Chain `UpdateDependenciesWorker` then `RequeuePendingDownloadsWorker` using unique `ONETIME_UPDATE_DEPENDENCIES` work