### PR TITLE
feat: Deduplicate downloads by sha256 and clarify flow-based use cases

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -20,6 +20,7 @@ import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.domain.usecase.combined.GetPendingDownloadsCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
+import org.strigate.ferrot.work.DeleteDuplicateDownloadsWorker
 import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
 import org.strigate.ferrot.work.DownloadWorker
 import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
@@ -94,6 +95,15 @@ class WorkerFactory @Inject constructor(
                     workerParameters = workerParameters,
                     getPendingDownloadsCombinedUseCase = getPendingDownloadsCombinedUseCase,
                     startDownloadUseCase = startDownloadUseCase,
+                )
+            }
+
+            DeleteDuplicateDownloadsWorker::class.java.name -> {
+                DeleteDuplicateDownloadsWorker(
+                    appContext = appContext,
+                    workerParameters = workerParameters,
+                    downloadVideoUseCase = downloadVideoUseCase,
+                    deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
                 )
             }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadVideoDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadVideoDao.kt
@@ -15,6 +15,9 @@ interface DownloadVideoDao {
     @Query("SELECT * FROM download_video WHERE downloadId = :downloadId LIMIT 1")
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadVideoEntity?>
 
+    @Query("SELECT downloadId FROM download_video WHERE sha256 = :sha256")
+    suspend fun getDownloadIdsBySha256(sha256: String): List<Long>
+
     @Query("DELETE FROM download_video WHERE downloadId = :downloadId")
     suspend fun deleteByDownloadId(downloadId: Long): Int
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImpl.kt
@@ -19,7 +19,13 @@ class DownloadVideoRepositoryImpl @Inject constructor(
     }
 
     override fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadVideo?> {
-        return downloadVideoDao.getByDownloadIdAsFlow(downloadId).map { it?.toDomain() }
+        return downloadVideoDao
+            .getByDownloadIdAsFlow(downloadId)
+            .map { it?.toDomain() }
+    }
+
+    override suspend fun getDownloadIdsBySha256(sha256: String): List<Long> {
+        return downloadVideoDao.getDownloadIdsBySha256(sha256)
     }
 
     override suspend fun deleteByDownloadId(downloadId: Long): Int {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/repository/DownloadVideoRepository.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/repository/DownloadVideoRepository.kt
@@ -6,5 +6,6 @@ import org.strigate.ferrot.domain.model.DownloadVideo
 interface DownloadVideoRepository {
     suspend fun save(downloadVideo: DownloadVideo): Long
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadVideo?>
+    suspend fun getDownloadIdsBySha256(sha256: String): List<Long>
     suspend fun deleteByDownloadId(downloadId: Long): Int
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadAudioUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadAudioUseCase.kt
@@ -1,12 +1,12 @@
 package org.strigate.ferrot.domain.usecase
 
 import org.strigate.ferrot.domain.usecase.downloadaudio.DeleteDownloadAudioUseCase
-import org.strigate.ferrot.domain.usecase.downloadaudio.GetDownloadAudioAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.downloadaudio.GetDownloadAudioByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadaudio.SaveDownloadAudioUseCase
 import javax.inject.Inject
 
 class DownloadAudioUseCase @Inject constructor(
     val saveDownloadAudioUseCase: SaveDownloadAudioUseCase,
-    val getDownloadAudioAsFlowUseCase: GetDownloadAudioAsFlowUseCase,
+    val getDownloadAudioByDownloadIdAsFlowUseCase: GetDownloadAudioByDownloadIdAsFlowUseCase,
     val deleteDownloadAudioUseCase: DeleteDownloadAudioUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadVideoUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadVideoUseCase.kt
@@ -1,12 +1,14 @@
 package org.strigate.ferrot.domain.usecase
 
 import org.strigate.ferrot.domain.usecase.downloadvideo.DeleteDownloadVideoUseCase
-import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadVideoAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadIdsBySha256UseCase
+import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadVideoByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadvideo.SaveDownloadVideoUseCase
 import javax.inject.Inject
 
 class DownloadVideoUseCase @Inject constructor(
     val saveDownloadVideoUseCase: SaveDownloadVideoUseCase,
-    val getDownloadVideoAsFlowUseCase: GetDownloadVideoAsFlowUseCase,
+    val getDownloadVideoByDownloadIdAsFlowUseCase: GetDownloadVideoByDownloadIdAsFlowUseCase,
+    val getDownloadIdsBySha256UseCase: GetDownloadIdsBySha256UseCase,
     val deleteDownloadVideoUseCase: DeleteDownloadVideoUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadaudio/GetDownloadAudioByDownloadIdAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadaudio/GetDownloadAudioByDownloadIdAsFlowUseCase.kt
@@ -5,7 +5,7 @@ import org.strigate.ferrot.domain.model.DownloadAudio
 import org.strigate.ferrot.domain.repository.DownloadAudioRepository
 import javax.inject.Inject
 
-class GetDownloadAudioAsFlowUseCase @Inject constructor(
+class GetDownloadAudioByDownloadIdAsFlowUseCase @Inject constructor(
     private val downloadAudioRepository: DownloadAudioRepository,
 ) {
     operator fun invoke(downloadId: Long): Flow<DownloadAudio?> {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadvideo/GetDownloadIdsBySha256UseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadvideo/GetDownloadIdsBySha256UseCase.kt
@@ -1,0 +1,19 @@
+package org.strigate.ferrot.domain.usecase.downloadvideo
+
+import org.strigate.ferrot.domain.repository.DownloadVideoRepository
+import javax.inject.Inject
+
+class GetDownloadIdsBySha256UseCase @Inject constructor(
+    private val downloadVideoRepository: DownloadVideoRepository,
+) {
+    suspend operator fun invoke(sha256: String?): List<Long> {
+        if (sha256.isNullOrBlank()) {
+            return emptyList()
+        }
+        return runCatching {
+            downloadVideoRepository.getDownloadIdsBySha256(sha256)
+        }.getOrElse {
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadvideo/GetDownloadVideoByDownloadIdAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadvideo/GetDownloadVideoByDownloadIdAsFlowUseCase.kt
@@ -5,7 +5,7 @@ import org.strigate.ferrot.domain.model.DownloadVideo
 import org.strigate.ferrot.domain.repository.DownloadVideoRepository
 import javax.inject.Inject
 
-class GetDownloadVideoAsFlowUseCase @Inject constructor(
+class GetDownloadVideoByDownloadIdAsFlowUseCase @Inject constructor(
     private val downloadVideoRepository: DownloadVideoRepository,
 ) {
     operator fun invoke(downloadId: Long): Flow<DownloadVideo?> {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadwithmetadata/GetDownloadIdsWithMetadataAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadwithmetadata/GetDownloadIdsWithMetadataAsFlowUseCase.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import org.strigate.ferrot.data.local.dao.DownloadWithMetadataViewDao
 import javax.inject.Inject
 
-class GetDownloadIdsWithMetadataUseCase @Inject constructor(
+class GetDownloadIdsWithMetadataAsFlowUseCase @Inject constructor(
     private val downloadWithMetadataViewDao: DownloadWithMetadataViewDao,
 ) {
     operator fun invoke(): Flow<List<Long>> {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadwithmetadata/GetDownloadsWithMetadataAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadwithmetadata/GetDownloadsWithMetadataAsFlowUseCase.kt
@@ -5,7 +5,7 @@ import org.strigate.ferrot.domain.model.DownloadWithMetadata
 import org.strigate.ferrot.domain.repository.DownloadWithMetadataRepository
 import javax.inject.Inject
 
-class GetDownloadsWithMetadataUseCase @Inject constructor(
+class GetDownloadsWithMetadataAsFlowUseCase @Inject constructor(
     private val downloadWithMetadataRepository: DownloadWithMetadataRepository,
 ) {
     operator fun invoke(): Flow<List<DownloadWithMetadata>> {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -28,7 +28,7 @@ import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
-import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadIdsWithMetadataUseCase
+import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadIdsWithMetadataAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.helper.PlayHelper
 import org.strigate.ferrot.helper.SaveHelper
@@ -51,7 +51,7 @@ class DownloadViewModel @Inject constructor(
     private val downloadAudioUseCase: DownloadAudioUseCase,
     private val downloadProgressUseCase: DownloadProgressUseCase,
     private val downloadMetadataUseCase: DownloadMetadataUseCase,
-    private val getDownloadIdsWithMetadataUseCase: GetDownloadIdsWithMetadataUseCase,
+    private val getDownloadIdsWithMetadataAsFlowUseCase: GetDownloadIdsWithMetadataAsFlowUseCase,
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
     private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
@@ -86,7 +86,7 @@ class DownloadViewModel @Inject constructor(
     }
 
     private fun getUiState(id: Long = initialId) =
-        getDownloadIdsWithMetadataUseCase()
+        getDownloadIdsWithMetadataAsFlowUseCase()
             .flatMapLatest { ids ->
                 if (ids.isEmpty()) {
                     flowOf(
@@ -102,9 +102,9 @@ class DownloadViewModel @Inject constructor(
                         val downloadFlow = downloadUseCase
                             .getDownloadByIdAsFlowUseCase(downloadId)
                         val videoFlow = downloadVideoUseCase
-                            .getDownloadVideoAsFlowUseCase(downloadId)
+                            .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
                         val audioFlow = downloadAudioUseCase
-                            .getDownloadAudioAsFlowUseCase(downloadId)
+                            .getDownloadAudioByDownloadIdAsFlowUseCase(downloadId)
                         val metadataFlow = downloadMetadataUseCase
                             .getDownloadMetadataByIdAsFlowUseCase(downloadId)
                         val progressFlow = downloadProgressUseCase

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -20,7 +20,7 @@ import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
-import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataUseCase
+import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
@@ -32,12 +32,12 @@ import javax.inject.Inject
 class DownloadsViewModel @Inject constructor(
     private val analyticsLogger: AnalyticsLogger,
     private val downloadUseCase: DownloadUseCase,
-    private val downloadProgressUseCase: DownloadProgressUseCase,
-    private val getDownloadsWithMetadata: GetDownloadsWithMetadataUseCase,
     private val stopDownloadsUseCase: StopDownloadUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
-    private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
     private val availableUpdateUseCase: AvailableUpdateUseCase,
+    private val downloadProgressUseCase: DownloadProgressUseCase,
+    private val getDownloadsWithMetadataAsFlowUseCase: GetDownloadsWithMetadataAsFlowUseCase,
+    private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
 ) : ViewModel() {
     val uiState: StateFlow<DownloadsUiState> = getUiState().stateIn(
         scope = viewModelScope,
@@ -46,7 +46,7 @@ class DownloadsViewModel @Inject constructor(
     )
 
     private fun getUiState(): Flow<DownloadsUiState> {
-        val downloadsFlow = getDownloadsWithMetadata()
+        val downloadsFlow = getDownloadsWithMetadataAsFlowUseCase()
             .map { aggregates -> aggregates.map { it.toUiData() } }
 
         val availableUpdateFlow = availableUpdateUseCase.getAvailableUpdateAsFlowUseCase()

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeleteDuplicateDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeleteDuplicateDownloadsWorker.kt
@@ -1,0 +1,81 @@
+package org.strigate.ferrot.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
+import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
+
+class DeleteDuplicateDownloadsWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters,
+    private val downloadVideoUseCase: DownloadVideoUseCase,
+    private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
+) : CoroutineWorker(appContext, workerParameters) {
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val downloadId = inputData.getLong(KEY_ID, -1L)
+        if (downloadId <= 0L) {
+            Log.w(LOG_TAG, "Invalid downloadId")
+            return@withContext Result.success()
+        }
+
+        val downloadVideo = downloadVideoUseCase
+            .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
+            .first()
+
+        val sha256 = downloadVideo?.sha256
+        if (sha256.isNullOrBlank()) {
+            Log.d(LOG_TAG, "No hash for downloadId=$downloadId, skipping")
+            return@withContext Result.success()
+        }
+
+        val duplicateDownloadIds = downloadVideoUseCase
+            .getDownloadIdsBySha256UseCase(sha256)
+            .filter { it != downloadId }
+
+        if (duplicateDownloadIds.isEmpty()) {
+            Log.d(LOG_TAG, "No duplicates found for downloadId=$downloadId")
+            return@withContext Result.success()
+        }
+
+        val msg = "Deleting ${duplicateDownloadIds.size} duplicate(s) for downloadId=$downloadId"
+        Log.d(LOG_TAG, msg)
+
+        duplicateDownloadIds.forEach { duplicateDownloadId ->
+            runCatching {
+                deleteDownloadAndRelatedCombinedUseCase(duplicateDownloadId)
+            }.onFailure {
+                Log.w(LOG_TAG, "Failed while deleting downloadId=$duplicateDownloadId", it)
+            }
+        }
+        Result.success()
+    }
+
+    companion object {
+        fun enqueueOneTimeReplace(context: Context, downloadId: Long, sha256: String) {
+            val inputData = Data.Builder()
+                .putLong(KEY_ID, downloadId)
+                .build()
+
+            val oneTimeWorkRequest = OneTimeWorkRequestBuilder<DeleteDuplicateDownloadsWorker>()
+                .setInputData(inputData)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "dedupe-${sha256}",
+                ExistingWorkPolicy.REPLACE,
+                oneTimeWorkRequest,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -338,6 +338,14 @@ class DownloadWorker(
                 )
                 analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_COMPLETED)
 
+                sha256?.let {
+                    DeleteDuplicateDownloadsWorker.enqueueOneTimeReplace(
+                        context = appContext,
+                        downloadId = downloadId,
+                        sha256 = sha256,
+                    )
+                }
+
                 val downloadComplete = appContext.getString(R.string.download_complete)
                 val contentText = videoTitle ?: download.url
 


### PR DESCRIPTION
- Add `DeleteDuplicateDownloadsWorker` to remove duplicate downloads sharing the same `sha256`
- Enqueue deduplication work after download completion in `DownloadWorker`
- Introduce `GetDownloadIdsBySha256UseCase` and repository support for hash-based lookup
- Rename flow-returning use cases to explicit `*AsFlowUseCase` variants
- Rename video and audio download flow use cases to include `ByDownloadId`
- Update `DownloadVideoRepository` and DAO with `getDownloadIdsBySha256`
- Wire new worker into `WorkerFactory`
- Update view models to use renamed flow-based use cases