### PR TITLE
refactor: Simplify thumbnail image loading and update branding string

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
-import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import org.strigate.ferrot.R
@@ -86,11 +85,9 @@ fun DownloadPrimaryActionButton(
                 .size(dimens.iconXLarge),
             contentAlignment = Alignment.Center,
         ) {
-            if (thumbnailFile != null) {
-                val request = ImageRequest.Builder(context)
-                    .data(thumbnailFile)
-                    .memoryCachePolicy(CachePolicy.DISABLED)
-                    .diskCachePolicy(CachePolicy.DISABLED)
+            thumbnailFile?.let {
+                val imageRequest = ImageRequest.Builder(context)
+                    .data(it)
                     .crossfade(true)
                     .build()
 
@@ -98,8 +95,8 @@ fun DownloadPrimaryActionButton(
                     modifier = Modifier
                         .matchParentSize(),
                     contentScale = ContentScale.Crop,
+                    model = imageRequest,
                     contentDescription = null,
-                    model = request,
                 )
                 Box(
                     modifier = Modifier

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Ferrot</string>
-    <string name="copyright">© %1$d Michael Bentz / Strigate</string>
+    <string name="copyright">© Strigate %1$d</string>
     <string name="file_provider">fileprovider</string>
     <string name="settings_description_website">ferrot.org</string>
     <string name="url_website">https://ferrot.org/</string>


### PR DESCRIPTION
- Remove explicit `CachePolicy` usage from `DownloadPrimaryActionButton`
- Simplify `ImageRequest` construction for thumbnail loading
- Rename local variable from `request` to `imageRequest`
- Update `copyright` string