### PR TITLE
refactor: Move wifi-only policy use case to combined package

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/ApplyWifiOnlyPolicyUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/ApplyWifiOnlyPolicyUseCase.kt
@@ -1,47 +1,55 @@
-package org.strigate.ferrot.domain.usecase.download
+package org.strigate.ferrot.domain.usecase.combined
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.strigate.ferrot.domain.model.DownloadStatus
-import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.download.DeleteDownloadFilesUseCase
+import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
+import org.strigate.ferrot.domain.usecase.download.UpdateDownloadErrorMessageUseCase
+import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusByIdUseCase
 import org.strigate.ferrot.util.NetworkOps
 import org.strigate.ferrot.work.DownloadWorker
 import javax.inject.Inject
 
 class ApplyWifiOnlyPolicyUseCase @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
-    private val downloadUseCase: DownloadUseCase,
+    private val getAllDownloadsUseCase: GetAllDownloadsUseCase,
+    private val updateDownloadErrorMessageUseCase: UpdateDownloadErrorMessageUseCase,
+    private val updateDownloadStatusByIdUseCase: UpdateDownloadStatusByIdUseCase,
+    private val deleteDownloadFilesUseCase: DeleteDownloadFilesUseCase,
 ) {
     suspend operator fun invoke(isWifiOnly: Boolean) = withContext(Dispatchers.IO) {
         val (_, isOnWifi) = NetworkOps.quickNetworkProbe(appContext)
-        val downloads = downloadUseCase.getAllDownloadsUseCase()
+        val downloads = getAllDownloadsUseCase()
 
         if (isWifiOnly) {
             if (!isOnWifi) {
-                val pushToWifiStatuses = setOf(
+                val downloadStatuses = setOf(
                     DownloadStatus.QUEUED,
                     DownloadStatus.WAITING_FOR_NETWORK,
                     DownloadStatus.PAUSED,
                     DownloadStatus.METADATA,
                     DownloadStatus.DOWNLOADING,
                 )
-                downloads.filter { it.status in pushToWifiStatuses }
+                downloads
+                    .filter {
+                        it.status in downloadStatuses
+                    }
                     .forEach { download ->
                         runCatching {
-                            downloadUseCase.updateDownloadErrorMessageUseCase(
-                                download.id,
-                                null,
+                            updateDownloadErrorMessageUseCase(download.id, null)
+                        }
+                        runCatching {
+                            updateDownloadStatusByIdUseCase(
+                                status = DownloadStatus.WAITING_FOR_WIFI,
+                                id = download.id,
                             )
                         }
                         runCatching {
-                            downloadUseCase.updateDownloadStatusByIdUseCase(
-                                download.id,
-                                DownloadStatus.WAITING_FOR_WIFI,
-                            )
+                            deleteDownloadFilesUseCase(download.id)
                         }
-                        runCatching { downloadUseCase.deleteDownloadFilesUseCase(download.id) }
                         DownloadWorker.enqueueOneTimeReplace(
                             context = appContext,
                             id = download.id,
@@ -50,18 +58,18 @@ class ApplyWifiOnlyPolicyUseCase @Inject constructor(
                     }
             }
         } else {
-            downloads.filter { it.status == DownloadStatus.WAITING_FOR_WIFI }
+            downloads
+                .filter {
+                    it.status == DownloadStatus.WAITING_FOR_WIFI
+                }
                 .forEach { download ->
                     runCatching {
-                        downloadUseCase.updateDownloadErrorMessageUseCase(
-                            download.id,
-                            null,
-                        )
+                        updateDownloadErrorMessageUseCase(download.id, null)
                     }
                     runCatching {
-                        downloadUseCase.updateDownloadStatusByIdUseCase(
-                            download.id,
-                            DownloadStatus.WAITING_FOR_NETWORK,
+                        updateDownloadStatusByIdUseCase(
+                            status = DownloadStatus.WAITING_FOR_NETWORK,
+                            id = download.id,
                         )
                     }
                     DownloadWorker.enqueueOneTimeReplace(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
-import org.strigate.ferrot.domain.usecase.download.ApplyWifiOnlyPolicyUseCase
+import org.strigate.ferrot.domain.usecase.combined.ApplyWifiOnlyPolicyUseCase
 import org.strigate.ferrot.presentation.model.SettingsUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import javax.inject.Inject


### PR DESCRIPTION
- Move `ApplyWifiOnlyPolicyUseCase` to `combined` package
- Replace `DownloadUseCase` with explicit download-related use cases
- Update `SettingsViewModel` import to new package