### PR TITLE
fix: Show up-to-date toast when no app update is available

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -78,6 +78,9 @@ class DownloadAvailableUpdateWorker(
                 return markCheckSuccess()
             }
             if (!isNewerVersion(latestTag, currentTag)) {
+                if (isAppInForeground()) {
+                    appContext.toast(R.string.toast_already_up_to_date, true)
+                }
                 Log.d(LOG_TAG, "Already up to date: latest=$latestTag current=$currentTag")
                 clearAvailableUpdate()
                 return markCheckSuccess()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="toast_dependencies_update_complete">Dependencies update complete</string>
     <string name="toast_dependencies_already_up_to_date">Dependencies already up to date</string>
     <string name="toast_downloading_app_update">Downloading app update</string>
+    <string name="toast_already_up_to_date">Already up to date</string>
 
     <string name="settings_section_general">General</string>
     <string name="settings_section_app_info">App info</string>


### PR DESCRIPTION
- Show toast when app is already up to date and app is in foreground
- Use `isAppInForeground` to avoid background spam
- Add `toast_already_up_to_date` string resource