### PR TITLE
fix: Reduce overlay scrim opacity on download primary action

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -67,7 +67,7 @@ fun DownloadPrimaryActionButton(
         )
     }
 
-    val overlayScrim = Color.Black.copy(alpha = 0.35f)
+    val overlayScrim = Color.Black.copy(alpha = 0.15f)
     val thumbnailFile = thumbnailFilePath
         ?.let { File(it) }
         ?.takeIf { it.exists() && it.length() > 0 }


### PR DESCRIPTION
- Lower overlay scrim alpha from `0.35f` to `0.15f` in `DownloadPrimaryActionButton`
- Improve thumbnail visibility while retaining action contrast