### PR TITLE
test: Add ViewModel unit tests

### DIFF
--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
@@ -1,0 +1,74 @@
+package org.strigate.ferrot.presentation.viewmodel
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.analytics.AnalyticsEvents
+import org.strigate.ferrot.analytics.AnalyticsLogger
+import org.strigate.ferrot.presentation.event.AboutEvent
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AboutViewModelTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var analyticsLogger: AnalyticsLogger
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun logShown_logsAboutScreen() {
+        val viewModel = AboutViewModel(analyticsLogger)
+
+        viewModel.logShown()
+
+        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.ABOUT)
+    }
+
+    @Test
+    fun onUrlClicked_emitsOpenUrlEvent() = runTest(testDispatcher) {
+        val viewModel = AboutViewModel(analyticsLogger)
+        val event = async { viewModel.event.first() }
+
+        viewModel.onUrlClicked("https://example.com")
+        advanceUntilIdle()
+
+        assertEquals(AboutEvent.OpenUrl("https://example.com"), event.await())
+    }
+
+    @Test
+    fun onBuildClicked_emitsOpenAppInfoEvent() = runTest(testDispatcher) {
+        val viewModel = AboutViewModel(analyticsLogger)
+        val event = async { viewModel.event.first() }
+
+        viewModel.onBuildClicked()
+        advanceUntilIdle()
+
+        assertEquals(AboutEvent.OpenAppInfo, event.await())
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
@@ -1,0 +1,182 @@
+package org.strigate.ferrot.presentation.viewmodel
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.analytics.AnalyticsEvents
+import org.strigate.ferrot.analytics.AnalyticsLogger
+import org.strigate.ferrot.domain.usecase.ApplyUseCase
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.domain.usecase.apply.ApplyAutomaticDuplicateDownloadDeletionSettingUseCase
+import org.strigate.ferrot.domain.usecase.apply.ApplyWifiOnlyPolicyUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticDuplicateDownloadDeletionSettingUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveDownloadWifiOnlySettingUseCase
+import org.strigate.ferrot.presentation.state.SettingsUiState
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var analyticsLogger: AnalyticsLogger
+
+    @Mock
+    private lateinit var settingsUseCase: SettingsUseCase
+
+    @Mock
+    private lateinit var applyUseCase: ApplyUseCase
+
+    @Mock
+    private lateinit var getDownloadWifiOnlySettingAsFlowUseCase: GetDownloadWifiOnlySettingAsFlowUseCase
+
+    @Mock
+    private lateinit var getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase: GetAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase
+
+    @Mock
+    private lateinit var saveDownloadWifiOnlySettingUseCase: SaveDownloadWifiOnlySettingUseCase
+
+    @Mock
+    private lateinit var saveAutomaticDuplicateDownloadDeletionSettingUseCase: SaveAutomaticDuplicateDownloadDeletionSettingUseCase
+
+    @Mock
+    private lateinit var applyWifiOnlyPolicyUseCase: ApplyWifiOnlyPolicyUseCase
+
+    @Mock
+    private lateinit var applyAutomaticDuplicateDownloadDeletionSettingUseCase: ApplyAutomaticDuplicateDownloadDeletionSettingUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun uiState_exposesMappedSettings() = runTest(testDispatcher) {
+        val downloadWifiOnlyFlow = MutableStateFlow(true)
+        val automaticDeletionFlow = MutableStateFlow(false)
+        val viewModel = createViewModel(
+            downloadWifiOnlyFlow = downloadWifiOnlyFlow,
+            automaticDeletionFlow = automaticDeletionFlow,
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { it is SettingsUiState.Data }
+
+        val state = viewModel.uiState.value as SettingsUiState.Data
+        assertEquals(true, state.data.downloadWifiOnly)
+        assertEquals(false, state.data.automaticDuplicateDownloadDeletion)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun logShown_logsSettingsScreen() {
+        val viewModel = createViewModel(
+            downloadWifiOnlyFlow = MutableStateFlow(false),
+            automaticDeletionFlow = MutableStateFlow(false),
+        )
+
+        viewModel.logShown()
+
+        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.SETTINGS)
+    }
+
+    @Test
+    fun setDownloadWifiOnly_savesSetting_andAppliesPolicy() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadWifiOnlyFlow = MutableStateFlow(false),
+            automaticDeletionFlow = MutableStateFlow(false),
+        )
+
+        viewModel.setDownloadWifiOnly(true)
+        advanceUntilIdle()
+
+        verify(saveDownloadWifiOnlySettingUseCase).invoke(true)
+        verify(applyWifiOnlyPolicyUseCase).invoke(true)
+    }
+
+    @Test
+    fun setAutomaticDuplicateDownloadDeletion_savesSetting_andAppliesPolicy() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                downloadWifiOnlyFlow = MutableStateFlow(false),
+                automaticDeletionFlow = MutableStateFlow(false),
+            )
+
+            viewModel.setAutomaticDuplicateDownloadDeletion(true)
+            advanceUntilIdle()
+
+            verify(saveAutomaticDuplicateDownloadDeletionSettingUseCase).invoke(true)
+            verify(applyAutomaticDuplicateDownloadDeletionSettingUseCase).invoke(
+                automaticDuplicateDownloadDeletion = true,
+            )
+        }
+
+    private fun createViewModel(
+        downloadWifiOnlyFlow: MutableStateFlow<Boolean>,
+        automaticDeletionFlow: MutableStateFlow<Boolean>,
+    ): SettingsViewModel {
+        `when`(getDownloadWifiOnlySettingAsFlowUseCase.invoke())
+            .thenReturn(downloadWifiOnlyFlow)
+        `when`(getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase.invoke())
+            .thenReturn(automaticDeletionFlow)
+        `when`(settingsUseCase.getDownloadWifiOnlySettingAsFlowUseCase)
+            .thenReturn(getDownloadWifiOnlySettingAsFlowUseCase)
+        `when`(settingsUseCase.getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase)
+            .thenReturn(getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase)
+        `when`(settingsUseCase.saveDownloadWifiOnlySettingUseCase)
+            .thenReturn(saveDownloadWifiOnlySettingUseCase)
+        `when`(settingsUseCase.saveAutomaticDuplicateDownloadDeletionSettingUseCase)
+            .thenReturn(saveAutomaticDuplicateDownloadDeletionSettingUseCase)
+        `when`(applyUseCase.applyWifiOnlyPolicyUseCase)
+            .thenReturn(applyWifiOnlyPolicyUseCase)
+        `when`(applyUseCase.applyAutomaticDuplicateDownloadDeletionSettingUseCase)
+            .thenReturn(applyAutomaticDuplicateDownloadDeletionSettingUseCase)
+
+        return SettingsViewModel(
+            analyticsLogger = analyticsLogger,
+            settingsUseCase = settingsUseCase,
+            applyUseCase = applyUseCase,
+        )
+    }
+
+    private suspend fun waitForUiState(
+        viewModel: SettingsViewModel,
+        predicate: (SettingsUiState) -> Boolean,
+    ) {
+        withTimeout(2.seconds) {
+            while (!predicate(viewModel.uiState.value)) {
+                kotlinx.coroutines.yield()
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
@@ -1,0 +1,157 @@
+package org.strigate.ferrot.presentation.viewmodel
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.analytics.AnalyticsEvents
+import org.strigate.ferrot.analytics.AnalyticsLogger
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.domain.usecase.StateUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetAutomaticDependencyUpdatesSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetAutomaticUpdatesSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.state.GetLastAvailableUpdateCheckMillisUseCase
+import org.strigate.ferrot.domain.usecase.state.GetLastDependencyUpdateCheckMillisUseCase
+import org.strigate.ferrot.presentation.state.UpdatesUiState
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdatesViewModelTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var analyticsLogger: AnalyticsLogger
+
+    @Mock
+    private lateinit var settingsUseCase: SettingsUseCase
+
+    @Mock
+    private lateinit var stateUseCase: StateUseCase
+
+    @Mock
+    private lateinit var getAutomaticUpdatesSettingAsFlowUseCase: GetAutomaticUpdatesSettingAsFlowUseCase
+
+    @Mock
+    private lateinit var getAutomaticDependencyUpdatesSettingAsFlowUseCase: GetAutomaticDependencyUpdatesSettingAsFlowUseCase
+
+    @Mock
+    private lateinit var getLastAvailableUpdateCheckMillisUseCase: GetLastAvailableUpdateCheckMillisUseCase
+
+    @Mock
+    private lateinit var getLastDependencyUpdateCheckMillisUseCase: GetLastDependencyUpdateCheckMillisUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun uiState_exposesMappedSettingsAndInfo() = runTest(testDispatcher) {
+        val automaticUpdatesFlow = MutableStateFlow(true)
+        val automaticDependencyUpdatesFlow = MutableStateFlow(false)
+        val lastAvailableCheckFlow = MutableStateFlow(123L)
+        val lastDependencyCheckFlow = MutableStateFlow(456L)
+        val viewModel = createViewModel(
+            automaticUpdatesFlow = automaticUpdatesFlow,
+            automaticDependencyUpdatesFlow = automaticDependencyUpdatesFlow,
+            lastAvailableCheckFlow = lastAvailableCheckFlow,
+            lastDependencyCheckFlow = lastDependencyCheckFlow,
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { it is UpdatesUiState.Data }
+
+        val state = viewModel.uiState.value as UpdatesUiState.Data
+        assertEquals(true, state.data.settings.automaticUpdates)
+        assertEquals(false, state.data.settings.automaticDependencyUpdates)
+        assertEquals(123L, state.data.info.lastAvailableUpdateCheckMillis)
+        assertEquals(456L, state.data.info.lastDependencyUpdateCheckMillis)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun logShown_logsUpdatesScreen() {
+        val viewModel = createViewModel(
+            automaticUpdatesFlow = MutableStateFlow(false),
+            automaticDependencyUpdatesFlow = MutableStateFlow(false),
+            lastAvailableCheckFlow = MutableStateFlow(0L),
+            lastDependencyCheckFlow = MutableStateFlow(0L),
+        )
+
+        viewModel.logShown()
+
+        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.UPDATES)
+    }
+
+    private fun createViewModel(
+        automaticUpdatesFlow: MutableStateFlow<Boolean>,
+        automaticDependencyUpdatesFlow: MutableStateFlow<Boolean>,
+        lastAvailableCheckFlow: MutableStateFlow<Long>,
+        lastDependencyCheckFlow: MutableStateFlow<Long>,
+    ): UpdatesViewModel {
+        `when`(getAutomaticUpdatesSettingAsFlowUseCase.invoke())
+            .thenReturn(automaticUpdatesFlow)
+        `when`(getAutomaticDependencyUpdatesSettingAsFlowUseCase.invoke())
+            .thenReturn(automaticDependencyUpdatesFlow)
+        `when`(getLastAvailableUpdateCheckMillisUseCase.invoke())
+            .thenReturn(lastAvailableCheckFlow)
+        `when`(getLastDependencyUpdateCheckMillisUseCase.invoke())
+            .thenReturn(lastDependencyCheckFlow)
+        `when`(settingsUseCase.getAutomaticUpdatesSettingAsFlowUseCase)
+            .thenReturn(getAutomaticUpdatesSettingAsFlowUseCase)
+        `when`(settingsUseCase.getAutomaticDependencyUpdatesSettingAsFlowUseCase)
+            .thenReturn(getAutomaticDependencyUpdatesSettingAsFlowUseCase)
+        `when`(stateUseCase.getLastAvailableUpdateCheckMillisUseCase)
+            .thenReturn(getLastAvailableUpdateCheckMillisUseCase)
+        `when`(stateUseCase.getLastDependencyUpdateCheckMillisUseCase)
+            .thenReturn(getLastDependencyUpdateCheckMillisUseCase)
+
+        return UpdatesViewModel(
+            appContext = appContext,
+            analyticsLogger = analyticsLogger,
+            settingsUseCase = settingsUseCase,
+            stateUseCase = stateUseCase,
+        )
+    }
+
+    private suspend fun waitForUiState(
+        viewModel: UpdatesViewModel,
+        predicate: (UpdatesUiState) -> Boolean,
+    ) {
+        withTimeout(2.seconds) {
+            while (!predicate(viewModel.uiState.value)) {
+                kotlinx.coroutines.yield()
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add `SettingsViewModelTest`
- Verify `uiState` exposes mapped settings from flows
- Verify `logShown` logs `AnalyticsEvents.Screens.SETTINGS`
- Verify `setDownloadWifiOnly` invokes `saveDownloadWifiOnlySettingUseCase` and `applyWifiOnlyPolicyUseCase`
- Verify `setAutomaticDuplicateDownloadDeletion` invokes `saveAutomaticDuplicateDownloadDeletionSettingUseCase` and `applyAutomaticDuplicateDownloadDeletionSettingUseCase`

- Add `AboutViewModelTest`
- Verify `logShown` logs `AnalyticsEvents.Screens.ABOUT`
- Verify `onUrlClicked` emits `AboutEvent.OpenUrl`
- Verify `onBuildClicked` emits `AboutEvent.OpenAppInfo`

- Add `UpdatesViewModelTest`
- Verify `uiState` exposes mapped settings and update check information
- Verify `logShown` logs `AnalyticsEvents.Screens.UPDATES`