### PR TITLE
refactor: Simplify download paging and separate page data flow

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadUiData.kt
@@ -1,6 +1,6 @@
 package org.strigate.ferrot.presentation.model
 
 data class DownloadUiData(
-    val downloads: List<DownloadPageUiData>,
+    val downloadIds: List<Long>,
     val id: Long?,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -69,6 +69,7 @@ import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
@@ -136,17 +137,21 @@ fun DownloadScreen(
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
-                DownloadEvent.NavigateBack ->
+                DownloadEvent.NavigateBack -> {
                     backDispatcher?.onBackPressed()
+                }
 
-                is DownloadEvent.Play ->
+                is DownloadEvent.Play -> {
                     PlayHelper.playFileIfExists(context, event.path)
+                }
 
-                is DownloadEvent.Share ->
+                is DownloadEvent.Share -> {
                     ShareHelper.shareFileIfExists(context, event.path)
+                }
 
-                is DownloadEvent.Save ->
+                is DownloadEvent.Save -> {
                     SaveHelper.saveToDownloads(context, event.path)
+                }
             }
         }
     }
@@ -198,6 +203,7 @@ fun DownloadScreen(
                             .padding(contentPadding)
                             .fillMaxSize(),
                         data = state.data,
+                        pageDataForId = viewModel::getDownloadPageUiData,
                         selectedId = selectedId,
                         selectedMedia = selectedMedia,
                         onEnsureDefaults = viewModel::setDefaultsForIds,
@@ -229,6 +235,7 @@ fun DownloadScreen(
 private fun DownloadPager(
     modifier: Modifier = Modifier,
     data: DownloadUiData,
+    pageDataForId: (Long) -> Flow<DownloadPageUiData?>,
     selectedId: Long,
     selectedMedia: DownloadMediaType,
     onEnsureDefaults: (List<Long>) -> Unit,
@@ -242,50 +249,39 @@ private fun DownloadPager(
     pageSpacing: Dp,
 ) {
     val dimens = LocalDimens.current
-    val downloads = data.downloads
-    if (downloads.isEmpty()) {
+    val downloadIds = data.downloadIds
+    if (downloadIds.isEmpty()) {
         DownloadError()
     } else {
-        val initialIndex = downloads
-            .indexOfFirst { it.id == data.id }
+        val initialIndex = downloadIds
+            .indexOfFirst { it == data.id }
             .coerceAtLeast(0)
 
         val pagerState = rememberPagerState(
             initialPage = initialIndex,
-            pageCount = { downloads.size },
+            pageCount = { downloadIds.size },
         )
-        val resolvedPage = remember(downloads, selectedId) {
-            downloads.indexOfFirst { it.id == selectedId }
+        val resolvedPage = remember(downloadIds, selectedId) {
+            downloadIds.indexOfFirst { it == selectedId }
         }
 
-        LaunchedEffect(downloads) {
-            onEnsureDefaults(downloads.map { it.id })
+        LaunchedEffect(downloadIds) {
+            onEnsureDefaults(downloadIds)
         }
         LaunchedEffect(resolvedPage) {
             if (resolvedPage >= 0 && pagerState.currentPage != resolvedPage) {
                 pagerState.scrollToPage(resolvedPage)
             }
         }
-        LaunchedEffect(pagerState, downloads) {
+        LaunchedEffect(pagerState, downloadIds) {
             snapshotFlow { pagerState.currentPage }
                 .map { pageIndex ->
-                    downloads.getOrNull(pageIndex)?.id
+                    downloadIds.getOrNull(pageIndex)
                 }
                 .filterNotNull()
                 .distinctUntilChanged()
                 .collect { downloadId ->
                     onDownloadPageSelected(downloadId)
-                    val currentDownload = downloads.firstOrNull { it.id == downloadId }
-                    val isAudioAvailable = currentDownload?.audio?.filePath?.isNotBlank() == true
-                    val isVideoAvailable = currentDownload?.video?.filePath?.isNotBlank() == true
-                    val correctedMediaType = when {
-                        isAudioAvailable && selectedMedia == DownloadMediaType.AUDIO -> DownloadMediaType.AUDIO
-                        isVideoAvailable && selectedMedia == DownloadMediaType.VIDEO -> DownloadMediaType.VIDEO
-                        isAudioAvailable -> DownloadMediaType.AUDIO
-                        isVideoAvailable -> DownloadMediaType.VIDEO
-                        else -> DownloadMediaType.VIDEO
-                    }
-                    onSelectedMedia(downloadId, correctedMediaType)
                 }
         }
 
@@ -295,9 +291,14 @@ private fun DownloadPager(
             state = pagerState,
             contentPadding = pagePadding,
             pageSpacing = pageSpacing,
-            key = { page -> downloads[page].id },
+            beyondViewportPageCount = 0,
+            key = { page -> downloadIds[page] },
         ) { page ->
-            val download = downloads[page]
+            val downloadId = downloadIds[page]
+            val pageData by remember(downloadId) {
+                pageDataForId(downloadId)
+            }.collectAsStateWithLifecycle(initialValue = null)
+
             Surface(
                 modifier = Modifier
                     .fillMaxSize()
@@ -306,28 +307,30 @@ private fun DownloadPager(
                 tonalElevation = dimens.tonalElevationLow,
                 shadowElevation = dimens.shadowElevationLow,
             ) {
-                DownloadPageContent(
-                    data = download,
-                    selectedMedia = selectedMedia,
-                    onMediaChange = { mediaType ->
-                        onSelectedMedia(download.id, mediaType)
-                    },
-                    onEnsureValidSelection = { mediaType ->
-                        onSelectedMedia(download.id, mediaType)
-                    },
-                    onPlayClick = {
-                        onPlayClick(download.id)
-                    },
-                    onSaveClick = {
-                        onSaveClick(download.id)
-                    },
-                    onShareClick = {
-                        onShareClick(download.id)
-                    },
-                    onRetryClick = {
-                        onRetryClick(download.id)
-                    },
-                )
+                pageData?.let { download ->
+                    DownloadPageContent(
+                        data = download,
+                        selectedMedia = selectedMedia,
+                        onMediaChange = { mediaType ->
+                            onSelectedMedia(download.id, mediaType)
+                        },
+                        onEnsureValidSelection = { mediaType ->
+                            onSelectedMedia(download.id, mediaType)
+                        },
+                        onPlayClick = {
+                            onPlayClick(download.id)
+                        },
+                        onSaveClick = {
+                            onSaveClick(download.id)
+                        },
+                        onShareClick = {
+                            onShareClick(download.id)
+                        },
+                        onRetryClick = {
+                            onRetryClick(download.id)
+                        },
+                    )
+                } ?: LoadingState()
             }
         }
     }
@@ -346,9 +349,16 @@ private fun DownloadPageContent(
 ) {
     val dimens = LocalDimens.current
     with(data) {
-        LaunchedEffect(audio?.filePath, selectedMedia) {
-            if (selectedMedia == DownloadMediaType.AUDIO && audio?.filePath.isNullOrBlank()) {
-                onEnsureValidSelection(DownloadMediaType.VIDEO)
+        LaunchedEffect(video?.filePath, audio?.filePath, selectedMedia) {
+            val hasVideo = !video?.filePath.isNullOrBlank()
+            val hasAudio = !audio?.filePath.isNullOrBlank()
+            val fallback = when {
+                selectedMedia == DownloadMediaType.VIDEO && !hasVideo && hasAudio -> DownloadMediaType.AUDIO
+                selectedMedia == DownloadMediaType.AUDIO && !hasAudio && hasVideo -> DownloadMediaType.VIDEO
+                else -> null
+            }
+            if (fallback != null) {
+                onEnsureValidSelection(fallback)
             }
         }
         Column(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,14 +11,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.DownloadMediaType
+import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.DownloadAudioUseCase
 import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
@@ -31,12 +30,11 @@ import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDown
 import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.mapper.toPageUiData
-import org.strigate.ferrot.presentation.model.DownloadStatusUiData
+import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
 import javax.inject.Inject
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class DownloadViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -57,6 +55,14 @@ class DownloadViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
         initialValue = DownloadUiState.Loading,
     )
+
+    private val downloadIds = downloadWithMetadataUseCase
+        .getDownloadIdsWithMetadataAsFlowUseCase()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+            initialValue = emptyList(),
+        )
 
     private val _selectedId = MutableStateFlow(initialId)
     val selectedId: StateFlow<Long> = _selectedId
@@ -83,60 +89,60 @@ class DownloadViewModel @Inject constructor(
         viewModelScope.launch {
             clearNotificationsByDownloadIdUseCase(initialId)
         }
+        viewModelScope.launch {
+            downloadIds.collect { ids ->
+                if (ids.isNotEmpty() && _selectedId.value !in ids) {
+                    _selectedId.value = ids.first()
+                }
+            }
+        }
     }
 
     private fun getUiState(id: Long = initialId): Flow<DownloadUiState> {
         return downloadWithMetadataUseCase
             .getDownloadIdsWithMetadataAsFlowUseCase()
-            .flatMapLatest { ids ->
-                if (ids.isEmpty()) {
-                    flowOf(
-                        DownloadUiState.Data(
-                            DownloadUiData(
-                                downloads = emptyList(),
-                                id = null,
-                            )
-                        )
-                    )
-                } else {
-                    val flows = ids.map { downloadId ->
-                        val downloadFlow = downloadUseCase
-                            .getDownloadByIdAsFlowUseCase(downloadId)
-                        val videoFlow = downloadVideoUseCase
-                            .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
-                        val audioFlow = downloadAudioUseCase
-                            .getDownloadAudioByDownloadIdAsFlowUseCase(downloadId)
-                        val metadataFlow = downloadMetadataUseCase
-                            .getDownloadMetadataByIdAsFlowUseCase(downloadId)
-                        val progressFlow = downloadProgressUseCase
-                            .getDownloadProgressByDownloadIdAsFlowUseCase(downloadId)
-
-                        combine(
-                            downloadFlow,
-                            videoFlow,
-                            audioFlow,
-                            metadataFlow,
-                            progressFlow,
-                        ) { base, video, audio, metadata, progress ->
-                            base?.toPageUiData(
-                                video = video,
-                                audio = audio,
-                                metadata = metadata,
-                                progress = progress,
-                            )
-                        }.filterNotNull()
-                    }
-                    combine(flows) { pagesArray ->
-                        val pagesList = pagesArray.map { it }
-                        DownloadUiState.Data(
-                            DownloadUiData(
-                                downloads = pagesList,
-                                id = id,
-                            )
-                        )
-                    }
+            .map { ids ->
+                val selectedOrDefaultId = when {
+                    ids.isEmpty() -> null
+                    id in ids -> id
+                    _selectedId.value in ids -> _selectedId.value
+                    else -> ids.firstOrNull()
                 }
+                DownloadUiState.Data(
+                    DownloadUiData(
+                        downloadIds = ids,
+                        id = selectedOrDefaultId,
+                    )
+                )
             }
+    }
+
+    fun getDownloadPageUiData(downloadId: Long): Flow<DownloadPageUiData?> {
+        val downloadFlow = downloadUseCase
+            .getDownloadByIdAsFlowUseCase(downloadId)
+        val videoFlow = downloadVideoUseCase
+            .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
+        val audioFlow = downloadAudioUseCase
+            .getDownloadAudioByDownloadIdAsFlowUseCase(downloadId)
+        val metadataFlow = downloadMetadataUseCase
+            .getDownloadMetadataByIdAsFlowUseCase(downloadId)
+        val progressFlow = downloadProgressUseCase
+            .getDownloadProgressByDownloadIdAsFlowUseCase(downloadId)
+
+        return combine(
+            downloadFlow,
+            videoFlow,
+            audioFlow,
+            metadataFlow,
+            progressFlow,
+        ) { base, video, audio, metadata, progress ->
+            base?.toPageUiData(
+                video = video,
+                audio = audio,
+                metadata = metadata,
+                progress = progress,
+            )
+        }
     }
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.DOWNLOAD)
@@ -154,12 +160,8 @@ class DownloadViewModel @Inject constructor(
     }
 
     fun markSeenIfCompleted(downloadId: Long) = viewModelScope.launch {
-        val state = uiState.value
-        if (state !is DownloadUiState.Data) {
-            return@launch
-        }
-        val download = state.data.downloads.firstOrNull { it.id == downloadId } ?: return@launch
-        if (download.status == DownloadStatusUiData.COMPLETED && !download.seen) {
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
+        if (download.status == DownloadStatus.COMPLETED && !download.seen) {
             downloadUseCase.updateDownloadSeenByIdUseCase(downloadId)
         }
     }
@@ -190,8 +192,7 @@ class DownloadViewModel @Inject constructor(
 
     fun deleteDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        val state = uiState.value as? DownloadUiState.Data ?: return@launch
-        val isLastDownload = state.data.downloads.count { it.id != downloadId } == 0
+        val isLastDownload = downloadIds.value.count { it != downloadId } == 0
         downloadUseCase.requestDeleteDownloadsUseCase(
             downloadIds = listOf(downloadId),
         )
@@ -223,12 +224,8 @@ class DownloadViewModel @Inject constructor(
         startDownloadUseCase(downloadId)
     }
 
-    private fun getSelectedMediaFilePath(downloadId: Long): String? {
-        val state = uiState.value
-        if (state !is DownloadUiState.Data) {
-            return null
-        }
-        val download = state.data.downloads.firstOrNull { it.id == downloadId } ?: return null
+    private suspend fun getSelectedMediaFilePath(downloadId: Long): String? {
+        val download = getDownloadPageUiData(downloadId).first() ?: return null
         val mediaType = selectedMedia.value
         return when (mediaType) {
             DownloadMediaType.VIDEO -> download.video?.filePath


### PR DESCRIPTION
- Replace `downloads: List<DownloadPageUiData>` with `downloadIds: List<Long>` in `DownloadUiData`
- Introduce `downloadIds` `StateFlow` in `DownloadViewModel`
- Remove `ExperimentalCoroutinesApi` opt-in
- Simplify `getUiState` to emit only `downloadIds` and selected `id`
- Add `getDownloadPageUiData` to expose per-download `Flow<DownloadPageUiData?>`
- Remove large `combine` over all downloads from `getUiState`
- Update `DownloadPager` to request page data lazily via `pageDataForId`
- Use `collectAsStateWithLifecycle` per page to observe `DownloadPageUiData`
- Add `beyondViewportPageCount = 0` to `HorizontalPager`
- Replace UI state lookup in `markSeenIfCompleted` with `getDownloadByIdUseCase`
- Replace UI state lookup in `deleteDownload` with `downloadIds`
- Convert `getSelectedMediaFilePath` to suspend and fetch page data via `first`
- Move media fallback logic into `DownloadPageContent`