### PR TITLE
fix: Use white tint for primary action icon

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -120,7 +120,7 @@ fun DownloadPrimaryActionButton(
                             tint = if (usePrimaryTint) {
                                 MaterialTheme.colorScheme.primary
                             } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
+                                Color.White
                             },
                             contentDescription = contentDescription,
                         )


### PR DESCRIPTION
- Replace `MaterialTheme.colorScheme.onSurfaceVariant` with `Color.White` in `DownloadPrimaryActionButton`