### PR TITLE
refactor: Make state components alignment configurable

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -22,13 +21,13 @@ import org.strigate.ferrot.presentation.theme.LocalDimens
 @Composable
 fun ErrorState(
     modifier: Modifier = Modifier,
+    alignment: Alignment,
     text: String? = null,
 ) {
     val dimens = LocalDimens.current
     Box(
-        modifier = modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        modifier = modifier,
+        contentAlignment = alignment,
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/LoadingState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/LoadingState.kt
@@ -1,7 +1,6 @@
 package org.strigate.ferrot.presentation.component.state
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -10,11 +9,11 @@ import androidx.compose.ui.Modifier
 @Composable
 fun LoadingState(
     modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
 ) {
     Box(
-        modifier = modifier
-            .fillMaxSize(),
-        contentAlignment = Alignment.Center,
+        modifier = modifier,
+        contentAlignment = alignment,
     ) {
         CircularProgressIndicator()
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -193,8 +193,15 @@ fun DownloadScreen(
         content = { contentPadding ->
             val dimens = LocalDimens.current
             when (val state = uiState) {
-                is DownloadUiState.Loading -> LoadingState()
-                is DownloadUiState.Error -> DownloadError()
+                is DownloadUiState.Loading -> {
+                    LoadingState(
+                        modifier = modifier
+                            .padding(contentPadding)
+                            .fillMaxSize(),
+                        alignment = Alignment.Center,
+                    )
+                }
+
                 is DownloadUiState.Data -> {
                     val peekPadding = dimens.spacingMediumAlt
                     val pageSpacing = dimens.spacingSmall
@@ -225,6 +232,8 @@ fun DownloadScreen(
                         pageSpacing = pageSpacing,
                     )
                 }
+
+                is DownloadUiState.Error -> DownloadError()
             }
         },
     )
@@ -330,7 +339,11 @@ private fun DownloadPager(
                             onRetryClick(download.id)
                         },
                     )
-                } ?: LoadingState()
+                } ?: LoadingState(
+                    modifier = Modifier
+                        .fillMaxSize(),
+                    alignment = Alignment.Center,
+                )
             }
         }
     }
@@ -761,7 +774,9 @@ private fun DownloadError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize(),
+        alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_download),
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -363,8 +363,14 @@ fun DownloadsScreen(
                 .fillMaxSize(),
         ) {
             when (val state = uiState) {
-                is DownloadsUiState.Loading -> LoadingState()
-                is DownloadsUiState.Error -> DownloadsError()
+                is DownloadsUiState.Loading -> {
+                    LoadingState(
+                        modifier = Modifier
+                            .fillMaxSize(),
+                        alignment = Alignment.Center,
+                    )
+                }
+
                 is DownloadsUiState.Data -> {
                     with(state.data) {
                         Column(
@@ -422,6 +428,8 @@ fun DownloadsScreen(
                         }
                     }
                 }
+
+                is DownloadsUiState.Error -> DownloadsError()
             }
         }
     }
@@ -825,7 +833,9 @@ private fun DownloadsError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize(),
+        alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_downloads),
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -3,6 +3,7 @@ package org.strigate.ferrot.presentation.screen
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -20,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -78,8 +80,14 @@ fun SettingsScreen(
                     .padding(contentPadding),
             ) {
                 when (val state = uiState) {
-                    is SettingsUiState.Loading -> LoadingState()
-                    is SettingsUiState.Error -> SettingsError()
+                    is SettingsUiState.Loading -> {
+                        LoadingState(
+                            modifier = Modifier
+                                .fillMaxSize(),
+                            alignment = Alignment.Center,
+                        )
+                    }
+
                     is SettingsUiState.Data -> {
                         with(state.data) {
                             Column(
@@ -125,6 +133,8 @@ fun SettingsScreen(
                             }
                         }
                     }
+
+                    is SettingsUiState.Error -> SettingsError()
                 }
             }
         },
@@ -136,7 +146,9 @@ private fun SettingsError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize(),
+        alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_settings),
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -76,8 +77,14 @@ fun UpdatesScreen(
                     .padding(contentPadding),
             ) {
                 when (val state = uiState) {
-                    is UpdatesUiState.Loading -> LoadingState()
-                    is UpdatesUiState.Error -> UpdatesError()
+                    is UpdatesUiState.Loading -> {
+                        LoadingState(
+                            modifier = Modifier
+                                .fillMaxSize(),
+                            alignment = Alignment.Center,
+                        )
+                    }
+
                     is UpdatesUiState.Data -> {
                         with(state.data) {
                             Column(
@@ -141,6 +148,8 @@ fun UpdatesScreen(
                             }
                         }
                     }
+
+                    is UpdatesUiState.Error -> UpdatesError()
                 }
             }
         },
@@ -152,7 +161,9 @@ private fun UpdatesError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize(),
+        alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_update_settings),
     )
 }


### PR DESCRIPTION
- Add `alignment` parameter to `LoadingState` and `ErrorState`
- Remove internal `fillMaxSize` usage from `LoadingState` and `ErrorState`
- Update screens to pass `modifier` and `alignment` when using `LoadingState` and `ErrorState`