### PR TITLE
chore: Guard initializer and clean worker formatting

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
@@ -101,7 +101,6 @@ abstract class ForegroundCoroutineWorker(
         if (progress != null || indeterminate) {
             builder.setProgress(100, progress?.coerceIn(0, 100) ?: 0, indeterminate)
         }
-
         val notification = builder.build()
         return ForegroundInfo(
             id.toInt(),

--- a/app/src/main/kotlin/org/strigate/ferrot/app/Initializer.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Initializer.kt
@@ -13,9 +13,13 @@ class Initializer : Initializer<Unit> {
 
     override fun create(context: Context) {
         Log.d(LOG_TAG, "Initializing")
-        YoutubeDL.getInstance().init(context)
-        FFmpeg.getInstance().init(context)
-        Aria2c.getInstance().init(context)
-        Log.d(LOG_TAG, "Initialized")
+        try {
+            YoutubeDL.getInstance().init(context)
+            FFmpeg.getInstance().init(context)
+            Aria2c.getInstance().init(context)
+            Log.d(LOG_TAG, "Initialized")
+        } catch (throwable: Throwable) {
+            Log.e(LOG_TAG, "Initialization failed", throwable)
+        }
     }
 }


### PR DESCRIPTION
- Wrap `YoutubeDL.getInstance().init`, `FFmpeg.getInstance().init`, and `Aria2c.getInstance().init` in a `try` block
- Log initialization failures using `Log.e`