### PR TITLE
refactor: Support multiple lifecycle events in LifecycleEffect

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -367,10 +367,7 @@ private fun DownloadsList(
                 lastSnackId = null
             }
         }
-        on(Lifecycle.Event.ON_PAUSE) {
-            delete()
-        }
-        on(Lifecycle.Event.ON_STOP) {
+        on(Lifecycle.Event.ON_PAUSE, Lifecycle.Event.ON_STOP) {
             delete()
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/util/LifecycleEffect.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/util/LifecycleEffect.kt
@@ -8,13 +8,14 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @Composable
-fun LifecycleEffect(block: LifecycleObserverScope.() -> Unit) {
+fun LifecycleEffect(
+    block: LifecycleObserverScope.() -> Unit,
+) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val scope = remember { LifecycleObserverScope() }.apply(block)
-
+    val lifecycleObserverScope = remember { LifecycleObserverScope() }.apply(block)
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            scope.callbacks[event]?.invoke()
+            lifecycleObserverScope.callbacks[event]?.invoke()
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
@@ -26,7 +27,9 @@ fun LifecycleEffect(block: LifecycleObserverScope.() -> Unit) {
 class LifecycleObserverScope {
     internal val callbacks = mutableMapOf<Lifecycle.Event, () -> Unit>()
 
-    fun on(event: Lifecycle.Event, block: () -> Unit) {
-        callbacks[event] = block
+    fun on(vararg events: Lifecycle.Event, block: () -> Unit) {
+        events.forEach { event ->
+            callbacks[event] = block
+        }
     }
 }


### PR DESCRIPTION
- Update `LifecycleObserverScope.on` to accept vararg `Lifecycle.Event`
- Merge `ON_PAUSE` and `ON_STOP` handling in `DownloadsScreen`
- Rename `scope` to `lifecycleObserverScope` for clarity
- Remove duplicate lifecycle callbacks while preserving behavior