### PR TITLE
feat: Improve download filenames and thumbnail handling

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
@@ -13,7 +13,7 @@ class BuildAudioDownloadRequestUseCase @Inject constructor() {
         return YoutubeDLRequest(url).apply {
             addOption("-f", "ba/b")
             addOption("-o", template)
-            addOption("--restrict-filenames")
+            addOption("--windows-filenames")
             addOption("--extract-audio")
             addOption("--audio-format", "mp3")
             addOption("--audio-quality", "0")

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
@@ -17,7 +17,7 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
         return YoutubeDLRequest(url).apply {
             addOption("-f", formatSelectorFor(qualityProfile))
             addOption("-o", template)
-            addOption("--restrict-filenames")
+            addOption("--windows-filenames")
 
             val encoderString = "$NAME ${BuildConfig.VERSION}"
             addOption("--add-metadata")

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadThumbnailUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadThumbnailUseCase.kt
@@ -32,6 +32,10 @@ class DownloadThumbnailUseCase @Inject constructor(
             .firstOrNull {
                 it.exists() && it.length() > 0
             }
-            ?.absolutePath
+            ?.let { sourceFile ->
+                val extension = sourceFile.extension
+                val destinationFile = File(outputDir, "thumb_${id}.$extension")
+                if (sourceFile.renameTo(destinationFile)) destinationFile.absolutePath else null
+            }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/helper/SaveHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/SaveHelper.kt
@@ -35,11 +35,7 @@ object SaveHelper {
             displayName = displayName,
         )
         if (existsInDownloads) {
-            val message = context.getString(
-                R.string.toast_already_saved,
-                displayName,
-                relativePathWithSlash,
-            )
+            val message = context.getString(R.string.toast_already_saved, relativePath)
             context.toast(message)
             return false
         }
@@ -65,10 +61,7 @@ object SaveHelper {
             }.also {
                 contentResolver.update(uri, it, null, null)
             }
-            val message = context.getString(
-                R.string.toast_saved_to,
-                "$relativePathWithSlash$displayName",
-            )
+            val message = context.getString(R.string.toast_saved_to, relativePath)
             context.toast(message)
             true
         } catch (throwable: Throwable) {

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -207,8 +207,8 @@ class DownloadWorker(
                     maxBytes = max(maxBytes, directoryBytesSum(uidDir))
                     maxBytes
                 }
-                val videoTemplate = "${uidDir.absolutePath}/%(id)s.V.%(ext)s"
-                val audioTemplate = "${uidDir.absolutePath}/%(id)s.A.%(ext)s"
+                val videoTemplate = "${uidDir.absolutePath}/%(title)s [%(id)s] - Video.%(ext)s"
+                val audioTemplate = "${uidDir.absolutePath}/%(title)s [%(id)s] - Audio.%(ext)s"
 
                 val phaseContext = PhaseContext(
                     phase = DownloadMediaType.VIDEO,
@@ -501,8 +501,14 @@ class DownloadWorker(
         extensions.map { File(dir, "$infoId.$it") }
             .firstOrNull { it.exists() && it.length() > 0L }
             ?.let { return it }
+
         return dir.listFiles()
-            ?.filter { it.isFile && it.name.startsWith("$infoId.") && it.length() > 0L }
+            ?.filter {
+                it.isFile && !it.name.startsWith("thumb_") && it.length() > 0L
+            }
+            ?.filter {
+                extensions.any { extension -> it.name.endsWith(".$extension") }
+            }
             ?.maxByOrNull { it.lastModified() }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="toast_checking_for_available_update">Checking for available update</string>
     <string name="toast_checking_for_dependency_updates">Checking for dependency updates</string>
     <string name="toast_saved_to">Saved to %1$s</string>
-    <string name="toast_already_saved">%1$s already saved in %2$s</string>
+    <string name="toast_already_saved">Already saved in %1$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
     <string name="toast_dependencies_update_complete">Dependencies update complete</string>
     <string name="toast_dependencies_already_up_to_date">Dependencies already up to date</string>


### PR DESCRIPTION
- Rename downloaded thumbnails to `thumb_<id>.<ext>` in `DownloadThumbnailUseCase`
- Replace `--restrict-filenames` with `--windows-filenames` in audio and video request builders
- Update video and audio output templates to include title, id, and media type
- Exclude thumbnail files when resolving downloaded media in `DownloadWorker`
- Prefer most recently modified valid media file when multiple matches exist