### PR TITLE
fix: Make audio download failure non-fatal and restore auto-scroll on…

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -403,19 +403,11 @@ private fun DownloadsList(
         }
     }
     LaunchedEffect(items.map { it.id to it.status }) {
-        val running = items.any {
-            when (it.status) {
-                DownloadStatusUiData.QUEUED,
-                DownloadStatusUiData.WAITING_FOR_WIFI,
-                DownloadStatusUiData.METADATA,
-                DownloadStatusUiData.DOWNLOADING -> true
-
-                else -> false
-            }
-        }
-        if (running) {
+        if (items.any { it.status == DownloadStatusUiData.QUEUED }) {
             runCatching {
-                lazyListState.animateScrollToItem(0)
+                coroutineScope.launch {
+                    lazyListState.animateScrollToItem(0)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -253,9 +253,13 @@ class DownloadWorker(
                         template = videoTemplate,
                         qualityProfile = qualityProfile,
                         bytesProviderRaw = bytesProviderRaw,
-                        phaseContext = phaseContext.copy(phase = DownloadMediaType.VIDEO),
+                        phaseContext = phaseContext.copy(
+                            phase = DownloadMediaType.VIDEO,
+                        ),
                         initialVideoPercent = 0f,
-                        onCanceled = { wasDownloadDeleted = true },
+                        onCanceled = {
+                            wasDownloadDeleted = true
+                        },
                         onCombined = {},
                     )
                 }
@@ -309,20 +313,29 @@ class DownloadWorker(
                 }
 
                 Log.d(LOG_TAG, "$tag Downloading audio")
-                withContext(Dispatchers.IO) {
-                    collectPhase(
-                        processId = audioProcessId,
-                        url = download.url,
-                        template = audioTemplate,
-                        qualityProfile = qualityProfile,
-                        bytesProviderRaw = bytesProviderRaw,
-                        phaseContext = phaseContext.copy(phase = DownloadMediaType.AUDIO),
-                        initialVideoPercent = 100f,
-                        onCanceled = { wasDownloadDeleted = true },
-                        onCombined = {},
-                    )
+                try {
+                    withContext(Dispatchers.IO) {
+                        collectPhase(
+                            processId = audioProcessId,
+                            url = download.url,
+                            template = audioTemplate,
+                            qualityProfile = qualityProfile,
+                            bytesProviderRaw = bytesProviderRaw,
+                            phaseContext = phaseContext.copy(
+                                phase = DownloadMediaType.AUDIO,
+                            ),
+                            initialVideoPercent = 100f,
+                            onCanceled = {
+                                wasDownloadDeleted = true
+                            },
+                            onCombined = {},
+                        )
+                    }
+                    Log.d(LOG_TAG, "$tag Downloaded audio")
+                } catch (throwable: Throwable) {
+                    val message = "$tag Audio download failed, continuing with video-only"
+                    Log.w(LOG_TAG, message, throwable)
                 }
-                Log.d(LOG_TAG, "$tag Downloaded audio")
 
                 val audioOutputFile = locateOutputFileByInfoId(
                     dir = uidDir,


### PR DESCRIPTION
… queue

- Wrap audio `collectPhase` in `try/catch` to allow video-only downloads on failure
- Log audio download failures without aborting the worker
- Format `phaseContext.copy` calls consistently
- Simplify running-state detection to only react to `DownloadStatusUiData.QUEUED`
- Move `animateScrollToItem(0)` into a launched coroutine