### PR TITLE
refactor: Decouple `DownloadPager` from `DownloadViewModel`

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -103,6 +103,7 @@ fun DownloadScreen(
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val selectedId by viewModel.selectedId.collectAsStateWithLifecycle()
     val selectedMedia by viewModel.selectedMedia.collectAsStateWithLifecycle(
         initialValue = DownloadMediaType.VIDEO,
     )
@@ -197,8 +198,20 @@ fun DownloadScreen(
                             .padding(contentPadding)
                             .fillMaxSize(),
                         data = state.data,
+                        selectedId = selectedId,
                         selectedMedia = selectedMedia,
-                        viewModel = viewModel,
+                        onEnsureDefaults = viewModel::setDefaultsForIds,
+                        onDownloadPageSelected = { downloadId ->
+                            viewModel.selectDownload(downloadId)
+                            viewModel.markSeenIfCompleted(downloadId)
+                        },
+                        onSelectedMedia = { downloadId, type ->
+                            viewModel.setSelectedMedia(type, downloadId)
+                        },
+                        onPlayClick = viewModel::playDownload,
+                        onSaveClick = viewModel::saveDownload,
+                        onShareClick = viewModel::shareDownload,
+                        onRetryClick = viewModel::retryDownload,
                         pagePadding = PaddingValues(
                             horizontal = peekPadding,
                             vertical = dimens.zero,
@@ -216,8 +229,15 @@ fun DownloadScreen(
 private fun DownloadPager(
     modifier: Modifier = Modifier,
     data: DownloadUiData,
+    selectedId: Long,
     selectedMedia: DownloadMediaType,
-    viewModel: DownloadViewModel,
+    onEnsureDefaults: (List<Long>) -> Unit,
+    onDownloadPageSelected: (Long) -> Unit,
+    onSelectedMedia: (Long, DownloadMediaType) -> Unit,
+    onPlayClick: (Long) -> Unit,
+    onSaveClick: (Long) -> Unit,
+    onShareClick: (Long) -> Unit,
+    onRetryClick: (Long) -> Unit,
     pagePadding: PaddingValues,
     pageSpacing: Dp,
 ) {
@@ -232,33 +252,40 @@ private fun DownloadPager(
 
         val pagerState = rememberPagerState(
             initialPage = initialIndex,
-            pageCount = { downloads.size }
+            pageCount = { downloads.size },
         )
+        val resolvedPage = remember(downloads, selectedId) {
+            downloads.indexOfFirst { it.id == selectedId }
+        }
 
         LaunchedEffect(downloads) {
-            viewModel.setDefaultsForIds(downloads.map { it.id })
+            onEnsureDefaults(downloads.map { it.id })
+        }
+        LaunchedEffect(resolvedPage) {
+            if (resolvedPage >= 0 && pagerState.currentPage != resolvedPage) {
+                pagerState.scrollToPage(resolvedPage)
+            }
         }
         LaunchedEffect(pagerState, downloads) {
             snapshotFlow { pagerState.currentPage }
-                .map { pageIndex -> downloads.getOrNull(pageIndex)?.id }
+                .map { pageIndex ->
+                    downloads.getOrNull(pageIndex)?.id
+                }
                 .filterNotNull()
                 .distinctUntilChanged()
                 .collect { downloadId ->
-                    viewModel.selectDownload(downloadId)
-                    viewModel.markSeenIfCompleted(downloadId)
-
+                    onDownloadPageSelected(downloadId)
                     val currentDownload = downloads.firstOrNull { it.id == downloadId }
                     val isAudioAvailable = currentDownload?.audio?.filePath?.isNotBlank() == true
                     val isVideoAvailable = currentDownload?.video?.filePath?.isNotBlank() == true
-                    val currentlySelectedMedia = viewModel.selectedMedia.value
                     val correctedMediaType = when {
-                        isAudioAvailable && currentlySelectedMedia == DownloadMediaType.AUDIO -> DownloadMediaType.AUDIO
-                        isVideoAvailable && currentlySelectedMedia == DownloadMediaType.VIDEO -> DownloadMediaType.VIDEO
+                        isAudioAvailable && selectedMedia == DownloadMediaType.AUDIO -> DownloadMediaType.AUDIO
+                        isVideoAvailable && selectedMedia == DownloadMediaType.VIDEO -> DownloadMediaType.VIDEO
                         isAudioAvailable -> DownloadMediaType.AUDIO
                         isVideoAvailable -> DownloadMediaType.VIDEO
                         else -> DownloadMediaType.VIDEO
                     }
-                    viewModel.setSelectedMedia(correctedMediaType, downloadId)
+                    onSelectedMedia(downloadId, correctedMediaType)
                 }
         }
 
@@ -268,6 +295,7 @@ private fun DownloadPager(
             state = pagerState,
             contentPadding = pagePadding,
             pageSpacing = pageSpacing,
+            key = { page -> downloads[page].id },
         ) { page ->
             val download = downloads[page]
             Surface(
@@ -282,22 +310,22 @@ private fun DownloadPager(
                     data = download,
                     selectedMedia = selectedMedia,
                     onMediaChange = { mediaType ->
-                        viewModel.setSelectedMedia(mediaType, download.id)
+                        onSelectedMedia(download.id, mediaType)
                     },
                     onEnsureValidSelection = { mediaType ->
-                        viewModel.setSelectedMedia(mediaType, download.id)
+                        onSelectedMedia(download.id, mediaType)
                     },
                     onPlayClick = {
-                        viewModel.playDownload(download.id)
+                        onPlayClick(download.id)
                     },
                     onSaveClick = {
-                        viewModel.saveDownload(download.id)
+                        onSaveClick(download.id)
                     },
                     onShareClick = {
-                        viewModel.shareDownload(download.id)
+                        onShareClick(download.id)
                     },
                     onRetryClick = {
-                        viewModel.retryDownload(download.id)
+                        onRetryClick(download.id)
                     },
                 )
             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -139,14 +139,14 @@ class DownloadViewModel @Inject constructor(
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.DOWNLOAD)
 
-    fun selectDownload(id: Long) {
-        _selectedId.value = id
-        if (_selectedMediaById.value[id] == null) {
+    fun selectDownload(downloadId: Long) {
+        _selectedId.value = downloadId
+        if (_selectedMediaById.value[downloadId] == null) {
             _selectedMediaById.value = _selectedMediaById
                 .value
                 .toMutableMap()
                 .also {
-                    it[id] = DownloadMediaType.VIDEO
+                    it[downloadId] = DownloadMediaType.VIDEO
                 }
         }
     }
@@ -218,7 +218,6 @@ class DownloadViewModel @Inject constructor(
 
     fun retryDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        _events.emit(DownloadEvent.NavigateBack)
         startDownloadUseCase(downloadId)
     }
 


### PR DESCRIPTION
- Lift `selectedId` into `DownloadScreen` and pass it explicitly
- Replace direct `DownloadViewModel` usage with callback lambdas
- Add stable pager keys using download `id`
- Sync pager position with `selectedId` via `resolvedPage`
- Move default selection and side effects behind explicit handlers
- Simplify `selectDownload` parameter naming for clarity
- Remove unnecessary back navigation event from `retryDownload`