### PR TITLE
chore: Update AGP version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.1"
+agp = "8.13.2"
 coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 startupRuntime = "1.2.0"


### PR DESCRIPTION
- Bump `agp` version from `8.13.1` to `8.13.2`