### PR TITLE
refactor: Add ripple feedback and unify settings item padding

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -45,17 +46,18 @@ fun ExpandableSettingsSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = ripple(),
+                ) {
+                    expanded = !expanded
+                }
+                .padding(vertical = 16.dp),
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(
-                        indication = null,
-                        interactionSource = remember { MutableInteractionSource() }
-                    ) {
-                        expanded = !expanded
-                    },
+                    .padding(horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
@@ -29,12 +29,13 @@ fun StaticSettingsSection(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(vertical = 16.dp),
         ) {
             text?.let {
                 Text(
                     modifier = Modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     text = it,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
@@ -13,10 +13,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -30,17 +32,21 @@ fun SwitchSetting(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 12.dp),
+            .clip(MaterialTheme.shapes.medium)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(),
+            ) {
+                onCheckedChange(!checked)
+            }
+            .padding(
+                horizontal = 16.dp,
+                vertical = 12.dp,
+            ),
     ) {
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                ) {
-                    onCheckedChange(!checked)
-                },
+                .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -40,7 +41,7 @@ fun TextNavigateSetting(
                 .fillMaxWidth()
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
+                    indication = ripple(),
                 ) {
                     onClick()
                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -24,16 +26,25 @@ fun TextSetting(
     description: String? = null,
     onClick: (() -> Unit)? = null,
 ) {
+    val clickableModifier = if (onClick != null) {
+        Modifier
+            .clip(MaterialTheme.shapes.medium)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(),
+            ) {
+                onClick()
+            }
+    } else Modifier
+
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 12.dp)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            ) {
-                onClick?.invoke()
-            },
+            .then(clickableModifier)
+            .padding(
+                horizontal = 16.dp,
+                vertical = 12.dp,
+            ),
     ) {
         Row(
             modifier = Modifier
@@ -46,23 +57,17 @@ fun TextSetting(
                     .weight(1f)
                     .padding(end = 24.dp),
             ) {
-                if (description != null) {
-                    Text(
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        text = text,
-                    )
+                Text(
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    text = text,
+                )
+                description?.let {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        text = description,
-                    )
-                } else {
-                    Text(
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        text = text,
+                        text = it,
                     )
                 }
             }


### PR DESCRIPTION
- Add `ripple()` indication to clickable settings components
- Apply `clip(MaterialTheme.shapes.medium)` to clickable containers
- Move click handling to parent containers where applicable
- Standardize horizontal and vertical padding across settings items
- Simplify text rendering logic in `TextSetting`