### PR TITLE
refactor: Standardize layout, padding, and elevation across screens

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -1,5 +1,6 @@
 package org.strigate.ferrot.presentation.component
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.Refresh
@@ -53,9 +54,10 @@ fun DownloadPrimaryActionButton(
         )
     }
     Surface(
-        modifier = modifier,
+        modifier = modifier
+            .size(dimens.iconXLarge),
         shape = MaterialTheme.shapes.medium,
-        tonalElevation = dimens.tonalElevationLow,
+        tonalElevation = dimens.tonalElevationHigh,
     ) {
         with(actionConfig) {
             IconButton(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -169,7 +169,7 @@ fun DownloadScreen(
                 is DownloadUiState.Loading -> LoadingState()
                 is DownloadUiState.Error -> DownloadError()
                 is DownloadUiState.Data -> {
-                    val peekPadding = dimens.spacingMediumAlt
+                    val peekPadding = dimens.spacingMedium
                     val pageSpacing = dimens.spacingSmall
                     DownloadPager(
                         modifier = modifier
@@ -251,7 +251,7 @@ private fun DownloadPager(
                 .fillMaxSize()
                 .padding(bottom = dimens.spacingSmall),
             shape = MaterialTheme.shapes.medium,
-            tonalElevation = dimens.tonalElevationHigh,
+            tonalElevation = dimens.tonalElevationLow,
             shadowElevation = dimens.shadowElevationLow,
         ) {
             DownloadPageContent(
@@ -302,15 +302,15 @@ private fun DownloadPageContent(
             Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(horizontal = dimens.spacingMediumAlt),
+                .padding(horizontal = dimens.spacingMedium),
             verticalArrangement = Arrangement.Top,
         ) {
             Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
             Text(
-                style = MaterialTheme.typography.titleLarge,
+                style = MaterialTheme.typography.bodyLarge,
                 overflow = TextOverflow.Ellipsis,
-                maxLines = 2,
                 text = metadata?.title ?: url,
+                maxLines = 2,
             )
             Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
             DownloadProgressSection(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -11,12 +11,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -256,10 +256,10 @@ private fun AvailableUpdateBanner(
                 .clickable {
                     onClick(localFilePath)
                 },
-            tonalElevation = dimens.tonalElevationHigh,
-            shadowElevation = dimens.shadowElevationLow,
             shape = MaterialTheme.shapes.medium,
             color = MaterialTheme.colorScheme.secondaryContainer,
+            tonalElevation = dimens.tonalElevationHigh,
+            shadowElevation = dimens.shadowElevationLow,
         ) {
             Row(
                 modifier = Modifier
@@ -402,8 +402,7 @@ private fun DownloadsList(
     ) {
         LazyColumn(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = dimens.spacingMediumAlt),
+                .fillMaxSize(),
             state = listState,
         ) {
             items(
@@ -470,7 +469,6 @@ private fun DownloadsList(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(bottom = dimens.spacingSmall)
                             .onGloballyPositioned { layoutCoordinates ->
                                 rowWidthPx = layoutCoordinates.size.width.toFloat()
                             },
@@ -538,16 +536,18 @@ private fun DownloadItem(
     val dimens = LocalDimens.current
     Surface(
         shape = MaterialTheme.shapes.medium,
-        tonalElevation = dimens.tonalElevationHigh,
-        shadowElevation = dimens.shadowElevationLow,
+        color = MaterialTheme.colorScheme.surface,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable(onClick = onClick)
-                .padding(dimens.spacingMediumAlt),
-            verticalAlignment = Alignment.CenterVertically,
+                .padding(
+                    vertical = dimens.spacingSmall,
+                    horizontal = dimens.spacingMedium,
+                ),
             horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             with(item) {
                 DownloadPrimaryActionButton(
@@ -558,7 +558,7 @@ private fun DownloadItem(
                 Spacer(modifier = Modifier.width(dimens.spacingMediumAlt))
                 Column(
                     modifier = Modifier
-                        .wrapContentHeight()
+                        .fillMaxHeight()
                         .weight(1f),
                 ) {
                     Text(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
@@ -27,9 +27,12 @@ data class Dimens(
     val radiusLarge: Dp = 16.dp,
 
     val tonalElevationLow: Dp = 1.dp,
+    val tonalElevation: Dp = 2.dp,
     val tonalElevationHigh: Dp = 4.dp,
 
     val shadowElevationLow: Dp = 1.dp,
+    val shadowElevation: Dp = 2.dp,
+    val shadowElevationHigh: Dp = 4.dp,
 
     val contentMaxWidth: Dp = 320.dp,
 


### PR DESCRIPTION
- Update `DownloadsScreen` row and column layouts
- Adjust paddings and remove unused `wrapContentHeight()`
- Reorder `Surface` params and unify `color` + elevation usage
- Add new dimens: `tonalElevation`, `shadowElevation`, `shadowElevationHigh`
- Update `DownloadScreen` pager padding and elevation
- Change title text style and horizontal padding in `DownloadPageContent`
- Update `DownloadPrimaryActionButton` with `.size(dimens.iconXLarge)` and higher elevation