### PR TITLE
feat: Add UTF-8 safe filename truncation for downloads

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/extensions/String.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/extensions/String.kt
@@ -18,9 +18,27 @@ fun String.extractFileExtension(): String? {
         ?.uppercase(Locale.ROOT)
 }
 
+fun String.toSafeFileName(maxBytes: Int = 120): String {
+    val byteArray = toByteArray(Charsets.UTF_8)
+    if (byteArray.size <= maxBytes) {
+        return this
+    }
+    var count = 0
+    val stringBuilder = StringBuilder()
+    for (char in this) {
+        val size = char.toString().toByteArray(Charsets.UTF_8).size
+        if (count + size > maxBytes) {
+            break
+        }
+        count += size
+        stringBuilder.append(char)
+    }
+    return stringBuilder.toString().trim()
+}
+
 fun String.guessMimeType(): String {
-    val ext = substringAfterLast('.', "").lowercase()
-    return when (ext) {
+    val extension = substringAfterLast('.', "").lowercase()
+    return when (extension) {
         "mp4", "m4v", "mov", "webm" -> "video/*"
         "mp3", "m4a", "aac", "opus" -> "audio/*"
         "jpg", "jpeg", "png", "webp" -> "image/*"

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -45,6 +45,7 @@ import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.extensions.extractFileExtension
 import org.strigate.ferrot.extensions.parseErrorMessage
+import org.strigate.ferrot.extensions.toSafeFileName
 import org.strigate.ferrot.extensions.toast
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -207,8 +208,9 @@ class DownloadWorker(
                     maxBytes = max(maxBytes, directoryBytesSum(uidDir))
                     maxBytes
                 }
-                val videoTemplate = "${uidDir.absolutePath}/%(title)s [%(id)s] - Video.%(ext)s"
-                val audioTemplate = "${uidDir.absolutePath}/%(title)s [%(id)s] - Audio.%(ext)s"
+                val title = (videoInfo.title ?: "video").toSafeFileName()
+                val videoTemplate = "${uidDir.absolutePath}/${title} [%(id)s] - Video.%(ext)s"
+                val audioTemplate = "${uidDir.absolutePath}/${title} [%(id)s] - Audio.%(ext)s"
 
                 val phaseContext = PhaseContext(
                     phase = DownloadMediaType.VIDEO,


### PR DESCRIPTION
- Add `toSafeFileName` extension to truncate strings by UTF-8 byte size
- Apply safe filename handling to `videoInfo.title` in `DownloadWorker`
- Preserve placeholders like `%(id)s` and `%(ext)s` while avoiding filesystem limits