### PR TITLE
refactor: Remove shape clipping from settings components

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SwitchSetting.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -32,7 +31,6 @@ fun SwitchSetting(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(MaterialTheme.shapes.medium)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -28,7 +27,6 @@ fun TextSetting(
 ) {
     val clickableModifier = if (onClick != null) {
         Modifier
-            .clip(MaterialTheme.shapes.medium)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(),


### PR DESCRIPTION
- Remove `clip` modifier from `SwitchSetting`
- Remove `clip` modifier from `TextSetting`
- Update clickable modifier chains accordingly