### PR TITLE
refactor: Move download side effects out of ViewModels

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadUseCase.kt
@@ -5,6 +5,7 @@ import org.strigate.ferrot.domain.usecase.download.DeleteDownloadFilesUseCase
 import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
+import org.strigate.ferrot.domain.usecase.download.RequestDeleteDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.SaveDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadCompletedAtUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadErrorMessageUseCase
@@ -23,6 +24,7 @@ class DownloadUseCase @Inject constructor(
     val updateDownloadSeenByIdUseCase: UpdateDownloadSeenByIdUseCase,
     val updateDownloadStartedAtUseCase: UpdateDownloadStartedAtUseCase,
     val updateDownloadStatusByIdUseCase: UpdateDownloadStatusByIdUseCase,
+    val requestDeleteDownloadsUseCase: RequestDeleteDownloadsUseCase,
     val deleteDownloadByIdUseCase: DeleteDownloadByIdUseCase,
     val deleteDownloadFilesUseCase: DeleteDownloadFilesUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadWithMetadataUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadWithMetadataUseCase.kt
@@ -1,0 +1,10 @@
+package org.strigate.ferrot.domain.usecase
+
+import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadIdsWithMetadataAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
+import javax.inject.Inject
+
+class DownloadWithMetadataUseCase @Inject constructor(
+    val getDownloadIdsWithMetadataAsFlowUseCase: GetDownloadIdsWithMetadataAsFlowUseCase,
+    val getDownloadsWithMetadataAsFlowUseCase: GetDownloadsWithMetadataAsFlowUseCase,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeleteDownloadsUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeleteDownloadsUseCase.kt
@@ -1,0 +1,20 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.strigate.ferrot.work.DeleteDownloadsWorker
+import javax.inject.Inject
+
+class RequestDeleteDownloadsUseCase @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
+) {
+    operator fun invoke(downloadIds: Collection<Long>) {
+        if (downloadIds.isEmpty()) {
+            return
+        }
+        DeleteDownloadsWorker.enqueueOneTimeAppend(
+            downloadIds = downloadIds,
+            context = appContext,
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/event/DownloadEvent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/event/DownloadEvent.kt
@@ -1,0 +1,8 @@
+package org.strigate.ferrot.presentation.event
+
+sealed interface DownloadEvent {
+    data object NavigateBack : DownloadEvent
+    data class Play(val path: String) : DownloadEvent
+    data class Share(val path: String) : DownloadEvent
+    data class Save(val path: String) : DownloadEvent
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -76,11 +76,15 @@ import kotlinx.coroutines.flow.map
 import org.strigate.ferrot.R
 import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.extensions.copyToClipboard
+import org.strigate.ferrot.helper.PlayHelper
+import org.strigate.ferrot.helper.SaveHelper
+import org.strigate.ferrot.helper.ShareHelper
 import org.strigate.ferrot.presentation.component.ActionIconButton
 import org.strigate.ferrot.presentation.component.ConfirmDialog
 import org.strigate.ferrot.presentation.component.DownloadProgressSection
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
+import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
@@ -96,6 +100,7 @@ fun DownloadScreen(
     modifier: Modifier = Modifier,
     viewModel: DownloadViewModel = hiltViewModel(),
 ) {
+    val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -112,11 +117,7 @@ fun DownloadScreen(
             message = stringResource(R.string.confirm_dialog_delete_download_description),
             positiveButtonText = stringResource(R.string.yes),
             onPositiveClick = {
-                val isLastItem = (uiState as? DownloadUiState.Data)?.data?.downloads?.size == 1
                 viewModel.deleteDownload()
-                if (isLastItem) {
-                    backDispatcher?.onBackPressed()
-                }
                 showConfirmDeleteDialog.value = false
             },
             negativeButtonText = stringResource(R.string.no),
@@ -127,6 +128,24 @@ fun DownloadScreen(
                 showConfirmDeleteDialog.value = false
             },
         )
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                DownloadEvent.NavigateBack ->
+                    backDispatcher?.onBackPressed()
+
+                is DownloadEvent.Play ->
+                    PlayHelper.playFileIfExists(context, event.path)
+
+                is DownloadEvent.Share ->
+                    ShareHelper.shareFileIfExists(context, event.path)
+
+                is DownloadEvent.Save ->
+                    SaveHelper.saveToDownloads(context, event.path)
+            }
+        }
     }
 
     Scaffold(
@@ -201,8 +220,6 @@ private fun DownloadPager(
     pageSpacing: Dp,
 ) {
     val dimens = LocalDimens.current
-    val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-
     val downloads = data.downloads
     if (downloads.isEmpty()) {
         DownloadError()
@@ -278,7 +295,6 @@ private fun DownloadPager(
                         viewModel.shareDownload(download.id)
                     },
                     onRetryClick = {
-                        backDispatcher?.onBackPressed()
                         viewModel.retryDownload(download.id)
                     },
                 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -1,15 +1,15 @@
 package org.strigate.ferrot.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -24,24 +24,20 @@ import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
-import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadIdsWithMetadataAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
-import org.strigate.ferrot.helper.PlayHelper
-import org.strigate.ferrot.helper.SaveHelper
-import org.strigate.ferrot.helper.ShareHelper
 import org.strigate.ferrot.presentation.Screen
+import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.mapper.toPageUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
-import org.strigate.ferrot.work.DeleteDownloadsWorker
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class DownloadViewModel @Inject constructor(
-    @param:ApplicationContext private val appContext: Context,
     savedStateHandle: SavedStateHandle,
     private val analyticsLogger: AnalyticsLogger,
     private val downloadUseCase: DownloadUseCase,
@@ -49,7 +45,7 @@ class DownloadViewModel @Inject constructor(
     private val downloadAudioUseCase: DownloadAudioUseCase,
     private val downloadProgressUseCase: DownloadProgressUseCase,
     private val downloadMetadataUseCase: DownloadMetadataUseCase,
-    private val getDownloadIdsWithMetadataAsFlowUseCase: GetDownloadIdsWithMetadataAsFlowUseCase,
+    private val downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
 ) : ViewModel() {
@@ -76,6 +72,12 @@ class DownloadViewModel @Inject constructor(
         initialValue = DownloadMediaType.VIDEO,
     )
 
+    private val _events = MutableSharedFlow<DownloadEvent>(
+        replay = 0,
+        extraBufferCapacity = 1,
+    )
+    val events = _events.asSharedFlow()
+
     init {
         viewModelScope.launch {
             clearNotificationsByDownloadIdUseCase(initialId)
@@ -83,7 +85,8 @@ class DownloadViewModel @Inject constructor(
     }
 
     private fun getUiState(id: Long = initialId) =
-        getDownloadIdsWithMetadataAsFlowUseCase()
+        downloadWithMetadataUseCase
+            .getDownloadIdsWithMetadataAsFlowUseCase()
             .flatMapLatest { ids ->
                 if (ids.isEmpty()) {
                     flowOf(
@@ -148,16 +151,14 @@ class DownloadViewModel @Inject constructor(
         }
     }
 
-    fun markSeenIfCompleted(downloadId: Long) {
-        viewModelScope.launch {
-            val state = uiState.value
-            if (state !is DownloadUiState.Data) {
-                return@launch
-            }
-            val download = state.data.downloads.firstOrNull { it.id == downloadId } ?: return@launch
-            if (download.status == DownloadStatusUiData.COMPLETED && !download.seen) {
-                downloadUseCase.updateDownloadSeenByIdUseCase(downloadId)
-            }
+    fun markSeenIfCompleted(downloadId: Long) = viewModelScope.launch {
+        val state = uiState.value
+        if (state !is DownloadUiState.Data) {
+            return@launch
+        }
+        val download = state.data.downloads.firstOrNull { it.id == downloadId } ?: return@launch
+        if (download.status == DownloadStatusUiData.COMPLETED && !download.seen) {
+            downloadUseCase.updateDownloadSeenByIdUseCase(downloadId)
         }
     }
 
@@ -185,34 +186,39 @@ class DownloadViewModel @Inject constructor(
         }
     }
 
-    fun deleteDownload(id: Long? = null) {
+    fun deleteDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        DeleteDownloadsWorker.enqueueOneTimeAppend(
-            context = appContext,
+        val state = uiState.value as? DownloadUiState.Data ?: return@launch
+        val isLastDownload = state.data.downloads.count { it.id != downloadId } == 0
+        downloadUseCase.requestDeleteDownloadsUseCase(
             downloadIds = listOf(downloadId),
         )
+        if (isLastDownload) {
+            _events.emit(DownloadEvent.NavigateBack)
+        }
     }
 
     fun shareDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
         val path = getSelectedMediaFilePath(downloadId) ?: return@launch
-        ShareHelper.shareFileIfExists(appContext, path)
+        _events.emit(DownloadEvent.Share(path))
     }
 
     fun saveDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
         val path = getSelectedMediaFilePath(downloadId) ?: return@launch
-        SaveHelper.saveToDownloads(appContext, path)
+        _events.emit(DownloadEvent.Save(path))
     }
 
     fun playDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
         val path = getSelectedMediaFilePath(downloadId) ?: return@launch
-        PlayHelper.playFileIfExists(appContext, path)
+        _events.emit(DownloadEvent.Play(path))
     }
 
     fun retryDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
+        _events.emit(DownloadEvent.NavigateBack)
         startDownloadUseCase(downloadId)
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -1,16 +1,13 @@
 package org.strigate.ferrot.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.strigate.ferrot.analytics.AnalyticsEvents
@@ -19,27 +16,25 @@ import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
-import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
 import org.strigate.ferrot.presentation.state.DownloadsUiState
-import org.strigate.ferrot.work.DeleteDownloadsWorker
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class DownloadsViewModel @Inject constructor(
-    @param:ApplicationContext val appContext: Context,
     private val analyticsLogger: AnalyticsLogger,
     private val downloadUseCase: DownloadUseCase,
     private val stopDownloadsUseCase: StopDownloadUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
     private val availableUpdateUseCase: AvailableUpdateUseCase,
     private val downloadProgressUseCase: DownloadProgressUseCase,
-    private val getDownloadsWithMetadataAsFlowUseCase: GetDownloadsWithMetadataAsFlowUseCase,
+    private val downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
 ) : ViewModel() {
     val uiState: StateFlow<DownloadsUiState> = getUiState().stateIn(
         scope = viewModelScope,
@@ -48,61 +43,55 @@ class DownloadsViewModel @Inject constructor(
     )
 
     private fun getUiState(): Flow<DownloadsUiState> {
-        val downloadsFlow = getDownloadsWithMetadataAsFlowUseCase()
-            .map { aggregates -> aggregates.map { it.toUiData() } }
+        val downloadsWithMetadataFlow = downloadWithMetadataUseCase
+            .getDownloadsWithMetadataAsFlowUseCase()
+        val availableUpdateFlow = availableUpdateUseCase
+            .getAvailableUpdateAsFlowUseCase()
 
-        val availableUpdateFlow = availableUpdateUseCase.getAvailableUpdateAsFlowUseCase()
         return combine(
-            downloadsFlow,
+            downloadsWithMetadataFlow,
             availableUpdateFlow,
-        ) { downloadItems, availableUpdate ->
+        ) { downloadsWithMetadata, availableUpdate ->
+            val downloadItemsUiData = downloadsWithMetadata.map { downloadWithMetadata ->
+                downloadWithMetadata.toUiData()
+            }
             val availableUpdateUiData = availableUpdate?.let {
                 AvailableUpdateUiData(
-                    tag = it.tag,
                     localFilePath = it.localFilePath,
+                    tag = it.tag,
                 )
             }
             DownloadsUiState.Data(
                 data = DownloadsUiData(
-                    downloads = downloadItems,
+                    downloads = downloadItemsUiData,
                     availableUpdate = availableUpdateUiData,
                 ),
-            ) as DownloadsUiState
+            )
         }
     }
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.DOWNLOADS)
 
-    fun stopDownload(downloadId: Long) {
-        viewModelScope.launch {
-            runCatching {
-                downloadUseCase.updateDownloadStatusByIdUseCase(downloadId, DownloadStatus.STOPPED)
-                downloadProgressUseCase.updateDownloadProgressUseCase(
-                    id = downloadId,
-                    progressPercent = 0F,
-                    bytesDownloaded = 0L,
-                    etaSeconds = null,
-                )
-            }
-            stopDownloadsUseCase(downloadId)
-        }
-    }
-
-    fun retryDownload(downloadId: Long) {
-        viewModelScope.launch {
-            startDownloadUseCase(downloadId)
-        }
-    }
-
-    fun deleteDownloads(downloadIds: Set<Long>) {
-        if (downloadIds.isEmpty()) {
-            return
-        }
-        viewModelScope.launch {
-            DeleteDownloadsWorker.enqueueOneTimeAppend(
-                context = appContext,
-                downloadIds = downloadIds,
+    fun stopDownload(downloadId: Long) = viewModelScope.launch {
+        runCatching {
+            downloadUseCase.updateDownloadStatusByIdUseCase(downloadId, DownloadStatus.STOPPED)
+            downloadProgressUseCase.updateDownloadProgressUseCase(
+                id = downloadId,
+                progressPercent = 0F,
+                bytesDownloaded = 0L,
+                etaSeconds = null,
             )
         }
+        stopDownloadsUseCase(downloadId)
+    }
+
+    fun retryDownload(downloadId: Long) = viewModelScope.launch {
+        startDownloadUseCase(downloadId)
+    }
+
+    fun deleteDownloads(downloadIds: Set<Long>) = viewModelScope.launch {
+        downloadUseCase.requestDeleteDownloadsUseCase(
+            downloadIds = downloadIds,
+        )
     }
 }


### PR DESCRIPTION
- Introduce `DownloadEvent` to handle navigation and file actions
- Replace direct context usage in `DownloadViewModel` with event emission
- Add `RequestDeleteDownloadsUseCase` to centralize delete worker enqueueing
- Introduce `DownloadWithMetadataUseCase` to group metadata related flows
- Update `DownloadScreen` to collect and handle download events
- Remove back navigation from UI logic and handle via events
- Simplify coroutine usage and inline `launch` blocks
- Clean up unused context injections and helpers from ViewModels