### PR TITLE
refactor: Rename DAO insert methods

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadAudioDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadAudioDao.kt
@@ -10,7 +10,7 @@ import org.strigate.ferrot.data.local.entity.DownloadAudioEntity
 @Dao
 interface DownloadAudioDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrReplace(entity: DownloadAudioEntity): Long
+    suspend fun insertReplace(entity: DownloadAudioEntity): Long
 
     @Query("SELECT * FROM download_audio WHERE downloadId = :downloadId LIMIT 1")
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadAudioEntity?>

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadVideoDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadVideoDao.kt
@@ -10,7 +10,7 @@ import org.strigate.ferrot.data.local.entity.DownloadVideoEntity
 @Dao
 interface DownloadVideoDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrReplace(entity: DownloadVideoEntity): Long
+    suspend fun insertReplace(entity: DownloadVideoEntity): Long
 
     @Query("SELECT * FROM download_video WHERE downloadId = :downloadId LIMIT 1")
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadVideoEntity?>

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImpl.kt
@@ -15,7 +15,7 @@ class DownloadAudioRepositoryImpl @Inject constructor(
     private val downloadAudioDao: DownloadAudioDao,
 ) : DownloadAudioRepository {
     override suspend fun save(downloadAudio: DownloadAudio): Long {
-        return downloadAudioDao.insertOrReplace(downloadAudio.toEntity())
+        return downloadAudioDao.insertReplace(downloadAudio.toEntity())
     }
 
     override fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadAudio?> {

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImpl.kt
@@ -15,7 +15,7 @@ class DownloadVideoRepositoryImpl @Inject constructor(
     private val downloadVideoDao: DownloadVideoDao,
 ) : DownloadVideoRepository {
     override suspend fun save(downloadVideo: DownloadVideo): Long {
-        return downloadVideoDao.insertOrReplace(downloadVideo.toEntity())
+        return downloadVideoDao.insertReplace(downloadVideo.toEntity())
     }
 
     override fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadVideo?> {


### PR DESCRIPTION
- Rename `insertOrReplace` to `insertReplace` in `DownloadAudioDao`
- Rename `insertOrReplace` to `insertReplace` in `DownloadVideoDao`
- Update `DownloadAudioRepositoryImpl` to call `insertReplace`
- Update `DownloadVideoRepositoryImpl` to call `insertReplace`