### PR TITLE
fix: Improve delete behavior and adjust download pager updates

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -1,6 +1,8 @@
 package org.strigate.ferrot.presentation.component
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DownloadDone
 import androidx.compose.material.icons.filled.Refresh
@@ -10,6 +12,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -55,23 +58,31 @@ fun DownloadPrimaryActionButton(
     }
     Surface(
         modifier = modifier
-            .size(dimens.iconXLarge),
+            .wrapContentSize(),
         shape = MaterialTheme.shapes.medium,
         tonalElevation = dimens.tonalElevationHigh,
     ) {
         with(actionConfig) {
-            IconButton(
-                onClick = onClick,
+            Box(
+                modifier = Modifier
+                    .size(dimens.iconXLarge),
             ) {
-                Icon(
-                    imageVector = icon,
-                    tint = if (usePrimaryTint) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                    contentDescription = contentDescription,
-                )
+                IconButton(
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .align(Alignment.Center),
+                    onClick = onClick,
+                ) {
+                    Icon(
+                        imageVector = icon,
+                        tint = if (usePrimaryTint) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        contentDescription = contentDescription,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -112,8 +112,11 @@ fun DownloadScreen(
             message = stringResource(R.string.confirm_dialog_delete_download_description),
             positiveButtonText = stringResource(R.string.yes),
             onPositiveClick = {
+                val isLastItem = (uiState as? DownloadUiState.Data)?.data?.downloads?.size == 1
                 viewModel.deleteDownload()
-                backDispatcher?.onBackPressed()
+                if (isLastItem) {
+                    backDispatcher?.onBackPressed()
+                }
                 showConfirmDeleteDialog.value = false
             },
             negativeButtonText = stringResource(R.string.no),
@@ -198,84 +201,86 @@ private fun DownloadPager(
     pageSpacing: Dp,
 ) {
     val dimens = LocalDimens.current
+    val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+
     val downloads = data.downloads
     if (downloads.isEmpty()) {
         DownloadError()
-        return
-    }
-    val initialIndex = downloads
-        .indexOfFirst { it.id == data.id }
-        .coerceAtLeast(0)
+    } else {
+        val initialIndex = downloads
+            .indexOfFirst { it.id == data.id }
+            .coerceAtLeast(0)
 
-    val pagerState = rememberPagerState(
-        initialPage = initialIndex,
-        pageCount = { downloads.size }
-    )
+        val pagerState = rememberPagerState(
+            initialPage = initialIndex,
+            pageCount = { downloads.size }
+        )
 
-    LaunchedEffect(downloads) {
-        viewModel.setDefaultsForIds(downloads.map { it.id })
-    }
-    LaunchedEffect(pagerState, downloads) {
-        snapshotFlow { pagerState.currentPage }
-            .map { pageIndex -> downloads.getOrNull(pageIndex)?.id }
-            .filterNotNull()
-            .distinctUntilChanged()
-            .collect { downloadId ->
-                viewModel.selectDownload(downloadId)
-                val currentDownload = downloads.firstOrNull { it.id == downloadId }
-                val isAudioAvailable = currentDownload?.audio?.filePath?.isNotBlank() == true
-                val isVideoAvailable = currentDownload?.video?.filePath?.isNotBlank() == true
-                val currentlySelectedMedia = viewModel.selectedMedia.value
-                val correctedMediaType = when {
-                    isAudioAvailable && currentlySelectedMedia == DownloadMediaType.AUDIO -> DownloadMediaType.AUDIO
-                    isVideoAvailable && currentlySelectedMedia == DownloadMediaType.VIDEO -> DownloadMediaType.VIDEO
-                    isAudioAvailable -> DownloadMediaType.AUDIO
-                    isVideoAvailable -> DownloadMediaType.VIDEO
-                    else -> DownloadMediaType.VIDEO
+        LaunchedEffect(downloads) {
+            viewModel.setDefaultsForIds(downloads.map { it.id })
+        }
+        LaunchedEffect(pagerState, downloads) {
+            snapshotFlow { pagerState.currentPage }
+                .map { pageIndex -> downloads.getOrNull(pageIndex)?.id }
+                .filterNotNull()
+                .distinctUntilChanged()
+                .collect { downloadId ->
+                    viewModel.selectDownload(downloadId)
+                    val currentDownload = downloads.firstOrNull { it.id == downloadId }
+                    val isAudioAvailable = currentDownload?.audio?.filePath?.isNotBlank() == true
+                    val isVideoAvailable = currentDownload?.video?.filePath?.isNotBlank() == true
+                    val currentlySelectedMedia = viewModel.selectedMedia.value
+                    val correctedMediaType = when {
+                        isAudioAvailable && currentlySelectedMedia == DownloadMediaType.AUDIO -> DownloadMediaType.AUDIO
+                        isVideoAvailable && currentlySelectedMedia == DownloadMediaType.VIDEO -> DownloadMediaType.VIDEO
+                        isAudioAvailable -> DownloadMediaType.AUDIO
+                        isVideoAvailable -> DownloadMediaType.VIDEO
+                        else -> DownloadMediaType.VIDEO
+                    }
+                    viewModel.setSelectedMedia(correctedMediaType, downloadId)
                 }
-                viewModel.setSelectedMedia(correctedMediaType, downloadId)
-            }
-    }
+        }
 
-    HorizontalPager(
-        modifier = modifier
-            .fillMaxSize(),
-        state = pagerState,
-        contentPadding = pagePadding,
-        pageSpacing = pageSpacing,
-    ) { page ->
-        val item = downloads[page]
-        Surface(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = dimens.spacingSmall),
-            shape = MaterialTheme.shapes.medium,
-            tonalElevation = dimens.tonalElevationLow,
-            shadowElevation = dimens.shadowElevationLow,
-        ) {
-            DownloadPageContent(
-                data = item,
-                selectedMedia = selectedMedia,
-                onMediaChange = { type ->
-                    viewModel.setSelectedMedia(type, item.id)
-                },
-                onEnsureValidSelection = { type ->
-                    viewModel.setSelectedMedia(type, item.id)
-                },
-                onPlayClick = {
-                    viewModel.playDownload(item.id)
-                },
-                onSaveClick = {
-                    viewModel.saveDownload(item.id)
-                },
-                onShareClick = {
-                    viewModel.shareDownload(item.id)
-                },
-                onRetryClick = {
-                    viewModel.selectDownload(item.id)
-                    viewModel.retryDownload(item.id)
-                },
-            )
+        HorizontalPager(
+            modifier = modifier
+                .fillMaxSize(),
+            state = pagerState,
+            contentPadding = pagePadding,
+            pageSpacing = pageSpacing,
+        ) { page ->
+            val download = downloads[page]
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = dimens.spacingSmall),
+                shape = MaterialTheme.shapes.medium,
+                tonalElevation = dimens.tonalElevationLow,
+                shadowElevation = dimens.shadowElevationLow,
+            ) {
+                DownloadPageContent(
+                    data = download,
+                    selectedMedia = selectedMedia,
+                    onMediaChange = { mediaType ->
+                        viewModel.setSelectedMedia(mediaType, download.id)
+                    },
+                    onEnsureValidSelection = { mediaType ->
+                        viewModel.setSelectedMedia(mediaType, download.id)
+                    },
+                    onPlayClick = {
+                        viewModel.playDownload(download.id)
+                    },
+                    onSaveClick = {
+                        viewModel.saveDownload(download.id)
+                    },
+                    onShareClick = {
+                        viewModel.shareDownload(download.id)
+                    },
+                    onRetryClick = {
+                        backDispatcher?.onBackPressed()
+                        viewModel.retryDownload(download.id)
+                    },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
- Add `isLastItem` check and only call `backDispatcher?.onBackPressed()` when the final download is removed
- Avoid early `return` and restructure pager initialization inside non-empty downloads block
- Introduce local `backDispatcher` inside `DownloadPager`
- Update pager page-handling logic to use `download` consistently instead of `item`
- Modify retry action to trigger `backDispatcher?.onBackPressed()` before calling `viewModel.retryDownload()`
- Update `DownloadPrimaryActionButton` to wrap content, add `Box` with fixed size, and center `IconButton` for consistent layout