### PR TITLE
fix: Persist selected media per download

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,10 +71,8 @@ import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.launch
 import org.strigate.ferrot.R
 import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.extensions.copyToClipboard
@@ -102,7 +99,7 @@ fun DownloadScreen(
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val selectedMedia by viewModel.selectedMediaFlow.collectAsStateWithLifecycle(initialValue = DownloadMediaType.VIDEO)
+    val selectedMedia by viewModel.selectedMedia.collectAsStateWithLifecycle(initialValue = DownloadMediaType.VIDEO)
     val showConfirmDeleteDialog = remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
@@ -210,31 +207,33 @@ private fun DownloadPager(
         .indexOfFirst { it.id == data.id }
         .coerceAtLeast(0)
 
-    val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(
         initialPage = initialIndex,
         pageCount = { downloads.size }
     )
 
+    LaunchedEffect(downloads) {
+        viewModel.setDefaultsForIds(downloads.map { it.id })
+    }
     LaunchedEffect(pagerState, downloads) {
         snapshotFlow { pagerState.currentPage }
-            .map { page -> downloads.getOrNull(page)?.id }
-            .filter { it != null }
+            .map { pageIndex -> downloads.getOrNull(pageIndex)?.id }
+            .filterNotNull()
             .distinctUntilChanged()
-            .collect { id ->
-                id?.let { viewModel.selectDownload(it) }
-            }
-    }
-    LaunchedEffect(data, viewModel.selectedId) {
-        snapshotFlow { viewModel.selectedId.value }
-            .mapNotNull { id -> downloads.indexOfFirst { it.id == id }.takeIf { it >= 0 } }
-            .distinctUntilChanged()
-            .collect { pageIndex ->
-                coroutineScope.launch {
-                    if (pagerState.currentPage != pageIndex) {
-                        pagerState.animateScrollToPage(pageIndex)
-                    }
+            .collect { downloadId ->
+                viewModel.selectDownload(downloadId)
+                val currentDownload = downloads.firstOrNull { it.id == downloadId }
+                val isAudioAvailable = currentDownload?.audio?.filePath?.isNotBlank() == true
+                val isVideoAvailable = currentDownload?.video?.filePath?.isNotBlank() == true
+                val currentlySelectedMedia = viewModel.selectedMedia.value
+                val correctedMediaType = when {
+                    isAudioAvailable && currentlySelectedMedia == DownloadMediaType.AUDIO -> DownloadMediaType.AUDIO
+                    isVideoAvailable && currentlySelectedMedia == DownloadMediaType.VIDEO -> DownloadMediaType.VIDEO
+                    isAudioAvailable -> DownloadMediaType.AUDIO
+                    isVideoAvailable -> DownloadMediaType.VIDEO
+                    else -> DownloadMediaType.VIDEO
                 }
+                viewModel.setSelectedMedia(correctedMediaType, downloadId)
             }
     }
 
@@ -257,11 +256,11 @@ private fun DownloadPager(
             DownloadPageContent(
                 data = item,
                 selectedMedia = selectedMedia,
-                onMediaChange = {
-                    viewModel.setSelectedMedia(it)
+                onMediaChange = { type ->
+                    viewModel.setSelectedMedia(type, item.id)
                 },
-                onEnsureValidSelection = {
-                    viewModel.setSelectedMedia(it)
+                onEnsureValidSelection = { type ->
+                    viewModel.setSelectedMedia(type, item.id)
                 },
                 onPlayClick = {
                     viewModel.playDownload(item.id)
@@ -273,6 +272,7 @@ private fun DownloadPager(
                     viewModel.shareDownload(item.id)
                 },
                 onRetryClick = {
+                    viewModel.selectDownload(item.id)
                     viewModel.retryDownload(item.id)
                 },
             )
@@ -325,8 +325,8 @@ private fun DownloadPageContent(
                 modifier = Modifier
                     .fillMaxWidth(),
                 selected = selectedMedia,
-                enableVideo = video != null,
-                enableAudio = audio != null,
+                enableVideo = video?.filePath?.isNotBlank() == true,
+                enableAudio = audio?.filePath?.isNotBlank() == true,
                 onSelect = onMediaChange,
             )
             Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -67,8 +66,17 @@ class DownloadViewModel @Inject constructor(
     private val _selectedId = MutableStateFlow(initialId)
     val selectedId: StateFlow<Long> = _selectedId
 
-    private val selectedMedia = MutableStateFlow(DownloadMediaType.VIDEO)
-    val selectedMediaFlow: Flow<DownloadMediaType> = selectedMedia
+    private val _selectedMediaById = MutableStateFlow<Map<Long, DownloadMediaType>>(emptyMap())
+    val selectedMedia: StateFlow<DownloadMediaType> = combine(
+        selectedId,
+        _selectedMediaById,
+    ) { id, map ->
+        map[id] ?: DownloadMediaType.VIDEO
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+        initialValue = DownloadMediaType.VIDEO,
+    )
 
     init {
         viewModelScope.launch {
@@ -132,10 +140,38 @@ class DownloadViewModel @Inject constructor(
 
     fun selectDownload(id: Long) {
         _selectedId.value = id
+        if (_selectedMediaById.value[id] == null) {
+            _selectedMediaById.value = _selectedMediaById
+                .value
+                .toMutableMap()
+                .also {
+                    it[id] = DownloadMediaType.VIDEO
+                }
+        }
     }
 
-    fun setSelectedMedia(type: DownloadMediaType) {
-        selectedMedia.value = type
+    fun setSelectedMedia(type: DownloadMediaType, forDownloadId: Long? = null) {
+        val id = forDownloadId ?: _selectedId.value
+        _selectedMediaById.value = _selectedMediaById
+            .value
+            .toMutableMap()
+            .also {
+                it[id] = type
+            }
+    }
+
+    fun setDefaultsForIds(ids: List<Long>) {
+        val current = _selectedMediaById.value.toMutableMap()
+        var changed = false
+        ids.forEach { id ->
+            if (current[id] == null) {
+                current[id] = DownloadMediaType.VIDEO
+                changed = true
+            }
+        }
+        if (changed) {
+            _selectedMediaById.value = current
+        }
     }
 
     fun deleteDownload(id: Long? = null) {
@@ -148,19 +184,19 @@ class DownloadViewModel @Inject constructor(
 
     fun shareDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        val path = currentSelectedFilePath(downloadId) ?: return@launch
+        val path = getSelectedMediaFilePath(downloadId) ?: return@launch
         ShareHelper.shareFileIfExists(appContext, path)
     }
 
     fun saveDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        val path = currentSelectedFilePath(downloadId) ?: return@launch
+        val path = getSelectedMediaFilePath(downloadId) ?: return@launch
         SaveHelper.saveToDownloads(appContext, path)
     }
 
     fun playDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        val path = currentSelectedFilePath(downloadId) ?: return@launch
+        val path = getSelectedMediaFilePath(downloadId) ?: return@launch
         PlayHelper.playFileIfExists(appContext, path)
     }
 
@@ -169,15 +205,16 @@ class DownloadViewModel @Inject constructor(
         startDownloadUseCase(downloadId)
     }
 
-    private fun currentSelectedFilePath(id: Long): String? {
+    private fun getSelectedMediaFilePath(downloadId: Long): String? {
         val state = uiState.value
         if (state !is DownloadUiState.Data) {
             return null
         }
-        val selected = state.data.downloads.firstOrNull { it.id == id } ?: return null
-        return when (selectedMedia.value) {
-            DownloadMediaType.VIDEO -> selected.video?.filePath
-            DownloadMediaType.AUDIO -> selected.audio?.filePath
+        val download = state.data.downloads.firstOrNull { it.id == downloadId } ?: return null
+        val mediaType = selectedMedia.value
+        return when (mediaType) {
+            DownloadMediaType.VIDEO -> download.video?.filePath
+            DownloadMediaType.AUDIO -> download.audio?.filePath
         }
     }
 


### PR DESCRIPTION
- Store media per id in `_selectedMediaById`.
- Expose `selectedMedia` via `combine(selectedId, _selectedMediaById)`.
- Update `selectDownload` to init media for new ids.
- Add `setSelectedMedia(type, id)` and `setDefaultsForIds(ids)`.
- Replace old file path resolver with `getSelectedMediaFilePath`.
- Update `DownloadScreen` to use new media state and pass `item.id` to setters.