### PR TITLE
chore: Update AGP to 9.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.1.0"
 coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 startupRuntime = "1.2.0"


### PR DESCRIPTION
- Bump `agp` from `9.0.1` to `9.1.0` in `libs.versions.toml`