### PR TITLE
fix: Gate worker toasts behind foreground check

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -31,6 +31,8 @@ import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.provider.UpdatePathProvider
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.StateUseCase
+import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.util.isAppInForeground
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -136,6 +138,9 @@ class DownloadAvailableUpdateWorker(
             enableForeground(
                 notificationText = appContext.getString(R.string.worker_notification_text_downloading_app_update),
             )
+            if (isAppInForeground()) {
+                appContext.toast(R.string.toast_downloading_app_update, true)
+            }
 
             try {
                 downloadFile(downloadUrl, partFile)

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -19,6 +19,7 @@ import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.util.isAppInForeground
 import java.time.Duration.between
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -41,14 +42,20 @@ class UpdateDependenciesWorker(
             )
             Log.d(LOG_TAG, "YoutubeDL update completed: status=$updateStatus")
 
-            when (updateStatus) {
-                YoutubeDL.UpdateStatus.ALREADY_UP_TO_DATE ->
-                    appContext.toast(appContext.getString(R.string.toast_dependencies_already_up_to_date))
+            if (isAppInForeground()) {
+                when (updateStatus) {
+                    YoutubeDL.UpdateStatus.ALREADY_UP_TO_DATE -> {
+                        appContext.toast(appContext.getString(R.string.toast_dependencies_already_up_to_date))
+                    }
 
-                YoutubeDL.UpdateStatus.DONE ->
-                    appContext.toast(appContext.getString(R.string.toast_dependencies_update_complete))
+                    YoutubeDL.UpdateStatus.DONE -> {
+                        appContext.toast(appContext.getString(R.string.toast_dependencies_update_complete))
+                    }
 
-                else -> appContext.toast("$updateStatus")
+                    else -> {
+                        appContext.toast("$updateStatus")
+                    }
+                }
             }
             markCheckSuccess()
         } catch (throwable: Throwable) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
     <string name="toast_dependencies_update_complete">Dependencies update complete</string>
     <string name="toast_dependencies_already_up_to_date">Dependencies already up to date</string>
+    <string name="toast_downloading_app_update">Downloading app update</string>
 
     <string name="settings_section_general">General</string>
     <string name="settings_section_app_info">App info</string>


### PR DESCRIPTION
- Guard toast calls in `DownloadAvailableUpdateWorker` with `isAppInForeground`
- Guard toast calls in `UpdateDependenciesWorker` with `isAppInForeground`
- Add `toast_downloading_app_update` string resource