### PR TITLE
feat: Add SHA256 hash support for downloaded videos

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
@@ -23,6 +23,7 @@ import org.strigate.ferrot.data.local.migration.MIGRATION_2_3
 import org.strigate.ferrot.data.local.migration.MIGRATION_3_4
 import org.strigate.ferrot.data.local.migration.MIGRATION_4_5
 import org.strigate.ferrot.data.local.migration.MIGRATION_5_6
+import org.strigate.ferrot.data.local.migration.MIGRATION_6_7
 import org.strigate.ferrot.data.local.typeconverter.DownloadStatusTypeConverter
 import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
 
@@ -39,7 +40,7 @@ import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
         DownloadWithMetadataView::class,
     ],
     exportSchema = false,
-    version = 6,
+    version = 7,
 )
 @TypeConverters(
     DownloadStatusTypeConverter::class,
@@ -80,5 +81,6 @@ private fun <T : RoomDatabase> RoomDatabase.Builder<T>.applyMigrations(): RoomDa
         MIGRATION_3_4,
         MIGRATION_4_5,
         MIGRATION_5_6,
+        MIGRATION_6_7,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/entity/DownloadVideoEntity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/entity/DownloadVideoEntity.kt
@@ -17,6 +17,7 @@ import androidx.room.PrimaryKey
     ],
     indices = [
         Index(value = ["downloadId"], unique = true),
+        Index(value = ["sha256"]),
     ],
 )
 data class DownloadVideoEntity(
@@ -25,4 +26,5 @@ data class DownloadVideoEntity(
     val downloadId: Long,
     val filePath: String,
     val fileExtension: String,
+    val sha256: String?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/migration/Migration6To7.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/migration/Migration6To7.kt
@@ -1,0 +1,21 @@
+package org.strigate.ferrot.data.local.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            ALTER TABLE download_video
+            ADD COLUMN sha256 TEXT
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_download_video_sha256
+            ON download_video(sha256)
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadVideoMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadVideoMappers.kt
@@ -8,10 +8,12 @@ internal fun DownloadVideo.toEntity() = DownloadVideoEntity(
     downloadId = downloadId,
     filePath = filePath,
     fileExtension = fileExtension,
+    sha256 = sha256,
 )
 
 internal fun DownloadVideoEntity.toDomain() = DownloadVideo(
     downloadId = downloadId,
     filePath = filePath,
     fileExtension = fileExtension,
+    sha256 = sha256,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadVideo.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadVideo.kt
@@ -4,4 +4,5 @@ data class DownloadVideo(
     val downloadId: Long,
     val filePath: String,
     val fileExtension: String,
+    val sha256: String?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/util/HashUtil.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/HashUtil.kt
@@ -1,0 +1,24 @@
+package org.strigate.ferrot.util
+
+import java.io.File
+import java.io.FileInputStream
+import java.security.MessageDigest
+
+fun sha256(filePath: String): String? {
+    val file = File(filePath)
+    if (!file.exists() || !file.isFile) {
+        return null
+    }
+    val messageDigest = MessageDigest.getInstance("SHA-256")
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    FileInputStream(file).use { input ->
+        while (true) {
+            val read = input.read(buffer)
+            if (read <= 0) {
+                break
+            }
+            messageDigest.update(buffer, 0, read)
+        }
+    }
+    return messageDigest.digest().joinToString("") { "%02x".format(it) }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/util/Utils.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/Utils.kt
@@ -2,16 +2,7 @@ package org.strigate.ferrot.util
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.OneTimeWorkRequest
-import androidx.work.OutOfQuotaPolicy
 
 fun isAppInForeground(): Boolean {
     return ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
-}
-
-fun OneTimeWorkRequest.Builder.setExpeditedIfAllowed(): OneTimeWorkRequest.Builder {
-    if (isAtLeastS() && isAppInForeground()) {
-        setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-    }
-    return this
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -47,6 +47,7 @@ import org.strigate.ferrot.extensions.extractFileExtension
 import org.strigate.ferrot.extensions.parseErrorMessage
 import org.strigate.ferrot.extensions.toSafeFileName
 import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.util.sha256
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.cancellation.CancellationException
@@ -252,12 +253,18 @@ class DownloadWorker(
                     .extractFileExtension()
                     .orEmpty()
 
-                Log.d(LOG_TAG, "$tag Video output file exists, saving path")
+                Log.d(LOG_TAG, "$tag Video output file exists, calculating hash")
+                val sha256 = withContext(Dispatchers.IO) {
+                    sha256(videoOutputFilePath)
+                }
+
+                Log.d(LOG_TAG, "$tag Calculated video file hash, saving download video")
                 downloadVideoUseCase.saveDownloadVideoUseCase(
                     DownloadVideo(
                         downloadId = downloadId,
                         filePath = videoOutputFilePath,
                         fileExtension = videoOutputFileExtension,
+                        sha256 = sha256,
                     )
                 )
 


### PR DESCRIPTION
- Add nullable `sha256` column to `DownloadVideoEntity`
- Create index on `sha256` for efficient deduplication lookups
- Compute SHA256 hash for video files after download completion
- Persist SHA256 hash via `DownloadVideo` domain model
- Add `HashUtil` with streaming file-based SHA256 calculation
- Introduce `MIGRATION_6_7` to add column and index safely
- Bump database version to `7`
- Remove unused expedited WorkManager helper