### PR TITLE
feat: Migrate downloads search to TextFieldValue

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -123,7 +124,7 @@ fun DownloadsScreen(
 
     BackHandler(enabled = searchActive) {
         searchActive = false
-        viewModel.updateSearchQuery("")
+        viewModel.updateSearchQuery(TextFieldValue(""))
         keyboardController?.hide()
     }
     LaunchedEffect(searchActive) {
@@ -222,8 +223,8 @@ fun DownloadsScreen(
                         ) {
                             AnimatedVisibility(
                                 visible = !searchActive,
-                                enter = Transitions.searchEnter,
-                                exit = Transitions.searchExit,
+                                enter = Transitions.titleEnter,
+                                exit = Transitions.titleExit,
                             ) {
                                 Text(
                                     modifier = Modifier
@@ -252,9 +253,7 @@ fun DownloadsScreen(
                                         .focusRequester(searchFocusRequester),
                                     singleLine = true,
                                     placeholder = {
-                                        Text(
-                                            text = stringResource(R.string.hint_search),
-                                        )
+                                        Text(text = stringResource(R.string.hint_search))
                                     },
                                     leadingIcon = {
                                         Icon(
@@ -280,7 +279,7 @@ fun DownloadsScreen(
                             onClick = {
                                 searchActive = !searchActive
                                 if (!searchActive) {
-                                    viewModel.updateSearchQuery("")
+                                    viewModel.updateSearchQuery(TextFieldValue(""))
                                     keyboardController?.hide()
                                 }
                             }
@@ -390,13 +389,11 @@ fun DownloadsScreen(
                                 items = downloads,
                                 selectedIds = selectedIds,
                                 bulkDeleteIds = pendingBulkDeleteIds,
-                                searchQuery = searchQuery,
+                                searchQuery = searchQuery.text,
                                 lazyListState = lazyListState,
                                 snackbarHostState = snackbarHostState,
                                 onItemClick = {
-                                    viewModel.updateSearchQuery("")
                                     keyboardController?.hide()
-                                    searchActive = false
                                     navController.navigate(Screen.Download.route(it.id))
                                 },
                                 onPauseResume = { item ->

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/transitions/Transitions.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/transitions/Transitions.kt
@@ -17,7 +17,6 @@ object Transitions {
     ) + fadeIn(
         animationSpec = tween(120),
     )
-
     val searchExit: ExitTransition = slideOutHorizontally(
         targetOffsetX = { it / 3 },
         animationSpec = tween(120),
@@ -25,15 +24,22 @@ object Transitions {
         animationSpec = tween(90),
     )
 
-    val emptyEnter: EnterTransition = fadeIn(
+    val titleExit: ExitTransition = slideOutHorizontally(
+        targetOffsetX = { -it / 3 },
+        animationSpec = tween(120),
+    ) + fadeOut(
+        animationSpec = tween(90),
+    )
+    val titleEnter: EnterTransition = slideInHorizontally(
+        initialOffsetX = { -it / 3 },
+        animationSpec = tween(180),
+    ) + fadeIn(
         animationSpec = tween(120),
     )
 
-    val emptyExit: ExitTransition = fadeOut(
-        animationSpec = tween(90),
-    )
+    val emptyEnter: EnterTransition = fadeIn(animationSpec = tween(120))
+    val emptyExit: ExitTransition = fadeOut(animationSpec = tween(90))
 
     val listItemEnter: EnterTransition = expandVertically() + fadeIn()
-
     val listItemExit: ExitTransition = shrinkVertically() + fadeOut()
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -1,5 +1,7 @@
 package org.strigate.ferrot.presentation.viewmodel
 
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -37,8 +39,10 @@ class DownloadsViewModel @Inject constructor(
     private val downloadProgressUseCase: DownloadProgressUseCase,
     private val downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
 ) : ViewModel() {
-    private val _searchQuery = MutableStateFlow("")
-    val searchQuery: StateFlow<String> = _searchQuery
+    private val _searchQuery = MutableStateFlow(
+        TextFieldValue(text = "", selection = TextRange(0))
+    )
+    val searchQuery: StateFlow<TextFieldValue> = _searchQuery
 
     val uiState: StateFlow<DownloadsUiState> = getUiState().stateIn(
         scope = viewModelScope,
@@ -57,10 +61,11 @@ class DownloadsViewModel @Inject constructor(
             availableUpdateFlow,
             _searchQuery,
         ) { downloadsWithMetadata, availableUpdate, query ->
+            val text = query.text
             val filteredDownloads = downloadsWithMetadata
                 .map { it.toUiData() }
                 .filter {
-                    query.isBlank() || it.title.contains(query, ignoreCase = true)
+                    text.isBlank() || it.title.contains(text, ignoreCase = true)
                 }
 
             val availableUpdateUiData = availableUpdate?.let {
@@ -80,10 +85,12 @@ class DownloadsViewModel @Inject constructor(
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.DOWNLOADS)
 
-    fun updateSearchQuery(query: String) {
-        _searchQuery.value = query
-            .trim()
-            .take(MAX_SEARCH_LENGTH)
+    fun updateSearchQuery(value: TextFieldValue) {
+        val trimmed = value.text.take(MAX_SEARCH_LENGTH)
+        _searchQuery.value = TextFieldValue(
+            text = trimmed,
+            selection = TextRange(trimmed.length),
+        )
     }
 
     fun stopDownload(downloadId: Long) = viewModelScope.launch {


### PR DESCRIPTION
- Replace `String` search state with `TextFieldValue`
- Preserve cursor position via `TextRange`
- Update filtering logic to use `text`
- Adjust `DownloadsScreen` interactions to pass `TextFieldValue`
- Rename search transitions to `titleEnter` and `titleExit`
- Simplify empty state transitions