### PR TITLE
chore: Update README supported sites and copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Ferrot is a clean and minimal downloader for video and audio on Android.
 
 When viewing a video or post on social media or in your browser, tap **Share** and choose **Ferrot**. Ferrot will try to download it straight to your device.
 
+Download videos from [1000+](https://ytdl-org.github.io/youtube-dl/supportedsites.html) sites supported by youtube-dl
+
 ## Installation
 Download the latest APK from the [**Latest Release**](https://github.com/strigate/ferrot/releases/latest/download/ferrot-release.apk).
 
@@ -16,5 +18,5 @@ See [CHANGELOG.md](CHANGELOG.md) for version history and notable changes.
 Built on [youtubedl-android](https://github.com/yausername/youtubedl-android).
 
 ## License
-© 2025 Michael Bentz / Strigate  
+© 2026 Michael Bentz / Strigate  
 Licensed under GPLv3-or-later


### PR DESCRIPTION
- Add reference to 1000+ sites supported by `youtube-dl`
- Update copyright year to 2026