### PR TITLE
chore: Upgrade Gradle, AGP, and Hilt tooling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,10 +11,9 @@ val googleServicesProperties = Properties()
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.hilt.android)
+    alias(libs.plugins.kotlin.compose)
 }
 
 if (keystorePropertiesFile.exists()) {
@@ -24,19 +23,26 @@ if (googleServicesPropertiesFile.exists()) {
     googleServicesProperties.load(FileInputStream(googleServicesPropertiesFile))
 }
 
+object BuildInfo {
+    const val PACKAGE_NAME = "org.strigate.ferrot"
+    const val BASE_VERSION = "1.4.1"
+    const val VERSION_CODE = 18
+    const val VERSION_NAME = "$BASE_VERSION-$VERSION_CODE"
+    const val RELEASE_APK_NAME = "ferrot"
+}
+
 android {
-    val baseVersion = "1.4.1"
-    namespace = "org.strigate.ferrot"
+    namespace = BuildInfo.PACKAGE_NAME
     compileSdk = 36
 
     defaultConfig {
         applicationId = "org.strigate.ferrot"
         minSdk = 30
         targetSdk = 36
-        versionCode = 18
-        versionName = buildVersionName(baseVersion, versionCode)
-        stringField("VERSION", baseVersion)
-        stringField("VERSION_TAG", "v$baseVersion")
+        versionCode = BuildInfo.VERSION_CODE
+        versionName = BuildInfo.VERSION_NAME
+        stringField("VERSION", BuildInfo.BASE_VERSION)
+        stringField("VERSION_TAG", "v${BuildInfo.BASE_VERSION}")
         applyFirebaseProperties()
         ndk {
             abiFilters += listOf("arm64-v8a", "x86_64")
@@ -66,6 +72,7 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            versionNameSuffix = "-D"
         }
         release {
             isDebuggable = false
@@ -80,6 +87,7 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+            versionNameSuffix = "-R"
         }
     }
     compileOptions {
@@ -89,6 +97,7 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+        resValues = true
     }
     splits {
         abi {
@@ -101,20 +110,33 @@ android {
             keepDebugSymbols += listOf("**/*.so")
         }
     }
-    applicationVariants.all {
-        outputs
-            .map { it as com.android.build.gradle.internal.api.ApkVariantOutputImpl }
-            .all {
-                it.outputFileName = "ferrot-${if (isDebugBuildType()) "debug" else "release"}.apk"
-                false
-            }
-    }
 }
 
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_11)
     }
+}
+
+tasks.register<Copy>("renameReleaseApk") {
+    val releaseDir = layout.buildDirectory.dir("outputs/apk/release")
+    from(releaseDir)
+    include("app-release.apk")
+    into(releaseDir)
+    rename {
+        "${BuildInfo.RELEASE_APK_NAME}-release.apk"
+    }
+    doFirst {
+        println("Renaming APK")
+    }
+}
+
+tasks.named("renameReleaseApk") {
+    mustRunAfter("createReleaseApkListingFileRedirect")
+}
+
+tasks.matching { it.name == "assembleRelease" }.configureEach {
+    finalizedBy("renameReleaseApk")
 }
 
 private fun ApplicationDefaultConfig.applyFirebaseProperties(
@@ -144,23 +166,12 @@ private fun ApplicationDefaultConfig.resString(name: String, value: String) {
     resValue("string", name, value.escapeForBuildConfig())
 }
 
-private fun Properties.getString(key: String): String = (this[key] as? String)?.trim().orEmpty()
-
-private fun String.escapeForBuildConfig(): String =
-    "\"" + this.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-
-private fun buildVersionName(baseVersion: String, versionCode: Int?): String {
-    val buildType = if (isDebugBuildType()) "D" else "R"
-    val versionCodePart = versionCode?.let { "-$it-" } ?: "-"
-    return "$baseVersion$versionCodePart$buildType"
+private fun Properties.getString(key: String): String {
+    return (this[key] as? String)?.trim().orEmpty()
 }
 
-private fun isDebugBuildType(): Boolean {
-    val taskNames = gradle.startParameter.taskNames
-    val isDebugTask = taskNames.any { taskName ->
-        taskName.contains("Debug", ignoreCase = true)
-    }
-    return isDebugTask
+private fun String.escapeForBuildConfig(): String {
+    return "\"" + this.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
 }
 
 dependencies {
@@ -190,11 +201,12 @@ dependencies {
     // Work Manager
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.work.runtime.ktx)
+    // Dagger / Hilt
+    implementation(libs.dagger.hilt.android)
+    ksp(libs.dagger.hilt.compiler)
     // Hilt
-    ksp(libs.hilt.compiler)
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    implementation(libs.hilt.work)
+    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.work)
     // Room
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.runtime)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.compose) apply false
-    alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.0.0"
 coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 startupRuntime = "1.2.0"
@@ -10,8 +10,8 @@ composeBom = "2026.01.00"
 activityCompose = "1.12.2"
 navigationCompose = "2.9.6"
 work = "2.11.0"
-hilt = "2.58"
-hiltExt = "1.3.0"
+dagger = "2.59"
+hilt = "1.3.0"
 room = "2.8.4"
 youtubeDlAndroid = "0.18.1"
 uuidCreator = "6.1.1"
@@ -51,11 +51,12 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 # Work Manager
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime", version.ref = "work" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+# Dagger Hilt
+dagger-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "dagger" }
+dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "dagger" }
 # Hilt
-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltExt" }
-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExt" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt" }
 # Room
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
@@ -81,7 +82,6 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgraded Gradle wrapper to `9.3.0`
- Bumped Android Gradle Plugin to `9.0.0`
- Migrated Hilt versions to Dagger `2.59`
- Removed legacy `kotlin-android` plugin usage
- Centralized versioning into `BuildInfo`
- Simplified `versionName` and `versionCode` handling
- Added `versionNameSuffix` for debug and release builds
- Replaced deprecated `applicationVariants` APK renaming
- Added `renameReleaseApk` task for release artifacts
- Enabled Gradle configuration cache
- Cleaned up removed version helper functions