### PR TITLE
feat: Add app metadata to downloaded media

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
@@ -1,9 +1,6 @@
 package org.strigate.ferrot.domain.usecase.youtubedl_android
 
 import com.yausername.youtubedl_android.YoutubeDLRequest
-import org.strigate.ferrot.BuildConfig
-import org.strigate.ferrot.app.Constants.NAME
-import org.strigate.ferrot.app.Constants.NAME_INTERNAL
 import javax.inject.Inject
 
 class BuildAudioDownloadRequestUseCase @Inject constructor() {
@@ -20,14 +17,6 @@ class BuildAudioDownloadRequestUseCase @Inject constructor() {
             addOption("--extract-audio")
             addOption("--audio-format", "mp3")
             addOption("--audio-quality", "0")
-
-            val encoderString = "$NAME ${BuildConfig.VERSION_NAME}"
-            addOption("--add-metadata")
-            addOption(
-                "--postprocessor-args",
-                "ffmpeg:-metadata encoder=\"$encoderString\" -metadata $NAME_INTERNAL=true"
-            )
-
             addOption("--no-overwrites")
             addOption("--no-post-overwrites")
             if (noProgress) {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
@@ -1,6 +1,9 @@
 package org.strigate.ferrot.domain.usecase.youtubedl_android
 
 import com.yausername.youtubedl_android.YoutubeDLRequest
+import org.strigate.ferrot.BuildConfig
+import org.strigate.ferrot.app.Constants.NAME
+import org.strigate.ferrot.app.Constants.NAME_INTERNAL
 import javax.inject.Inject
 
 class BuildAudioDownloadRequestUseCase @Inject constructor() {
@@ -17,6 +20,14 @@ class BuildAudioDownloadRequestUseCase @Inject constructor() {
             addOption("--extract-audio")
             addOption("--audio-format", "mp3")
             addOption("--audio-quality", "0")
+
+            val encoderString = "$NAME ${BuildConfig.VERSION_NAME}"
+            addOption("--add-metadata")
+            addOption(
+                "--postprocessor-args",
+                "ffmpeg:-metadata encoder=\"$encoderString\" -metadata $NAME_INTERNAL=true"
+            )
+
             addOption("--no-overwrites")
             addOption("--no-post-overwrites")
             if (noProgress) {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
@@ -20,11 +20,17 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
             addOption("-o", template)
             addOption("--restrict-filenames")
 
-            val encoderString = "$NAME ${BuildConfig.VERSION_NAME}"
+            val encoderString = "$NAME ${BuildConfig.VERSION_TAG}"
             addOption("--add-metadata")
+            addOption("--embed-metadata")
             addOption(
                 "--postprocessor-args",
-                "ffmpeg:-metadata encoder=\"$encoderString\" -metadata $NAME_INTERNAL=true"
+                buildString {
+                    append("Merger+ffmpeg:")
+                    append("-metadata:s:v:0 encoder=\"$encoderString\" ")
+                    append("-metadata encoder=\"$encoderString\" ")
+                    append("-metadata $NAME_INTERNAL=true")
+                }
             )
 
             if (qualityProfile == QualityProfile.COMPAT_2160) {
@@ -40,11 +46,13 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
             } else {
                 addOption("--newline")
             }
+
             addOption("--external-downloader", "aria2c")
             addOption("--external-downloader-args", "aria2c:-x16 -k1M")
         }
     }
 }
+
 
 private fun formatSelectorFor(profile: QualityProfile): String = when (profile) {
     QualityProfile.MAX -> "bv*+ba/b"

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
@@ -1,6 +1,9 @@
 package org.strigate.ferrot.domain.usecase.youtubedl_android
 
 import com.yausername.youtubedl_android.YoutubeDLRequest
+import org.strigate.ferrot.BuildConfig
+import org.strigate.ferrot.app.Constants.NAME
+import org.strigate.ferrot.app.Constants.NAME_INTERNAL
 import org.strigate.ferrot.domain.model.QualityProfile
 import javax.inject.Inject
 
@@ -16,6 +19,14 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
             addOption("-f", formatSelectorFor(qualityProfile))
             addOption("-o", template)
             addOption("--restrict-filenames")
+
+            val encoderString = "$NAME ${BuildConfig.VERSION_NAME}"
+            addOption("--add-metadata")
+            addOption(
+                "--postprocessor-args",
+                "ffmpeg:-metadata encoder=\"$encoderString\" -metadata $NAME_INTERNAL=true"
+            )
+
             if (qualityProfile == QualityProfile.COMPAT_2160) {
                 addOption("--merge-output-format", "mp4")
             }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -76,7 +76,6 @@ class DownloadWorker(
 
         val downloadId = _downloadId
         val tag = "Download[$downloadId]:"
-
         Log.d(LOG_TAG, "$tag Starting work")
 
         if (runAttemptCount > 20 || downloadId <= 0L) {


### PR DESCRIPTION
- Add encoder metadata using `BuildConfig.VERSION_NAME` in `BuildVideoDownloadRequestUseCase`
- Add encoder metadata using `BuildConfig.VERSION_NAME` in `BuildAudioDownloadRequestUseCase`
- Inject app identifiers via `NAME` and `NAME_INTERNAL` for internal tagging
- Enable `--add-metadata` and custom ffmpeg postprocessor args