### PR TITLE
chore: Bump Compose BOM and `activityCompose`, tidy build files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,7 +119,6 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
-
 private fun ApplicationDefaultConfig.applyMockBootstrapProperty(enabled: Boolean) {
     boolField("BOOTSTRAP_MOCK_DATA", enabled)
 }
@@ -183,7 +182,7 @@ private fun isDebugBuildType(): Boolean {
 }
 
 dependencies {
-    // Core
+    // Android
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.startup.runtime)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ startupRuntime = "1.2.0"
 datastorePreferences = "1.2.0"
 material = "1.13.0"
 lifecycle = "2.10.0"
-composeBom = "2025.11.01"
-activityCompose = "1.12.0"
+composeBom = "2025.12.00"
+activityCompose = "1.12.1"
 navigationCompose = "2.9.6"
 work = "2.11.0"
 hilt = "2.57.2"
@@ -24,7 +24,7 @@ kotlin = "2.2.21"
 ksp = "2.2.21-2.0.4"
 
 [libraries]
-# Core
+# Android
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "startupRuntime" }


### PR DESCRIPTION
- Update `composeBom` from `2025.11.01` to `2025.12.00` in `gradle/libs.versions.toml`
- Bump `activityCompose` from `1.12.0` to `1.12.1` in `gradle/libs.versions.toml`
- Rename header `# Core` to `# Android` in `gradle/libs.versions.toml`
- Change comment `// Core` to `// Android` in `app/build.gradle.kts`