### PR TITLE
refactor: Replace singleton database with Hilt-provided Room builder

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Database.kt
@@ -1,10 +1,7 @@
 package org.strigate.ferrot.app
 
-import android.content.Context
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
-import org.strigate.ferrot.app.Constants.Database.DATABASE_NAME
 import org.strigate.ferrot.data.local.dao.AvailableUpdateDao
 import org.strigate.ferrot.data.local.dao.DownloadAudioDao
 import org.strigate.ferrot.data.local.dao.DownloadDao
@@ -54,28 +51,9 @@ abstract class Database : RoomDatabase() {
     abstract fun downloadProgressDao(): DownloadProgressDao
     abstract fun downloadMetadataDao(): DownloadMetadataDao
     abstract fun downloadWithMetadataViewDao(): DownloadWithMetadataViewDao
-
-    companion object {
-        @Volatile
-        private var instance: Database? = null
-
-        fun getInstance(context: Context): Database {
-            return instance ?: synchronized(this) {
-                instance ?: buildDatabase(context).also { instance = it }
-            }
-        }
-
-        private fun buildDatabase(context: Context): Database {
-            val roomDatabaseBuilder = Room
-                .databaseBuilder(context, Database::class.java, DATABASE_NAME)
-                .applyMigrations()
-
-            return roomDatabaseBuilder.build()
-        }
-    }
 }
 
-private fun <T : RoomDatabase> RoomDatabase.Builder<T>.applyMigrations(): RoomDatabase.Builder<T> {
+internal fun <T : RoomDatabase> RoomDatabase.Builder<T>.applyMigrations(): RoomDatabase.Builder<T> {
     return addMigrations(
         MIGRATION_1_2,
         MIGRATION_2_3,

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/module/DatabaseModule.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/module/DatabaseModule.kt
@@ -1,12 +1,15 @@
 package org.strigate.ferrot.app.di.module
 
 import android.content.Context
+import androidx.room.Room
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import org.strigate.ferrot.app.Constants.Database.DATABASE_NAME
 import org.strigate.ferrot.app.Database
+import org.strigate.ferrot.app.applyMigrations
 import org.strigate.ferrot.data.local.dao.AvailableUpdateDao
 import org.strigate.ferrot.data.local.dao.DownloadAudioDao
 import org.strigate.ferrot.data.local.dao.DownloadDao
@@ -21,10 +24,11 @@ import javax.inject.Singleton
 object DatabaseModule {
     @Provides
     @Singleton
-    fun provideDatabase(
-        @ApplicationContext context: Context,
-    ): Database {
-        return Database.getInstance(context)
+    fun provideDatabase(@ApplicationContext appContext: Context): Database {
+        return Room
+            .databaseBuilder(appContext, Database::class.java, DATABASE_NAME)
+            .applyMigrations()
+            .build()
     }
 
     @Provides


### PR DESCRIPTION
- Remove `Database` companion object and `getInstance`
- Remove manual `buildDatabase` logic
- Provide `Database` via `Room.databaseBuilder` in `DatabaseModule`
- Use `DATABASE_NAME` constant in module
- Change `applyMigrations` visibility to `internal`