### PR TITLE
refactor: Replace About navigation StateFlow with SharedFlow events

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/event/AboutEvent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/event/AboutEvent.kt
@@ -1,0 +1,6 @@
+package org.strigate.ferrot.presentation.event
+
+sealed interface AboutEvent {
+    data object OpenAppInfo : AboutEvent
+    data class OpenUrl(val url: String) : AboutEvent
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/event/AboutNavigationEvent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/event/AboutNavigationEvent.kt
@@ -1,6 +1,0 @@
-package org.strigate.ferrot.presentation.event
-
-sealed interface AboutNavigationEvent {
-    data object OpenAppInfo : AboutNavigationEvent
-    data class OpenUrl(val url: String) : AboutNavigationEvent
-}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -23,20 +23,18 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.copyToClipboard
 import org.strigate.ferrot.presentation.component.Copyright
 import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
 import org.strigate.ferrot.presentation.component.settings.TextSetting
-import org.strigate.ferrot.presentation.event.AboutNavigationEvent
+import org.strigate.ferrot.presentation.event.AboutEvent
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.viewmodel.AboutViewModel
 
@@ -50,31 +48,28 @@ fun AboutScreen(
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
-    val navigationEvent by viewModel.navigationEvent.collectAsStateWithLifecycle()
-
     LaunchedEffect(Unit) {
         viewModel.logShown()
     }
-    LaunchedEffect(navigationEvent) {
-        when (val event = navigationEvent) {
-            AboutNavigationEvent.OpenAppInfo -> {
-                val intent = Intent(
-                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                ).apply {
-                    data = Uri.fromParts("package", context.packageName, null)
+    LaunchedEffect(Unit) {
+        viewModel.event.collect { event ->
+            when (event) {
+                AboutEvent.OpenAppInfo -> {
+                    val intent = Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    ).apply {
+                        data = Uri.fromParts("package", context.packageName, null)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
                 }
-                context.startActivity(intent)
-                viewModel.onNavigationEventConsumed()
-            }
 
-            is AboutNavigationEvent.OpenUrl -> {
-                context.startActivity(
-                    Intent(Intent.ACTION_VIEW, event.url.toUri())
-                )
-                viewModel.onNavigationEventConsumed()
+                is AboutEvent.OpenUrl -> {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, event.url.toUri())
+                    )
+                }
             }
-
-            null -> Unit
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModel.kt
@@ -1,32 +1,34 @@
 package org.strigate.ferrot.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
-import org.strigate.ferrot.presentation.event.AboutNavigationEvent
+import org.strigate.ferrot.presentation.event.AboutEvent
 import javax.inject.Inject
 
 @HiltViewModel
 class AboutViewModel @Inject constructor(
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
-    private val _navigationEvent = MutableStateFlow<AboutNavigationEvent?>(null)
-    val navigationEvent: StateFlow<AboutNavigationEvent?> = _navigationEvent
+    private val _event = MutableSharedFlow<AboutEvent>()
+    val event = _event.asSharedFlow()
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.ABOUT)
 
     fun onUrlClicked(url: String) {
-        _navigationEvent.value = AboutNavigationEvent.OpenUrl(url)
+        viewModelScope.launch {
+            _event.emit(AboutEvent.OpenUrl(url))
+        }
     }
 
     fun onBuildClicked() {
-        _navigationEvent.value = AboutNavigationEvent.OpenAppInfo
-    }
-
-    fun onNavigationEventConsumed() {
-        _navigationEvent.value = null
+        viewModelScope.launch {
+            _event.emit(AboutEvent.OpenAppInfo)
+        }
     }
 }


### PR DESCRIPTION
- Replace `MutableStateFlow<AboutNavigationEvent?>` with `MutableSharedFlow<AboutEvent>` in `AboutViewModel`
- Expose `event` via `asSharedFlow`
- Emit events using `viewModelScope.launch` in `onUrlClicked` and `onBuildClicked`
- Remove `onNavigationEventConsumed`
- Rename `AboutNavigationEvent` to `AboutEvent`
- Update `AboutScreen` to collect `event` inside `LaunchedEffect`
- Add `Intent.FLAG_ACTIVITY_NEW_TASK` when launching app info settings