### PR TITLE
feat: Display completed download timestamp in UI

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadMappers.kt
@@ -10,6 +10,7 @@ internal fun DownloadEntity.toDomain() = Download(
     status = status.toDomain(),
     seen = seen,
     errorMessage = errorMessage,
+    completedAtMillis = completedAtMillis,
 )
 
 internal fun Download.toEntity() = DownloadEntity(
@@ -19,4 +20,5 @@ internal fun Download.toEntity() = DownloadEntity(
     status = status.toEntity(),
     seen = seen,
     errorMessage = errorMessage,
+    completedAtMillis = completedAtMillis,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadWithMetadataViewMapper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadWithMetadataViewMapper.kt
@@ -14,4 +14,5 @@ fun DownloadWithMetadataView.toDomain() = DownloadWithMetadata(
     etaSeconds = etaSeconds,
     bytesDownloaded = bytesDownloaded,
     expectedBytes = expectedBytes,
+    completedAtMillis = completedAtMillis,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/Download.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/Download.kt
@@ -7,4 +7,5 @@ data class Download(
     val status: DownloadStatus,
     val seen: Boolean,
     val errorMessage: String? = null,
+    val completedAtMillis: Long? = null,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadWithMetadata.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadWithMetadata.kt
@@ -11,4 +11,5 @@ data class DownloadWithMetadata(
     val etaSeconds: Long?,
     val bytesDownloaded: Long,
     val expectedBytes: Long?,
+    val completedAtMillis: Long?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.theme.LocalDimens
@@ -24,6 +26,7 @@ fun DownloadProgressSection(
     progressFraction: Float?,
     etaSeconds: Long?,
     bytesDownloaded: Long,
+    completedAtMillis: Long?,
     modifier: Modifier = Modifier,
     forcePrimaryBar: Boolean = false,
 ) {
@@ -63,6 +66,7 @@ fun DownloadProgressSection(
                 },
                 bytesDownloaded = bytesDownloaded,
                 etaSeconds = etaSeconds,
+                completedAtMillis = completedAtMillis,
             )
         }
     }
@@ -74,7 +78,9 @@ private fun StatusSizeEtaRow(
     progressFraction: Float?,
     bytesDownloaded: Long,
     etaSeconds: Long?,
+    completedAtMillis: Long?,
 ) {
+    val context = LocalContext.current
     val statusText = when (status) {
         DownloadStatusUiData.QUEUED -> stringResource(R.string.status_queued)
         DownloadStatusUiData.WAITING_FOR_NETWORK -> stringResource(R.string.status_waiting_for_network)
@@ -97,7 +103,10 @@ private fun StatusSizeEtaRow(
     }.joinToString(" · ")
 
     val rightText = when (status) {
-        DownloadStatusUiData.COMPLETED -> null
+        DownloadStatusUiData.COMPLETED -> completedAtMillis?.let {
+            UiFormatter.formatCompletedAtTime(context, it)
+        }
+
         DownloadStatusUiData.STOPPED -> stringResource(R.string.percent_0)
         else -> progressFraction?.let { "${(it * 100f).toInt().coerceIn(0, 100)}%" }
     }
@@ -132,6 +141,7 @@ private fun InfoLine(
                 } else {
                     MaterialTheme.colorScheme.onSurfaceVariant
                 },
+                overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
                 text = leftText,
             )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappers.kt
@@ -20,7 +20,8 @@ fun Download.toPageUiData(
     metadata: DownloadMetadata?,
     progress: DownloadProgress?,
 ): DownloadPageUiData {
-    val downloadVideoUiData = video?.filePath
+    val downloadVideoUiData = video
+        ?.filePath
         ?.takeIf { it.isNotBlank() }
         ?.let { filePath ->
             DownloadVideoUiData(
@@ -33,7 +34,8 @@ fun Download.toPageUiData(
             )
         }
 
-    val downloadAudioUiData = audio?.filePath
+    val downloadAudioUiData = audio
+        ?.filePath
         ?.takeIf { it.isNotBlank() }
         ?.let { filePath ->
             DownloadAudioUiData(
@@ -56,7 +58,8 @@ fun Download.toPageUiData(
         ?.stripFileExtension()
         ?.takeIf { it.isNotBlank() }
 
-    val titleValue = metadata?.title
+    val titleValue = metadata
+        ?.title
         ?.takeIf { it.isNotBlank() }
         ?: derivedTitleFromVideo
         ?: derivedTitleFromAudio
@@ -93,5 +96,6 @@ fun Download.toPageUiData(
         progress = progressUiData,
         seen = seen,
         errorMessage = errorMessage,
+        completedAtMillis = completedAtMillis,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadWithMetadataMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadWithMetadataMappers.kt
@@ -23,5 +23,6 @@ fun DownloadWithMetadata.toUiData(): DownloadItemUiData {
         etaSeconds = etaSeconds,
         bytesDownloaded = bytesDownloaded,
         expectedBytes = expectedBytes,
+        completedAtMillis = completedAtMillis,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadItemUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadItemUiData.kt
@@ -11,4 +11,5 @@ data class DownloadItemUiData(
     val etaSeconds: Long?,
     val bytesDownloaded: Long,
     val expectedBytes: Long?,
+    val completedAtMillis: Long?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadPageUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadPageUiData.kt
@@ -10,4 +10,5 @@ data class DownloadPageUiData(
     val progress: DownloadProgressUiData?,
     val seen: Boolean,
     val errorMessage: String?,
+    val completedAtMillis: Long?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -344,6 +344,7 @@ private fun DownloadPageContent(
                 etaSeconds = progress?.etaSeconds,
                 bytesDownloaded = progress?.bytesDownloaded ?: 0L,
                 forcePrimaryBar = status == DownloadStatusUiData.COMPLETED,
+                completedAtMillis = completedAtMillis,
             )
             Spacer(modifier = Modifier.height(dimens.spacingXSmall))
             MediaSwitcherSegmentedButtonRow(
@@ -425,25 +426,42 @@ private fun DownloadPageContent(
                     DownloadMediaType.VIDEO -> video?.fileName
                     DownloadMediaType.AUDIO -> audio?.fileName
                 }
-                selectedName?.let {
-                    MetaItem(
-                        label = stringResource(R.string.download_filename),
-                        value = it,
-                    )
-                }
-                val formattedDuration = UiFormatter.formatDuration(metadata?.durationSeconds)
-                formattedDuration?.let {
-                    MetaItem(
-                        label = stringResource(R.string.download_duration),
-                        value = it,
-                    )
-                }
-                errorMessage?.let {
-                    MetaItem(
-                        label = stringResource(R.string.download_error_message),
-                        value = it,
-                    )
-                }
+                selectedName
+                    ?.let {
+                        MetaItem(
+                            label = stringResource(R.string.download_filename),
+                            value = it,
+                        )
+                    }
+
+                metadata?.durationSeconds
+                    ?.let(UiFormatter::formatDuration)
+                    ?.let { formattedDuration ->
+                        MetaItem(
+                            label = stringResource(R.string.download_duration),
+                            value = formattedDuration,
+                        )
+                    }
+
+                completedAtMillis
+                    ?.takeIf { status == DownloadStatusUiData.COMPLETED }
+                    ?.let { completedAt ->
+                        MetaItem(
+                            label = stringResource(R.string.download_completed_at),
+                            value = UiFormatter.formatCompletedAtDetail(
+                                context = LocalContext.current,
+                                millis = completedAt,
+                            ),
+                        )
+                    }
+
+                errorMessage
+                    ?.let {
+                        MetaItem(
+                            label = stringResource(R.string.download_error_message),
+                            value = it,
+                        )
+                    }
             }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -661,6 +661,7 @@ private fun DownloadItem(
                     progressFraction = item.progressFraction,
                     etaSeconds = item.etaSeconds,
                     bytesDownloaded = item.bytesDownloaded,
+                    completedAtMillis = item.completedAtMillis,
                 )
             }
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/util/UiFormatter.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/util/UiFormatter.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import android.text.format.DateFormat
 import android.text.format.DateUtils
 import org.strigate.ferrot.R
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 
@@ -65,5 +69,48 @@ object UiFormatter {
         } else {
             String.format(Locale.getDefault(), "%d:%02d", minutes, remainingSeconds)
         }
+    }
+
+    fun formatCompletedAtTime(
+        context: Context,
+        millis: Long,
+    ): String {
+        val zoned = Instant
+            .ofEpochMilli(millis)
+            .atZone(ZoneId.systemDefault())
+
+        val locale = Locale.getDefault()
+        val is24Hour = DateFormat.is24HourFormat(context)
+        val timePattern = if (is24Hour) {
+            "HH:mm"
+        } else {
+            "hh:mm a"
+        }
+        val timeFormatter = DateTimeFormatter.ofPattern(timePattern, locale)
+        val bestDatePattern = DateFormat.getBestDateTimePattern(locale, "EEE, MMM d")
+        val dateFormatter = DateTimeFormatter.ofPattern(bestDatePattern, locale)
+        val today = LocalDate.now()
+        return if (zoned.toLocalDate() == today) {
+            zoned.format(timeFormatter)
+        } else {
+            "${zoned.format(dateFormatter)} ${zoned.format(timeFormatter)}"
+        }
+    }
+
+    fun formatCompletedAtDetail(
+        context: Context,
+        millis: Long,
+    ): String {
+        val zoned = Instant
+            .ofEpochMilli(millis)
+            .atZone(ZoneId.systemDefault())
+
+        val is24Hour = DateFormat.is24HourFormat(context)
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
+        val timeFormatter = DateTimeFormatter.ofPattern(
+            if (is24Hour) "HH:mm" else "hh:mm a",
+            Locale.getDefault(),
+        )
+        return "${zoned.format(dateFormatter)} ${zoned.format(timeFormatter)}"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="download_filename">Filename</string>
     <string name="download_duration">Duration</string>
     <string name="download_error_message">Failed error message</string>
+    <string name="download_completed_at">Downloaded</string>
 
     <string name="status_queued">Queued</string>
     <string name="status_waiting_for_network">Waiting for network</string>


### PR DESCRIPTION
- Add `completedAtMillis` to domain, data, and UI models
- Propagate `completedAtMillis` through download mappers
- Show formatted completion time in `DownloadProgressSection`
- Add detailed completed-at metadata to `DownloadScreen`
- Introduce `UiFormatter.formatCompletedAtTime` and `formatCompletedAtDetail`
- Ellipsize long status text to prevent layout overflow
- Add `download_completed_at` string resource