### PR TITLE
test: Add tests for `SettingsRepositoryImpl` and `StateRepositoryImpl`

### DIFF
--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
@@ -1,0 +1,83 @@
+package org.strigate.ferrot.data.repository
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_UPDATES
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY
+import java.nio.file.Files
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsRepositoryImplTest {
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {
+        val repository = createRepository(backgroundScope)
+
+        assertEquals(
+            DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY,
+            repository.getDownloadWifiOnlyAsFlow().first(),
+        )
+        assertEquals(
+            DEFAULT_VALUE_AUTOMATIC_UPDATES,
+            repository.getAutomaticUpdatesAsFlow().first(),
+        )
+        assertEquals(
+            DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES,
+            repository.getAutomaticDependencyUpdatesAsFlow().first(),
+        )
+        assertEquals(
+            DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION,
+            repository.getAutomaticDuplicateDownloadDeletionAsFlow().first(),
+        )
+    }
+
+    @Test
+    fun saveMethods_persistUpdatedValues() = runTest(testDispatcher) {
+        val repository = createRepository(backgroundScope)
+
+        repository.saveDownloadWifiOnly(false)
+        repository.saveAutomaticUpdates(false)
+        repository.saveAutomaticDependencyUpdates(false)
+        repository.saveAutomaticDuplicateDownloadDeletion(false)
+
+        assertEquals(false, repository.getDownloadWifiOnlyAsFlow().first())
+        assertEquals(false, repository.getAutomaticUpdatesAsFlow().first())
+        assertEquals(false, repository.getAutomaticDependencyUpdatesAsFlow().first())
+        assertEquals(false, repository.getAutomaticDuplicateDownloadDeletionAsFlow().first())
+    }
+
+    private fun createRepository(scope: CoroutineScope): SettingsRepositoryImpl {
+        val tempFile = Files.createTempFile("settings-repository-test", ".preferences_pb")
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { tempFile.toFile() },
+        )
+
+        return SettingsRepositoryImpl(dataStore)
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
@@ -1,0 +1,76 @@
+package org.strigate.ferrot.data.repository
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_BOOT_TIME_MILLIS
+import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_LAST_AVAILABLE_UPDATE_CHECK_MILLIS
+import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS
+import java.nio.file.Files
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StateRepositoryImplTest {
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {
+        val repository = createRepository(backgroundScope)
+
+        assertEquals(
+            DEFAULT_VALUE_BOOT_TIME_MILLIS,
+            repository.getBootTimeMillisAsFlow().first(),
+        )
+        assertEquals(
+            DEFAULT_VALUE_LAST_AVAILABLE_UPDATE_CHECK_MILLIS,
+            repository.getLastAvailableUpdateCheckMillisAsFlow().first(),
+        )
+        assertEquals(
+            DEFAULT_VALUE_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS,
+            repository.getLastDependencyUpdateCheckMillisAsFlow().first(),
+        )
+    }
+
+    @Test
+    fun saveMethods_persistUpdatedValues() = runTest(testDispatcher) {
+        val repository = createRepository(backgroundScope)
+
+        repository.saveBootTimeMillis(123L)
+        repository.saveLastAvailableUpdateCheckMillis(456L)
+        repository.saveLastDependencyUpdateCheckMillis(789L)
+
+        assertEquals(123L, repository.getBootTimeMillisAsFlow().first())
+        assertEquals(456L, repository.getLastAvailableUpdateCheckMillisAsFlow().first())
+        assertEquals(789L, repository.getLastDependencyUpdateCheckMillisAsFlow().first())
+    }
+
+    private fun createRepository(scope: CoroutineScope): StateRepositoryImpl {
+        val tempFile = Files.createTempFile("state-repository-test", ".preferences_pb")
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { tempFile.toFile() },
+        )
+
+        return StateRepositoryImpl(dataStore)
+    }
+}


### PR DESCRIPTION
- Add `SettingsRepositoryImplTest`
- Test default values returned by `SettingsRepositoryImpl` getters
- Test persistence behavior of `saveDownloadWifiOnly`
- Test persistence behavior of `saveAutomaticUpdates`
- Test persistence behavior of `saveAutomaticDependencyUpdates`
- Test persistence behavior of `saveAutomaticDuplicateDownloadDeletion`
- Add `StateRepositoryImplTest`
- Test default values returned by `StateRepositoryImpl` getters
- Test persistence behavior of `saveBootTimeMillis`
- Test persistence behavior of `saveLastAvailableUpdateCheckMillis`
- Test persistence behavior of `saveLastDependencyUpdateCheckMillis`
- Use `PreferenceDataStoreFactory` with temporary files for isolated tests
- Configure coroutine testing with `StandardTestDispatcher`