### PR TITLE
chore: Bump AGP to 9.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.0"
+agp = "9.0.1"
 coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 startupRuntime = "1.2.0"


### PR DESCRIPTION
- Update `agp` version in `libs.versions.toml` from `9.0.0` to `9.0.1`