### PR TITLE
feat: Deduplicate downloads using metadata source and videoId

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
@@ -24,6 +24,7 @@ import org.strigate.ferrot.data.local.migration.MIGRATION_3_4
 import org.strigate.ferrot.data.local.migration.MIGRATION_4_5
 import org.strigate.ferrot.data.local.migration.MIGRATION_5_6
 import org.strigate.ferrot.data.local.migration.MIGRATION_6_7
+import org.strigate.ferrot.data.local.migration.MIGRATION_7_8
 import org.strigate.ferrot.data.local.typeconverter.DownloadStatusTypeConverter
 import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
 
@@ -40,7 +41,7 @@ import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
         DownloadWithMetadataView::class,
     ],
     exportSchema = false,
-    version = 7,
+    version = 8,
 )
 @TypeConverters(
     DownloadStatusTypeConverter::class,
@@ -82,5 +83,6 @@ private fun <T : RoomDatabase> RoomDatabase.Builder<T>.applyMigrations(): RoomDa
         MIGRATION_4_5,
         MIGRATION_5_6,
         MIGRATION_6_7,
+        MIGRATION_7_8,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -115,6 +115,7 @@ class WorkerFactory @Inject constructor(
                     appContext = appContext,
                     workerParameters = workerParameters,
                     downloadUseCase = downloadUseCase,
+                    downloadMetadataUseCase = downloadMetadataUseCase,
                     downloadVideoUseCase = downloadVideoUseCase,
                     deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
                 )

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadMetadataDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadMetadataDao.kt
@@ -15,6 +15,9 @@ interface DownloadMetadataDao {
     @Query("SELECT * FROM download_metadata WHERE downloadId = :downloadId")
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadMetadataEntity?>
 
+    @Query("SELECT downloadId FROM download_metadata WHERE source = :source AND videoId = :videoId")
+    suspend fun getDownloadIdsBySourceAndVideoId(source: String, videoId: String): List<Long>
+
     @Query("DELETE FROM download_metadata WHERE downloadId = :downloadId")
     suspend fun deleteByDownloadId(downloadId: Long): Int
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/entity/DownloadMetadataEntity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/entity/DownloadMetadataEntity.kt
@@ -17,10 +17,13 @@ import androidx.room.Index
     ],
     indices = [
         Index(value = ["downloadId"], unique = true),
+        Index(value = ["source", "videoId"]),
     ],
 )
 data class DownloadMetadataEntity(
     val downloadId: Long,
+    val videoId: String? = null,
+    val source: String? = null,
     val title: String? = null,
     val thumbnailFilePath: String? = null,
     val durationSeconds: Int? = null,

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/migration/Migration7To8.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/migration/Migration7To8.kt
@@ -1,0 +1,37 @@
+package org.strigate.ferrot.data.local.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            ALTER TABLE download_metadata
+            ADD COLUMN videoId TEXT
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE download_metadata
+            ADD COLUMN source TEXT
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            DROP INDEX IF EXISTS index_download_metadata_videoId
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            DROP INDEX IF EXISTS index_download_metadata_source_videoId
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            CREATE INDEX IF NOT EXISTS index_download_metadata_source_videoId
+            ON download_metadata(source, videoId)
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadMetadataMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadMetadataMappers.kt
@@ -5,6 +5,8 @@ import org.strigate.ferrot.domain.model.DownloadMetadata
 
 internal fun DownloadMetadataEntity.toDomain() = DownloadMetadata(
     downloadId = downloadId,
+    videoId = videoId,
+    source = source,
     title = title,
     thumbnailFilePath = thumbnailFilePath,
     durationSeconds = durationSeconds,
@@ -12,6 +14,8 @@ internal fun DownloadMetadataEntity.toDomain() = DownloadMetadata(
 
 internal fun DownloadMetadata.toEntity() = DownloadMetadataEntity(
     downloadId = downloadId,
+    videoId = videoId,
+    source = source,
     title = title,
     thumbnailFilePath = thumbnailFilePath,
     durationSeconds = durationSeconds,

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImpl.kt
@@ -14,11 +14,10 @@ import javax.inject.Singleton
 class AvailableUpdateRepositoryImpl @Inject constructor(
     private val availableUpdateDao: AvailableUpdateDao,
 ) : AvailableUpdateRepository {
-
     override fun getAsFlow(): Flow<AvailableUpdate?> {
         return availableUpdateDao
             .get()
-            .map { entity -> entity?.toDomain() }
+            .map { it?.toDomain() }
     }
 
     override suspend fun save(update: AvailableUpdate) {

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImpl.kt
@@ -19,7 +19,9 @@ class DownloadAudioRepositoryImpl @Inject constructor(
     }
 
     override fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadAudio?> {
-        return downloadAudioDao.getByDownloadIdAsFlow(downloadId).map { it?.toDomain() }
+        return downloadAudioDao
+            .getByDownloadIdAsFlow(downloadId)
+            .map { it?.toDomain() }
     }
 
     override suspend fun deleteByDownloadId(downloadId: Long): Int {

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImpl.kt
@@ -21,7 +21,17 @@ class DownloadMetadataRepositoryImpl @Inject constructor(
     override fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadMetadata?> {
         return downloadMetadataDao
             .getByDownloadIdAsFlow(downloadId)
-            .map { entity -> entity?.toDomain() }
+            .map { it?.toDomain() }
+    }
+
+    override suspend fun getDownloadIdsBySourceAndVideoId(
+        source: String,
+        videoId: String,
+    ): List<Long> {
+        return downloadMetadataDao.getDownloadIdsBySourceAndVideoId(
+            source = source,
+            videoId = videoId,
+        )
     }
 
     override suspend fun deleteByDownloadId(downloadId: Long): Int {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadMetadata.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadMetadata.kt
@@ -2,6 +2,8 @@ package org.strigate.ferrot.domain.model
 
 data class DownloadMetadata(
     val downloadId: Long,
+    val videoId: String?,
+    val source: String?,
     val title: String?,
     val thumbnailFilePath: String?,
     val durationSeconds: Int?,

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/repository/DownloadMetadataRepository.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/repository/DownloadMetadataRepository.kt
@@ -6,5 +6,6 @@ import org.strigate.ferrot.domain.model.DownloadMetadata
 interface DownloadMetadataRepository {
     suspend fun save(downloadMetadata: DownloadMetadata): Long
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadMetadata?>
+    suspend fun getDownloadIdsBySourceAndVideoId(source: String, videoId: String): List<Long>
     suspend fun deleteByDownloadId(downloadId: Long): Int
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadMetadataUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadMetadataUseCase.kt
@@ -1,6 +1,7 @@
 package org.strigate.ferrot.domain.usecase
 
 import org.strigate.ferrot.domain.usecase.downloadmetadata.DeleteDownloadMetadataByDownloadIdUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadIdsBySourceAndVideoIdUseCase
 import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadMetadataByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadmetadata.SaveDownloadMetadataUseCase
 import javax.inject.Inject
@@ -8,5 +9,6 @@ import javax.inject.Inject
 class DownloadMetadataUseCase @Inject constructor(
     val saveDownloadMetadataUseCase: SaveDownloadMetadataUseCase,
     val getDownloadMetadataByIdAsFlowUseCase: GetDownloadMetadataByIdAsFlowUseCase,
+    val getDownloadIdsBySourceAndVideoIdUseCase: GetDownloadIdsBySourceAndVideoIdUseCase,
     val deleteDownloadMetadataByDownloadIdUseCase: DeleteDownloadMetadataByDownloadIdUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadmetadata/GetDownloadIdsBySourceAndVideoIdUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadmetadata/GetDownloadIdsBySourceAndVideoIdUseCase.kt
@@ -1,0 +1,15 @@
+package org.strigate.ferrot.domain.usecase.downloadmetadata
+
+import org.strigate.ferrot.domain.repository.DownloadMetadataRepository
+import javax.inject.Inject
+
+class GetDownloadIdsBySourceAndVideoIdUseCase @Inject constructor(
+    private val downloadMetadataRepository: DownloadMetadataRepository,
+) {
+    suspend operator fun invoke(source: String, videoId: String): List<Long> {
+        return downloadMetadataRepository.getDownloadIdsBySourceAndVideoId(
+            source = source,
+            videoId = videoId,
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeleteAllDuplicateDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeleteAllDuplicateDownloadsWorker.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.withContext
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_CLEANUP_DUPLICATE_DOWNLOADS
 import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_CLEANUP_DUPLICATE_DOWNLOADS
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
@@ -30,6 +32,7 @@ class DeleteAllDuplicateDownloadsWorker(
     appContext: Context,
     workerParameters: WorkerParameters,
     private val downloadUseCase: DownloadUseCase,
+    private val downloadMetadataUseCase: DownloadMetadataUseCase,
     private val downloadVideoUseCase: DownloadVideoUseCase,
     private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
 ) : CoroutineWorker(appContext, workerParameters) {
@@ -37,33 +40,66 @@ class DeleteAllDuplicateDownloadsWorker(
         Log.d(LOG_TAG, "Starting scan for duplicate downloads")
 
         val downloads = runCatching {
-            downloadUseCase.getAllDownloadsUseCase()
+            downloadUseCase
+                .getAllDownloadsUseCase()
+                .filter {
+                    it.status == DownloadStatus.COMPLETED
+                }
+
         }.getOrElse {
-            Log.w(LOG_TAG, "Failed to load all downloads", it)
+            Log.w(LOG_TAG, "Failed to load downloads", it)
             return@withContext Result.failure()
         }
+
         downloads.forEach { download ->
-            val downloadId = download.id
+            val downloadMetadata = downloadMetadataUseCase
+                .getDownloadMetadataByIdAsFlowUseCase(download.id)
+                .first() ?: return@forEach
+
+            val source = downloadMetadata.source ?: return@forEach
+            val videoId = downloadMetadata.videoId ?: return@forEach
+            val duplicateDownloadIds = downloadMetadataUseCase
+                .getDownloadIdsBySourceAndVideoIdUseCase(
+                    source = source,
+                    videoId = videoId,
+                )
+            if (duplicateDownloadIds.size <= 1) {
+                return@forEach
+            }
+            val keepDownloadId = duplicateDownloadIds.maxOrNull() ?: return@forEach
+            duplicateDownloadIds
+                .filter { it != keepDownloadId }
+                .forEach { deleteId ->
+                    runCatching {
+                        deleteDownloadAndRelatedCombinedUseCase(deleteId)
+                        val message = "Deleted duplicate downloadId=$deleteId for $source:$videoId"
+                        Log.d(LOG_TAG, message)
+                    }.onFailure {
+                        Log.w(LOG_TAG, "Failed deleting identity duplicate $deleteId", it)
+                    }
+                }
+        }
+
+        downloads.forEach { download ->
             val downloadVideo = downloadVideoUseCase
-                .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
+                .getDownloadVideoByDownloadIdAsFlowUseCase(download.id)
                 .first() ?: return@forEach
 
             val sha256 = downloadVideo.sha256 ?: return@forEach
-            val duplicateDownloadIds = downloadVideoUseCase
-                .getDownloadIdsBySha256UseCase(sha256)
-
-            if (duplicateDownloadIds.size <= 1) return@forEach
-            val latestDownloadId = duplicateDownloadIds.maxOrNull() ?: return@forEach
-
+            val duplicateDownloadIds = downloadVideoUseCase.getDownloadIdsBySha256UseCase(sha256)
+            if (duplicateDownloadIds.size <= 1) {
+                return@forEach
+            }
+            val keepDownloadId = duplicateDownloadIds.maxOrNull() ?: return@forEach
             duplicateDownloadIds
-                .filter { it != latestDownloadId }
-                .forEach { olderDownloadId ->
+                .filter { it != keepDownloadId }
+                .forEach { deleteId ->
                     runCatching {
-                        deleteDownloadAndRelatedCombinedUseCase(olderDownloadId)
-                        val msg = "Deleted duplicate downloadId=$olderDownloadId for sha256=$sha256"
-                        Log.d(LOG_TAG, msg)
+                        deleteDownloadAndRelatedCombinedUseCase(deleteId)
+                        val message = "Deleted duplicate downloadId=$deleteId for sha256=$sha256"
+                        Log.d(LOG_TAG, message)
                     }.onFailure {
-                        Log.w(LOG_TAG, "Failed deleting downloadId=$olderDownloadId", it)
+                        Log.w(LOG_TAG, "Failed deleting sha256 duplicate $deleteId", it)
                     }
                 }
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -187,6 +187,8 @@ class DownloadWorker(
                             downloadMetadataUseCase.saveDownloadMetadataUseCase(
                                 DownloadMetadata(
                                     downloadId = downloadId,
+                                    videoId = videoInfo.id,
+                                    source = videoInfo.extractorKey?.lowercase(),
                                     title = videoInfo.title,
                                     thumbnailFilePath = thumbnailFilePath,
                                     durationSeconds = videoInfo.duration.takeIf { it > 0 },


### PR DESCRIPTION
- Add `videoId` and `source` to `DownloadMetadata`
- Persist `videoId` and `source` during download creation
- Add index on `download_metadata(source, videoId)`
- Introduce `GetDownloadIdsBySourceAndVideoIdUseCase`
- Extend `DownloadMetadataRepository` to query duplicates by source and videoId
- Update `DeleteAllDuplicateDownloadsWorker` to remove completed duplicates using metadata and sha256
- Inject `DownloadMetadataUseCase` into worker factory
- Bump database version to 8 and add `MIGRATION_7_8`
- Minor repository flow mapping cleanup