### PR TITLE
chore: Upgrade Kotlin to 2.3.0 and KSP to 2.3.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ firebaseBom = "34.7.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-kotlin = "2.2.21"
-ksp = "2.2.21-2.0.4"
+kotlin = "2.3.0"
+ksp = "2.3.4"
 
 [libraries]
 # Android


### PR DESCRIPTION
- Update `kotlin` version to `2.3.0`
- Update `ksp` version to `2.3.4`
- Align KSP with decoupled Kotlin versioning model