### PR TITLE
feat: Improve ffmpeg metadata authorship for video downloads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
         targetSdk = 36
         versionCode = 11
         versionName = buildVersionName(baseVersion, versionCode)
+        stringField("VERSION", baseVersion)
         stringField("VERSION_TAG", "v$baseVersion")
         applyFirebaseProperties()
         ndk {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
@@ -3,7 +3,6 @@ package org.strigate.ferrot.domain.usecase.youtubedl_android
 import com.yausername.youtubedl_android.YoutubeDLRequest
 import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.app.Constants.NAME
-import org.strigate.ferrot.app.Constants.NAME_INTERNAL
 import org.strigate.ferrot.domain.model.QualityProfile
 import javax.inject.Inject
 
@@ -20,16 +19,17 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
             addOption("-o", template)
             addOption("--restrict-filenames")
 
-            val encoderString = "$NAME ${BuildConfig.VERSION_TAG}"
+            val encoderString = "$NAME ${BuildConfig.VERSION}"
             addOption("--add-metadata")
-            addOption("--embed-metadata")
             addOption(
                 "--postprocessor-args",
                 buildString {
                     append("Merger+ffmpeg:")
-                    append("-metadata:s:v:0 encoder=\"$encoderString\" ")
                     append("-metadata encoder=\"$encoderString\" ")
-                    append("-metadata $NAME_INTERNAL=true")
+                    append("-metadata encoded_by=\"$encoderString\" ")
+                    append("-metadata:s:v:0 encoder=\"$encoderString\" ")
+                    append("-metadata:s:v:0 encoded_by=\"$encoderString\" ")
+                    append("-metadata:s:a:0 encoder=\"$encoderString\" ")
                 }
             )
 


### PR DESCRIPTION
- Update encoder string to use `BuildConfig.VERSION`
- Refine ffmpeg postprocessor metadata arguments for container, video, and audio streams
- Remove unused `NAME_INTERNAL` metadata flag
- Drop `--embed-metadata` to reduce conflicting mux behavior
- Expose app version via `BuildConfig.VERSION`