### PR TITLE
feat: Add unit tests for repositories, mappers, and utilities

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -97,7 +97,7 @@ class DownloadViewModel @Inject constructor(
                 val currentSelectedId = _selectedId.value
                 if (ids.isNotEmpty() && currentSelectedId !in ids) {
                     val previousIndex = previousIds.indexOf(currentSelectedId)
-                    _selectedId.value = if (previousIndex in ids.indices) {
+                    _selectedId.value = if (previousIndex >= 0 && previousIndex < ids.size) {
                         ids[previousIndex]
                     } else {
                         ids.last()

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
@@ -1,0 +1,103 @@
+package org.strigate.ferrot.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.data.local.dao.DownloadAudioDao
+import org.strigate.ferrot.data.local.entity.DownloadAudioEntity
+import org.strigate.ferrot.domain.model.DownloadAudio
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadAudioRepositoryImplTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadAudioDao: DownloadAudioDao
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun save_insertsMappedEntity() = runTest(testDispatcher) {
+        val repository = DownloadAudioRepositoryImpl(downloadAudioDao)
+
+        `when`(downloadAudioDao.insertReplace(sampleEntity()))
+            .thenReturn(4L)
+
+        val result = repository.save(sampleAudio())
+        assertEquals(4L, result)
+        verify(downloadAudioDao).insertReplace(sampleEntity())
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
+        `when`(downloadAudioDao.getByDownloadIdAsFlow(3L))
+            .thenReturn(flowOf(sampleEntity(downloadId = 3L)))
+
+        val repository = DownloadAudioRepositoryImpl(downloadAudioDao)
+        val result = repository.getByDownloadIdAsFlow(3L).first()
+        assertEquals(sampleAudio(downloadId = 3L), result)
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_returnsNull_whenDaoEmitsNull() = runTest(testDispatcher) {
+        `when`(downloadAudioDao.getByDownloadIdAsFlow(3L))
+            .thenReturn(flowOf(null))
+
+        val repository = DownloadAudioRepositoryImpl(downloadAudioDao)
+        assertNull(repository.getByDownloadIdAsFlow(3L).first())
+    }
+
+    @Test
+    fun queryMethods_delegateToDao() = runTest(testDispatcher) {
+        `when`(downloadAudioDao.getAllFilePaths())
+            .thenReturn(listOf("/tmp/audio.m4a"))
+        `when`(downloadAudioDao.deleteByDownloadId(3L))
+            .thenReturn(1)
+
+        val repository = DownloadAudioRepositoryImpl(downloadAudioDao)
+        assertEquals(listOf("/tmp/audio.m4a"), repository.getAllFilePaths())
+        assertEquals(1, repository.deleteByDownloadId(3L))
+
+        verify(downloadAudioDao).getAllFilePaths()
+        verify(downloadAudioDao).deleteByDownloadId(3L)
+    }
+
+    private fun sampleAudio(downloadId: Long = 1L) = DownloadAudio(
+        downloadId = downloadId,
+        filePath = "/tmp/audio.m4a",
+        fileExtension = "m4a",
+    )
+
+    private fun sampleEntity(downloadId: Long = 1L) = DownloadAudioEntity(
+        id = 0L,
+        downloadId = downloadId,
+        filePath = "/tmp/audio.m4a",
+        fileExtension = "m4a",
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
@@ -1,0 +1,116 @@
+package org.strigate.ferrot.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.data.local.dao.DownloadMetadataDao
+import org.strigate.ferrot.data.local.entity.DownloadMetadataEntity
+import org.strigate.ferrot.domain.model.DownloadMetadata
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadMetadataRepositoryImplTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadMetadataDao: DownloadMetadataDao
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun save_insertsMappedEntity() = runTest(testDispatcher) {
+        val repository = DownloadMetadataRepositoryImpl(downloadMetadataDao)
+        `when`(downloadMetadataDao.insertReplace(sampleEntity()))
+            .thenReturn(6L)
+
+        val result = repository.save(sampleMetadata())
+
+        assertEquals(6L, result)
+        verify(downloadMetadataDao).insertReplace(sampleEntity())
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
+        `when`(downloadMetadataDao.getByDownloadIdAsFlow(2L))
+            .thenReturn(flowOf(sampleEntity(downloadId = 2L)))
+
+        val repository = DownloadMetadataRepositoryImpl(downloadMetadataDao)
+        val result = repository.getByDownloadIdAsFlow(2L).first()
+        assertEquals(sampleMetadata(downloadId = 2L), result)
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_returnsNull_whenDaoEmitsNull() = runTest(testDispatcher) {
+        `when`(downloadMetadataDao.getByDownloadIdAsFlow(2L))
+            .thenReturn(flowOf(null))
+
+        val repository = DownloadMetadataRepositoryImpl(downloadMetadataDao)
+        assertNull(repository.getByDownloadIdAsFlow(2L).first())
+    }
+
+    @Test
+    fun queryMethods_delegateToDao() = runTest(testDispatcher) {
+        `when`(downloadMetadataDao.getDownloadIdsBySourceAndVideoId("youtube", "abc123"))
+            .thenReturn(listOf(1L, 9L))
+        `when`(downloadMetadataDao.getAllThumbnailFilePaths())
+            .thenReturn(listOf("/tmp/one.jpg", "/tmp/two.jpg"))
+        `when`(downloadMetadataDao.deleteByDownloadId(2L))
+            .thenReturn(1)
+
+        val repository = DownloadMetadataRepositoryImpl(downloadMetadataDao)
+
+        assertEquals(
+            listOf(1L, 9L),
+            repository.getDownloadIdsBySourceAndVideoId("youtube", "abc123")
+        )
+        assertEquals(listOf("/tmp/one.jpg", "/tmp/two.jpg"), repository.getAllThumbnailFilePaths())
+        assertEquals(1, repository.deleteByDownloadId(2L))
+
+        verify(downloadMetadataDao).getDownloadIdsBySourceAndVideoId("youtube", "abc123")
+        verify(downloadMetadataDao).getAllThumbnailFilePaths()
+        verify(downloadMetadataDao).deleteByDownloadId(2L)
+    }
+
+    private fun sampleMetadata(downloadId: Long = 1L) = DownloadMetadata(
+        downloadId = downloadId,
+        videoId = "abc123",
+        source = "youtube",
+        title = "Sample title",
+        thumbnailFilePath = "/tmp/thumb.jpg",
+        durationSeconds = 91,
+    )
+
+    private fun sampleEntity(downloadId: Long = 1L) = DownloadMetadataEntity(
+        downloadId = downloadId,
+        videoId = "abc123",
+        source = "youtube",
+        title = "Sample title",
+        thumbnailFilePath = "/tmp/thumb.jpg",
+        durationSeconds = 91,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
@@ -1,0 +1,124 @@
+package org.strigate.ferrot.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.data.local.dao.DownloadProgressDao
+import org.strigate.ferrot.data.local.entity.DownloadProgressEntity
+import org.strigate.ferrot.domain.model.DownloadProgress
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadProgressRepositoryImplTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadProgressDao: DownloadProgressDao
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun save_insertsMappedEntity() = runTest(testDispatcher) {
+        val repository = DownloadProgressRepositoryImpl(downloadProgressDao)
+        val progress = sampleDownloadProgress()
+
+        `when`(downloadProgressDao.insertReplace(sampleEntity()))
+            .thenReturn(5L)
+
+        val result = repository.save(progress)
+
+        assertEquals(5L, result)
+        verify(downloadProgressDao).insertReplace(sampleEntity())
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
+        `when`(downloadProgressDao.getByDownloadIdAsFlow(7L))
+            .thenReturn(flowOf(sampleEntity(downloadId = 7L)))
+
+        val repository = DownloadProgressRepositoryImpl(downloadProgressDao)
+        val result = repository.getByDownloadIdAsFlow(7L).first()
+        assertEquals(sampleDownloadProgress(downloadId = 7L), result)
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_returnsNull_whenDaoEmitsNull() = runTest(testDispatcher) {
+        `when`(downloadProgressDao.getByDownloadIdAsFlow(7L))
+            .thenReturn(flowOf(null))
+
+        val repository = DownloadProgressRepositoryImpl(downloadProgressDao)
+        assertNull(repository.getByDownloadIdAsFlow(7L).first())
+    }
+
+    @Test
+    fun updateExpectedBytes_delegatesToDao() = runTest(testDispatcher) {
+        doReturn(2)
+            .`when`(downloadProgressDao)
+            .updateExpectedBytes(eq(7L), eq(4096L), anyLong())
+
+        val repository = DownloadProgressRepositoryImpl(downloadProgressDao)
+        val result = repository.updateExpectedBytes(7L, 4096L)
+
+        assertEquals(2, result)
+        verify(downloadProgressDao)
+            .updateExpectedBytes(eq(7L), eq(4096L), anyLong())
+    }
+
+    @Test
+    fun deleteByDownloadId_returnsDaoDeleteCount() = runTest(testDispatcher) {
+        `when`(downloadProgressDao.deleteByDownloadId(7L))
+            .thenReturn(1)
+
+        val repository = DownloadProgressRepositoryImpl(downloadProgressDao)
+        val result = repository.deleteByDownloadId(7L)
+
+        assertEquals(1, result)
+        verify(downloadProgressDao).deleteByDownloadId(7L)
+    }
+
+    private fun sampleDownloadProgress(downloadId: Long = 4L) = DownloadProgress(
+        downloadId = downloadId,
+        updatedAtMillis = 123L,
+        progressPercent = 42.5F,
+        bytesDownloaded = 2048L,
+        etaSeconds = 17L,
+        expectedBytes = 4096L,
+    )
+
+    private fun sampleEntity(downloadId: Long = 4L) = DownloadProgressEntity(
+        downloadId = downloadId,
+        updatedAtMillis = 123L,
+        progressPercent = 42.5F,
+        bytesDownloaded = 2048L,
+        etaSeconds = 17L,
+        expectedBytes = 4096L,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
@@ -15,6 +15,8 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -46,57 +48,27 @@ class DownloadRepositoryImplTest {
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
-        var insertedEntity: DownloadEntity? = null
         val download = sampleDownload()
-        val repository = DownloadRepositoryImpl(
-            object : DownloadDao {
-                override suspend fun insert(downloadEntity: DownloadEntity): Long {
-                    insertedEntity = downloadEntity
-                    return 12L
-                }
-
-                override suspend fun getAll(): List<DownloadEntity> = error("Not used")
-
-                override suspend fun getById(id: Long): DownloadEntity = error("Not used")
-
-                override fun getByIdAsFlow(id: Long) = error("Not used")
-
-                override suspend fun updateStatusById(id: Long, status: EntityStatus): Int =
-                    error("Not used")
-
-                override suspend fun updateSeenById(id: Long, seen: Boolean): Int =
-                    error("Not used")
-
-                override suspend fun updateErrorMessageById(id: Long, errorMessage: String?): Int =
-                    error("Not used")
-
-                override suspend fun updateStartedAtById(id: Long, startedAtMillis: Long?): Int =
-                    error("Not used")
-
-                override suspend fun updateCompletedAtById(
-                    id: Long,
-                    completedAtMillis: Long?,
-                ): Int = error("Not used")
-
-                override suspend fun deleteById(id: Long): Int = error("Not used")
-            },
-        )
+        var insertedEntity: DownloadEntity? = null
+        doAnswer { invocation ->
+            insertedEntity = invocation.getArgument(0)
+            12L
+        }.`when`(downloadDao).insert(anyObject())
+        val repository = DownloadRepositoryImpl(downloadDao)
 
         val result = repository.save(download)
 
         assertEquals(12L, result)
-        assertEquals(
-            DownloadEntity(
-                id = download.id,
-                uid = download.uid,
-                url = download.url,
-                status = EntityStatus.QUEUED,
-                seen = download.seen,
-                errorMessage = download.errorMessage,
-                completedAtMillis = download.completedAtMillis,
-            ),
-            insertedEntity,
-        )
+        assertEquals(download.id, insertedEntity?.id)
+        assertEquals(download.uid, insertedEntity?.uid)
+        assertEquals(download.url, insertedEntity?.url)
+        assertEquals(EntityStatus.QUEUED, insertedEntity?.status)
+        assertEquals(download.seen, insertedEntity?.seen)
+        assertEquals(download.errorMessage, insertedEntity?.errorMessage)
+        assertEquals(download.completedAtMillis, insertedEntity?.completedAtMillis)
+        assertNull(insertedEntity?.startedAtMillis)
+
+        verify(downloadDao).insert(insertedEntity ?: error("Entity not captured"))
     }
 
     @Test
@@ -126,12 +98,8 @@ class DownloadRepositoryImplTest {
 
     @Test
     fun getById_returnsMappedDomain_whenDaoReturnsEntity() = runTest(testDispatcher) {
-        `when`(downloadDao.getById(4L)).thenReturn(
-            sampleEntity(
-                id = 4L,
-                status = EntityStatus.FAILED,
-            )
-        )
+        `when`(downloadDao.getById(4L))
+            .thenReturn(sampleEntity(id = 4L, status = EntityStatus.FAILED))
 
         val repository = DownloadRepositoryImpl(downloadDao)
         val result = repository.getById(4L)
@@ -175,6 +143,7 @@ class DownloadRepositoryImplTest {
         `when`(downloadDao.updateStartedAtById(3L, 100L)).thenReturn(1)
         `when`(downloadDao.updateCompletedAtById(3L, 200L)).thenReturn(1)
         `when`(downloadDao.deleteById(3L)).thenReturn(1)
+
         val repository = DownloadRepositoryImpl(downloadDao)
 
         assertEquals(1, repository.updateStatusById(3L, DownloadStatus.STOPPED))
@@ -221,4 +190,7 @@ class DownloadRepositoryImplTest {
         startedAtMillis = 20L,
         completedAtMillis = completedAtMillis,
     )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> anyObject(): T = Mockito.any<T>() ?: null as T
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
@@ -1,0 +1,224 @@
+package org.strigate.ferrot.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.data.local.dao.DownloadDao
+import org.strigate.ferrot.data.local.entity.DownloadEntity
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.data.local.entity.DownloadStatus as EntityStatus
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadRepositoryImplTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadDao: DownloadDao
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun save_insertsMappedEntity() = runTest(testDispatcher) {
+        var insertedEntity: DownloadEntity? = null
+        val download = sampleDownload()
+        val repository = DownloadRepositoryImpl(
+            object : DownloadDao {
+                override suspend fun insert(downloadEntity: DownloadEntity): Long {
+                    insertedEntity = downloadEntity
+                    return 12L
+                }
+
+                override suspend fun getAll(): List<DownloadEntity> = error("Not used")
+
+                override suspend fun getById(id: Long): DownloadEntity = error("Not used")
+
+                override fun getByIdAsFlow(id: Long) = error("Not used")
+
+                override suspend fun updateStatusById(id: Long, status: EntityStatus): Int =
+                    error("Not used")
+
+                override suspend fun updateSeenById(id: Long, seen: Boolean): Int =
+                    error("Not used")
+
+                override suspend fun updateErrorMessageById(id: Long, errorMessage: String?): Int =
+                    error("Not used")
+
+                override suspend fun updateStartedAtById(id: Long, startedAtMillis: Long?): Int =
+                    error("Not used")
+
+                override suspend fun updateCompletedAtById(
+                    id: Long,
+                    completedAtMillis: Long?,
+                ): Int = error("Not used")
+
+                override suspend fun deleteById(id: Long): Int = error("Not used")
+            },
+        )
+
+        val result = repository.save(download)
+
+        assertEquals(12L, result)
+        assertEquals(
+            DownloadEntity(
+                id = download.id,
+                uid = download.uid,
+                url = download.url,
+                status = EntityStatus.QUEUED,
+                seen = download.seen,
+                errorMessage = download.errorMessage,
+                completedAtMillis = download.completedAtMillis,
+            ),
+            insertedEntity,
+        )
+    }
+
+    @Test
+    fun getAll_mapsEntitiesToDomain() = runTest(testDispatcher) {
+        `when`(downloadDao.getAll()).thenReturn(
+            listOf(
+                sampleEntity(id = 1L, status = EntityStatus.DOWNLOADING),
+                sampleEntity(id = 2L, status = EntityStatus.COMPLETED, completedAtMillis = 300L),
+            ),
+        )
+
+        val repository = DownloadRepositoryImpl(downloadDao)
+        val result = repository.getAll()
+
+        assertEquals(
+            listOf(
+                sampleDownload(id = 1L, status = DownloadStatus.DOWNLOADING),
+                sampleDownload(
+                    id = 2L,
+                    status = DownloadStatus.COMPLETED,
+                    completedAtMillis = 300L,
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun getById_returnsMappedDomain_whenDaoReturnsEntity() = runTest(testDispatcher) {
+        `when`(downloadDao.getById(4L)).thenReturn(
+            sampleEntity(
+                id = 4L,
+                status = EntityStatus.FAILED,
+            )
+        )
+
+        val repository = DownloadRepositoryImpl(downloadDao)
+        val result = repository.getById(4L)
+        assertEquals(sampleDownload(id = 4L, status = DownloadStatus.FAILED), result)
+    }
+
+    @Test
+    fun getById_returnsNull_whenDaoReturnsNull() = runTest(testDispatcher) {
+        `when`(downloadDao.getById(4L))
+            .thenReturn(null)
+
+        val repository = DownloadRepositoryImpl(downloadDao)
+        assertNull(repository.getById(4L))
+    }
+
+    @Test
+    fun getByIdAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
+        `when`(downloadDao.getByIdAsFlow(8L))
+            .thenReturn(flowOf(sampleEntity(id = 8L, status = EntityStatus.PAUSED)))
+
+        val repository = DownloadRepositoryImpl(downloadDao)
+        val result = repository.getByIdAsFlow(8L).first()
+
+        assertEquals(sampleDownload(id = 8L, status = DownloadStatus.PAUSED), result)
+    }
+
+    @Test
+    fun getByIdAsFlow_returnsNull_whenDaoEmitsNull() = runTest(testDispatcher) {
+        `when`(downloadDao.getByIdAsFlow(8L))
+            .thenReturn(flowOf(null))
+
+        val repository = DownloadRepositoryImpl(downloadDao)
+        assertNull(repository.getByIdAsFlow(8L).first())
+    }
+
+    @Test
+    fun updateMethods_delegateToDao() = runTest(testDispatcher) {
+        `when`(downloadDao.updateStatusById(3L, EntityStatus.STOPPED)).thenReturn(1)
+        `when`(downloadDao.updateErrorMessageById(3L, "boom")).thenReturn(1)
+        `when`(downloadDao.updateSeenById(3L, true)).thenReturn(1)
+        `when`(downloadDao.updateStartedAtById(3L, 100L)).thenReturn(1)
+        `when`(downloadDao.updateCompletedAtById(3L, 200L)).thenReturn(1)
+        `when`(downloadDao.deleteById(3L)).thenReturn(1)
+        val repository = DownloadRepositoryImpl(downloadDao)
+
+        assertEquals(1, repository.updateStatusById(3L, DownloadStatus.STOPPED))
+        assertEquals(1, repository.updateErrorMessageById(3L, "boom"))
+        assertEquals(1, repository.updateSeenById(3L, true))
+        assertEquals(1, repository.updateStartedAtById(3L, 100L))
+        assertEquals(1, repository.updateCompletedAtById(3L, 200L))
+        assertEquals(1, repository.deleteById(3L))
+
+        verify(downloadDao).updateStatusById(3L, EntityStatus.STOPPED)
+        verify(downloadDao).updateErrorMessageById(3L, "boom")
+        verify(downloadDao).updateSeenById(3L, true)
+        verify(downloadDao).updateStartedAtById(3L, 100L)
+        verify(downloadDao).updateCompletedAtById(3L, 200L)
+        verify(downloadDao).deleteById(3L)
+    }
+
+    private fun sampleDownload(
+        id: Long = 9L,
+        status: DownloadStatus = DownloadStatus.QUEUED,
+        completedAtMillis: Long? = null,
+    ) = Download(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/$id",
+        status = status,
+        seen = false,
+        errorMessage = "error-$id",
+        completedAtMillis = completedAtMillis,
+    )
+
+    private fun sampleEntity(
+        id: Long = 9L,
+        status: EntityStatus = EntityStatus.QUEUED,
+        completedAtMillis: Long? = null,
+    ) = DownloadEntity(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/$id",
+        status = status,
+        seen = false,
+        errorMessage = "error-$id",
+        enqueuedAtMillis = 10L,
+        startedAtMillis = 20L,
+        completedAtMillis = completedAtMillis,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
@@ -1,0 +1,107 @@
+package org.strigate.ferrot.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.data.local.dao.DownloadVideoDao
+import org.strigate.ferrot.data.local.entity.DownloadVideoEntity
+import org.strigate.ferrot.domain.model.DownloadVideo
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadVideoRepositoryImplTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadVideoDao: DownloadVideoDao
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun save_insertsMappedEntity() = runTest(testDispatcher) {
+        val repository = DownloadVideoRepositoryImpl(downloadVideoDao)
+        `when`(downloadVideoDao.insertReplace(sampleEntity()))
+            .thenReturn(5L)
+
+        val result = repository.save(sampleVideo())
+        assertEquals(5L, result)
+
+        verify(downloadVideoDao).insertReplace(sampleEntity())
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
+        `when`(downloadVideoDao.getByDownloadIdAsFlow(3L))
+            .thenReturn(flowOf(sampleEntity(downloadId = 3L)))
+
+        val repository = DownloadVideoRepositoryImpl(downloadVideoDao)
+        val result = repository.getByDownloadIdAsFlow(3L).first()
+
+        assertEquals(sampleVideo(downloadId = 3L), result)
+    }
+
+    @Test
+    fun getByDownloadIdAsFlow_returnsNull_whenDaoEmitsNull() = runTest(testDispatcher) {
+        `when`(downloadVideoDao.getByDownloadIdAsFlow(3L))
+            .thenReturn(flowOf(null))
+
+        val repository = DownloadVideoRepositoryImpl(downloadVideoDao)
+        assertNull(repository.getByDownloadIdAsFlow(3L).first())
+    }
+
+    @Test
+    fun queryMethods_delegateToDao() = runTest(testDispatcher) {
+        `when`(downloadVideoDao.getDownloadIdsBySha256("sha")).thenReturn(listOf(2L, 8L))
+        `when`(downloadVideoDao.getAllFilePaths()).thenReturn(listOf("/tmp/video.mp4"))
+        `when`(downloadVideoDao.deleteByDownloadId(3L)).thenReturn(1)
+        val repository = DownloadVideoRepositoryImpl(downloadVideoDao)
+
+        assertEquals(listOf(2L, 8L), repository.getDownloadIdsBySha256("sha"))
+        assertEquals(listOf("/tmp/video.mp4"), repository.getAllFilePaths())
+        assertEquals(1, repository.deleteByDownloadId(3L))
+
+        verify(downloadVideoDao).getDownloadIdsBySha256("sha")
+        verify(downloadVideoDao).getAllFilePaths()
+        verify(downloadVideoDao).deleteByDownloadId(3L)
+    }
+
+    private fun sampleVideo(downloadId: Long = 1L) = DownloadVideo(
+        downloadId = downloadId,
+        filePath = "/tmp/video.mp4",
+        fileExtension = "mp4",
+        sha256 = "sha",
+    )
+
+    private fun sampleEntity(downloadId: Long = 1L) = DownloadVideoEntity(
+        id = 0L,
+        downloadId = downloadId,
+        filePath = "/tmp/video.mp4",
+        fileExtension = "mp4",
+        sha256 = "sha",
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
@@ -1,0 +1,104 @@
+package org.strigate.ferrot.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.data.local.dao.DownloadWithMetadataViewDao
+import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.model.DownloadWithMetadata
+import org.strigate.ferrot.data.local.entity.DownloadStatus as EntityStatus
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadWithMetadataRepositoryImplTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadWithMetadataViewDao: DownloadWithMetadataViewDao
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    @Test
+    fun getAllDownloadsWithMetadataAsFlow_mapsViewsToDomain() = runTest(testDispatcher) {
+        `when`(downloadWithMetadataViewDao.getAllAsFlow()).thenReturn(
+            flowOf(
+                listOf(
+                    sampleView(id = 1L, status = EntityStatus.DOWNLOADING),
+                    sampleView(id = 2L, status = EntityStatus.COMPLETED, completedAtMillis = 88L),
+                ),
+            ),
+        )
+
+        val repository = DownloadWithMetadataRepositoryImpl(downloadWithMetadataViewDao)
+        val result = repository.getAllDownloadsWithMetadataAsFlow().first()
+        assertEquals(
+            listOf(
+                sampleDomain(id = 1L, status = DownloadStatus.DOWNLOADING),
+                sampleDomain(id = 2L, status = DownloadStatus.COMPLETED, completedAtMillis = 88L),
+            ),
+            result,
+        )
+    }
+
+    private fun sampleView(
+        id: Long,
+        status: EntityStatus,
+        completedAtMillis: Long? = null,
+    ) = DownloadWithMetadataView(
+        id = id,
+        url = "https://example.com/$id",
+        resolvedTitle = "Title $id",
+        thumbnailFilePath = "/tmp/$id.jpg",
+        status = status,
+        seen = id % 2L == 0L,
+        progressPercent = 35F,
+        etaSeconds = 12L,
+        bytesDownloaded = 1024L,
+        expectedBytes = 4096L,
+        enqueuedAtMillis = 10L,
+        startedAtMillis = 20L,
+        completedAtMillis = completedAtMillis,
+    )
+
+    private fun sampleDomain(
+        id: Long,
+        status: DownloadStatus,
+        completedAtMillis: Long? = null,
+    ) = DownloadWithMetadata(
+        id = id,
+        url = "https://example.com/$id",
+        title = "Title $id",
+        thumbnailFilePath = "/tmp/$id.jpg",
+        status = status,
+        seen = id % 2L == 0L,
+        progressPercent = 35F,
+        etaSeconds = 12L,
+        bytesDownloaded = 1024L,
+        expectedBytes = 4096L,
+        completedAtMillis = completedAtMillis,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/extensions/StringTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/extensions/StringTest.kt
@@ -1,0 +1,84 @@
+package org.strigate.ferrot.extensions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class StringTest {
+    @Test
+    fun extractFileName_returnsLastPathSegment() {
+        assertEquals("video.mp4", "/tmp/media/video.mp4".extractFileName())
+    }
+
+    @Test
+    fun extractFileName_returnsNull_whenPathEndsWithSlashOrIsBlank() {
+        assertNull("/tmp/media/".extractFileName())
+        assertNull("   ".extractFileName())
+        assertNull("video.mp4".extractFileName())
+    }
+
+    @Test
+    fun stripFileExtension_removesOnlyLastExtension() {
+        assertEquals("archive.tar", "archive.tar.gz".stripFileExtension())
+        assertEquals("README", "README".stripFileExtension())
+    }
+
+    @Test
+    fun extractFileExtension_returnsUppercaseExtension() {
+        assertEquals("MP4", "/tmp/media/video.mp4".extractFileExtension())
+        assertEquals("GZ", "/tmp/archive.tar.gz".extractFileExtension())
+        assertEquals("PNG", "/tmp/cover.PnG".extractFileExtension())
+    }
+
+    @Test
+    fun extractFileExtension_returnsNull_whenNoUsableExtensionExists() {
+        assertNull("/tmp/media/readme".extractFileExtension())
+        assertNull("/tmp/media/".extractFileExtension())
+    }
+
+    @Test
+    fun toSafeFileName_removesUnsafeCharacters_andCollapsesWhitespace() {
+        val result = " https://example.com/ a:*?\"<>|#%  title  ".toSafeFileName()
+
+        assertEquals("example.com a title", result)
+    }
+
+    @Test
+    fun toSafeFileName_returnsSanitizedValue_whenWithinLimit() {
+        assertEquals("simple name", "simple   name".toSafeFileName(maxBytes = 40))
+    }
+
+    @Test
+    fun toSafeFileName_truncatesWithoutBreakingUtf8Characters() {
+        val result = "éééé".toSafeFileName(maxBytes = 5)
+
+        assertEquals("éé", result)
+    }
+
+    @Test
+    fun toSafeFileName_returnsEmptyString_whenOnlyUnsafeCharactersRemain() {
+        assertEquals("", "https://#%/:*?\"<>|   ".toSafeFileName())
+    }
+
+    @Test
+    fun toSafeFileName_keepsValue_whenByteCountMatchesLimitExactly() {
+        assertEquals("éé", "éé".toSafeFileName(maxBytes = 4))
+    }
+
+    @Test
+    fun toSafeFileName_trimsTrailingSpace_afterTruncation() {
+        assertEquals("abc", "abc def".toSafeFileName(maxBytes = 4))
+    }
+
+    @Test
+    fun guessMimeType_mapsKnownTypesAndFallsBackToWildcard() {
+        assertEquals("video/*", "movie.webm".guessMimeType())
+        assertEquals("audio/*", "track.m4a".guessMimeType())
+        assertEquals("image/*", "cover.jpeg".guessMimeType())
+        assertEquals("application/pdf", "document.pdf".guessMimeType())
+        assertEquals("text/plain", "notes.txt".guessMimeType())
+        assertEquals("*/*", "archive.bin".guessMimeType())
+        assertEquals("*/*", "README".guessMimeType())
+        assertEquals("video/*", "movie.MOV".guessMimeType())
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
@@ -3,8 +3,6 @@ package org.strigate.ferrot.presentation
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -20,6 +18,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
@@ -45,6 +45,9 @@ class MainViewModelTest {
     @Mock
     private lateinit var startDownloadUseCase: StartDownloadUseCase
 
+    @Mock
+    private lateinit var downloadRepository: DownloadRepository
+
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
@@ -62,7 +65,7 @@ class MainViewModelTest {
 
     @Test
     fun navigateTo_updatesNavigationEvent() {
-        val viewModel = createViewModel().first
+        val viewModel = createViewModel()
 
         viewModel.navigateTo(route = Screen.Settings.route, popUpToDownloads = true)
 
@@ -77,7 +80,7 @@ class MainViewModelTest {
 
     @Test
     fun navigateTo_defaultsPopUpToDownloadsToFalse() {
-        val viewModel = createViewModel().first
+        val viewModel = createViewModel()
 
         viewModel.navigateTo(route = Screen.About.route)
 
@@ -96,8 +99,9 @@ class MainViewModelTest {
             status = DownloadStatus.QUEUED,
             seen = false,
         )
-        val (viewModel, downloadRepository) = createViewModel()
-        downloadRepository.downloadsById[42L] = download
+        val viewModel = createViewModel()
+        `when`(downloadRepository.getById(42L))
+            .thenReturn(download)
 
         viewModel.navigateToDownload(42L)
         advanceUntilIdle()
@@ -114,7 +118,9 @@ class MainViewModelTest {
     @Test
     fun navigateToDownload_keepsNavigationEmpty_whenDownloadDoesNotExist() =
         runTest(testDispatcher) {
-            val viewModel = createViewModel().first
+            val viewModel = createViewModel()
+            `when`(downloadRepository.getById(99L))
+                .thenReturn(null)
 
             viewModel.navigateToDownload(99L)
             advanceUntilIdle()
@@ -125,36 +131,45 @@ class MainViewModelTest {
     @Test
     fun startDownload_savesQueuedUnseenDownloadAndStartsIt_whenSaveSucceeds() =
         runTest(testDispatcher) {
-            val (viewModel, downloadRepository) = createViewModel()
-            downloadRepository.nextSaveResult = 12L
+            val viewModel = createViewModel()
+            val savedDownloads = mutableListOf<Download>()
+            doAnswer { invocation ->
+                savedDownloads += invocation.getArgument<Download>(0)
+                12L
+            }.`when`(downloadRepository).save(anyObject())
 
             viewModel.startDownload("https://example.com/video")
             advanceUntilIdle()
 
-            val savedDownload = downloadRepository.savedDownloads.single()
+            val savedDownload = savedDownloads.single()
             assertEquals("https://example.com/video", savedDownload.url)
             assertEquals(DownloadStatus.QUEUED, savedDownload.status)
             assertFalse(savedDownload.seen)
             assertNotNull(savedDownload.uid)
             assertFalse(savedDownload.uid.isBlank())
+
             verify(startDownloadUseCase).invoke(12L)
         }
 
     @Test
     fun startDownload_doesNotStartIt_whenSaveFails() = runTest(testDispatcher) {
-        val (viewModel, downloadRepository) = createViewModel()
-        downloadRepository.nextSaveResult = -1L
+        val viewModel = createViewModel()
+        val savedDownloads = mutableListOf<Download>()
+        doAnswer { invocation ->
+            savedDownloads += invocation.getArgument<Download>(0)
+            -1L
+        }.`when`(downloadRepository).save(anyObject())
 
         viewModel.startDownload("https://example.com/video")
         advanceUntilIdle()
 
-        assertEquals("https://example.com/video", downloadRepository.savedDownloads.single().url)
+        assertEquals("https://example.com/video", savedDownloads.single().url)
         verifyNoInteractions(startDownloadUseCase)
     }
 
     @Test
     fun resetNavigate_clearsNavigationEvent() {
-        val viewModel = createViewModel().first
+        val viewModel = createViewModel()
 
         viewModel.navigateTo(Screen.About.route)
         viewModel.resetNavigate()
@@ -162,46 +177,21 @@ class MainViewModelTest {
         assertNull(viewModel.navigateRoute.value)
     }
 
-    private fun createViewModel(): Pair<MainViewModel, FakeDownloadRepository> {
-        val downloadRepository = FakeDownloadRepository()
+    private fun createViewModel(): MainViewModel {
         val saveDownloadUseCase = SaveDownloadUseCase(downloadRepository)
         val getDownloadByIdUseCase = GetDownloadByIdUseCase(downloadRepository)
 
-        `when`(downloadUseCase.saveDownloadUseCase).thenReturn(saveDownloadUseCase)
-        `when`(downloadUseCase.getDownloadByIdUseCase).thenReturn(getDownloadByIdUseCase)
+        `when`(downloadUseCase.saveDownloadUseCase)
+            .thenReturn(saveDownloadUseCase)
+        `when`(downloadUseCase.getDownloadByIdUseCase)
+            .thenReturn(getDownloadByIdUseCase)
 
         return MainViewModel(
             downloadUseCase = downloadUseCase,
             startDownloadUseCase = startDownloadUseCase,
-        ) to downloadRepository
+        )
     }
 
-    private class FakeDownloadRepository : DownloadRepository {
-        val downloadsById = linkedMapOf<Long, Download>()
-        val savedDownloads = mutableListOf<Download>()
-        var nextSaveResult: Long = 1L
-
-        override suspend fun save(download: Download): Long {
-            savedDownloads += download
-            return nextSaveResult
-        }
-
-        override suspend fun getAll(): List<Download> = downloadsById.values.toList()
-
-        override suspend fun getById(id: Long): Download? = downloadsById[id]
-
-        override fun getByIdAsFlow(id: Long): Flow<Download?> = flowOf(downloadsById[id])
-
-        override suspend fun updateStatusById(id: Long, status: DownloadStatus): Int = 0
-
-        override suspend fun updateErrorMessageById(id: Long, errorMessage: String?): Int = 0
-
-        override suspend fun updateSeenById(id: Long, seen: Boolean): Int = 0
-
-        override suspend fun updateStartedAtById(id: Long, startedAtMillis: Long?): Int = 0
-
-        override suspend fun updateCompletedAtById(id: Long, completedAtMillis: Long?): Int = 0
-
-        override suspend fun deleteById(id: Long): Int = 0
-    }
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> anyObject(): T = Mockito.any<T>() ?: null as T
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappersTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadMappersTest.kt
@@ -1,0 +1,197 @@
+package org.strigate.ferrot.presentation.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadAudio
+import org.strigate.ferrot.domain.model.DownloadMetadata
+import org.strigate.ferrot.domain.model.DownloadProgress
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.model.DownloadVideo
+
+class DownloadMappersTest {
+    @Test
+    fun toPageUiData_prefersMetadataTitle_andBuildsMediaUiData() {
+        val result = sampleDownload().toPageUiData(
+            video = DownloadVideo(
+                downloadId = 1L,
+                filePath = "/tmp/video-file.mp4",
+                fileExtension = "",
+                sha256 = null,
+            ),
+            audio = DownloadAudio(
+                downloadId = 1L,
+                filePath = "/tmp/audio-track.m4a",
+                fileExtension = "",
+            ),
+            metadata = DownloadMetadata(
+                downloadId = 1L,
+                videoId = "abc",
+                source = "youtube",
+                title = "Real title",
+                thumbnailFilePath = "/tmp/thumb.jpg",
+                durationSeconds = 90,
+            ),
+            progress = DownloadProgress(
+                downloadId = 1L,
+                updatedAtMillis = 10L,
+                progressPercent = 25f,
+                bytesDownloaded = 100L,
+                etaSeconds = 4L,
+                expectedBytes = 400L,
+            ),
+        )
+
+        assertEquals("Real title", result.metadata?.title)
+        assertEquals("video-file.mp4", result.video?.fileName)
+        assertEquals("MP4", result.video?.fileExtension)
+        assertEquals("audio-track.m4a", result.audio?.fileName)
+        assertEquals("M4A", result.audio?.fileExtension)
+        assertEquals(0.25f, result.progress?.progressFraction)
+    }
+
+    @Test
+    fun toPageUiData_fallsBackToDerivedVideoTitle_whenMetadataTitleIsBlank() {
+        val result = sampleDownload(url = "https://example.com/fallback").toPageUiData(
+            video = DownloadVideo(
+                downloadId = 1L,
+                filePath = "/tmp/episode-final.mp4",
+                fileExtension = "MP4",
+                sha256 = null,
+            ),
+            audio = null,
+            metadata = DownloadMetadata(
+                downloadId = 1L,
+                videoId = null,
+                source = null,
+                title = " ",
+                thumbnailFilePath = null,
+                durationSeconds = null,
+            ),
+            progress = null,
+        )
+
+        assertEquals("episode-final", result.metadata?.title)
+        assertNull(result.audio)
+        assertNull(result.progress)
+    }
+
+    @Test
+    fun toPageUiData_filtersBlankMediaPaths_andClampsInvalidProgress() {
+        val result = sampleDownload().toPageUiData(
+            video = DownloadVideo(
+                downloadId = 1L,
+                filePath = " ",
+                fileExtension = "MP4",
+                sha256 = null,
+            ),
+            audio = DownloadAudio(
+                downloadId = 1L,
+                filePath = "",
+                fileExtension = "M4A",
+            ),
+            metadata = null,
+            progress = DownloadProgress(
+                downloadId = 1L,
+                updatedAtMillis = 10L,
+                progressPercent = Float.NaN,
+                bytesDownloaded = 100L,
+                etaSeconds = null,
+                expectedBytes = null,
+            ),
+        )
+
+        assertNull(result.video)
+        assertNull(result.audio)
+        assertNotNull(result.metadata)
+        assertEquals(sampleDownload().url, result.metadata?.title)
+        assertEquals(0f, result.progress?.progressFraction)
+    }
+
+    @Test
+    fun toPageUiData_fallsBackToDerivedAudioTitle_whenVideoTitleIsUnavailable() {
+        val result = sampleDownload(url = "https://example.com/audio-only").toPageUiData(
+            video = null,
+            audio = DownloadAudio(
+                downloadId = 1L,
+                filePath = "/tmp/podcast-episode.opus",
+                fileExtension = "OPUS",
+            ),
+            metadata = DownloadMetadata(
+                downloadId = 1L,
+                videoId = null,
+                source = null,
+                title = "",
+                thumbnailFilePath = null,
+                durationSeconds = null,
+            ),
+            progress = null,
+        )
+
+        assertEquals("podcast-episode", result.metadata?.title)
+        assertEquals("OPUS", result.audio?.fileExtension)
+    }
+
+    @Test
+    fun toPageUiData_usesExplicitVideoExtension_andClampsProgressAboveHundred() {
+        val result = sampleDownload().toPageUiData(
+            video = DownloadVideo(
+                downloadId = 1L,
+                filePath = "/tmp/archive.bin",
+                fileExtension = "MKV",
+                sha256 = null,
+            ),
+            audio = null,
+            metadata = null,
+            progress = DownloadProgress(
+                downloadId = 1L,
+                updatedAtMillis = 10L,
+                progressPercent = 150f,
+                bytesDownloaded = 100L,
+                etaSeconds = 1L,
+                expectedBytes = 100L,
+            ),
+        )
+
+        assertEquals("MKV", result.video?.fileExtension)
+        assertEquals(1f, result.progress?.progressFraction)
+    }
+
+    @Test
+    fun toPageUiData_usesEmptyExtension_whenFileNameHasNoExtension_andClampsNegativeProgress() {
+        val result = sampleDownload().toPageUiData(
+            video = DownloadVideo(
+                downloadId = 1L,
+                filePath = "/tmp/readme",
+                fileExtension = "",
+                sha256 = null,
+            ),
+            audio = null,
+            metadata = null,
+            progress = DownloadProgress(
+                downloadId = 1L,
+                updatedAtMillis = 10L,
+                progressPercent = -25f,
+                bytesDownloaded = 0L,
+                etaSeconds = null,
+                expectedBytes = null,
+            ),
+        )
+
+        assertEquals("", result.video?.fileExtension)
+        assertEquals("readme", result.video?.fileName)
+        assertEquals(0f, result.progress?.progressFraction)
+    }
+
+    private fun sampleDownload(url: String = "https://example.com/video") = Download(
+        id = 1L,
+        uid = "uid-1",
+        url = url,
+        status = DownloadStatus.DOWNLOADING,
+        seen = false,
+        errorMessage = null,
+        completedAtMillis = null,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadStatusUiMappersTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadStatusUiMappersTest.kt
@@ -1,0 +1,26 @@
+package org.strigate.ferrot.presentation.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.presentation.model.DownloadStatusUiData
+
+class DownloadStatusUiMappersTest {
+    @Test
+    fun toUiData_mapsEveryDomainStatusToMatchingUiStatus() {
+        val mapped = DownloadStatus.entries.associateWith { it.toUiData() }
+
+        assertEquals(DownloadStatusUiData.QUEUED, mapped[DownloadStatus.QUEUED])
+        assertEquals(
+            DownloadStatusUiData.WAITING_FOR_NETWORK,
+            mapped[DownloadStatus.WAITING_FOR_NETWORK]
+        )
+        assertEquals(DownloadStatusUiData.WAITING_FOR_WIFI, mapped[DownloadStatus.WAITING_FOR_WIFI])
+        assertEquals(DownloadStatusUiData.METADATA, mapped[DownloadStatus.METADATA])
+        assertEquals(DownloadStatusUiData.DOWNLOADING, mapped[DownloadStatus.DOWNLOADING])
+        assertEquals(DownloadStatusUiData.PAUSED, mapped[DownloadStatus.PAUSED])
+        assertEquals(DownloadStatusUiData.COMPLETED, mapped[DownloadStatus.COMPLETED])
+        assertEquals(DownloadStatusUiData.FAILED, mapped[DownloadStatus.FAILED])
+        assertEquals(DownloadStatusUiData.STOPPED, mapped[DownloadStatus.STOPPED])
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadWithMetadataMappersTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadWithMetadataMappersTest.kt
@@ -1,0 +1,93 @@
+package org.strigate.ferrot.presentation.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.model.DownloadWithMetadata
+
+class DownloadWithMetadataMappersTest {
+    @Test
+    fun toUiData_prefersExpectedBytesBasedProgress_whenAvailable() {
+        val result = sampleDownloadWithMetadata(
+            bytesDownloaded = 75L,
+            expectedBytes = 50L,
+            progressPercent = 10f,
+        ).toUiData()
+
+        assertEquals(1f, result.progressFraction)
+    }
+
+    @Test
+    fun toUiData_fallsBackToProgressPercent_whenExpectedBytesAreUnavailable() {
+        val result = sampleDownloadWithMetadata(
+            bytesDownloaded = 75L,
+            expectedBytes = null,
+            progressPercent = 25f,
+        ).toUiData()
+
+        assertEquals(0.25f, result.progressFraction)
+    }
+
+    @Test
+    fun toUiData_returnsNullProgress_whenNoUsableProgressExists() {
+        val result = sampleDownloadWithMetadata(
+            bytesDownloaded = -1L,
+            expectedBytes = null,
+            progressPercent = -1f,
+        ).toUiData()
+
+        assertNull(result.progressFraction)
+    }
+
+    @Test
+    fun toUiData_fallsBackToProgressPercent_whenExpectedBytesIsZero() {
+        val result = sampleDownloadWithMetadata(
+            bytesDownloaded = 50L,
+            expectedBytes = 0L,
+            progressPercent = 40f,
+        ).toUiData()
+
+        assertEquals(0.4f, result.progressFraction)
+    }
+
+    @Test
+    fun toUiData_fallsBackToProgressPercent_whenBytesDownloadedIsNegative() {
+        val result = sampleDownloadWithMetadata(
+            bytesDownloaded = -5L,
+            expectedBytes = 100L,
+            progressPercent = 60f,
+        ).toUiData()
+
+        assertEquals(0.6f, result.progressFraction)
+    }
+
+    @Test
+    fun toUiData_clampsProgressPercentAboveHundred() {
+        val result = sampleDownloadWithMetadata(
+            bytesDownloaded = -1L,
+            expectedBytes = null,
+            progressPercent = 150f,
+        ).toUiData()
+
+        assertEquals(1f, result.progressFraction)
+    }
+
+    private fun sampleDownloadWithMetadata(
+        bytesDownloaded: Long,
+        expectedBytes: Long?,
+        progressPercent: Float,
+    ) = DownloadWithMetadata(
+        id = 1L,
+        url = "https://example.com/video",
+        title = "Title",
+        thumbnailFilePath = null,
+        status = DownloadStatus.DOWNLOADING,
+        seen = false,
+        progressPercent = progressPercent,
+        etaSeconds = 10L,
+        bytesDownloaded = bytesDownloaded,
+        expectedBytes = expectedBytes,
+        completedAtMillis = null,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/util/UiFormatterTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/util/UiFormatterTest.kt
@@ -1,0 +1,196 @@
+package org.strigate.ferrot.presentation.util
+
+import android.content.Context
+import android.text.format.DateFormat
+import android.text.format.DateUtils
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.`when`
+import org.strigate.ferrot.R
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Locale
+
+class UiFormatterTest {
+    private lateinit var originalLocale: Locale
+    private lateinit var originalZoneId: ZoneId
+
+    @Before
+    fun setUp() {
+        originalLocale = Locale.getDefault()
+        originalZoneId = ZoneId.systemDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(originalZoneId))
+    }
+
+    @Test
+    fun formatBytes_handlesZeroAndScaledValues() {
+        assertEquals("0 B", UiFormatter.formatBytes(0))
+        assertEquals("1.0 KB", UiFormatter.formatBytes(1024))
+        assertEquals("1.5 KB", UiFormatter.formatBytes(1536))
+        assertEquals("1.0 MB", UiFormatter.formatBytes(1024 * 1024))
+    }
+
+    @Test
+    fun formatEta_formatsHoursMinutesAndSeconds() {
+        assertNull(UiFormatter.formatEta(null))
+        assertNull(UiFormatter.formatEta(0))
+        assertEquals("59s", UiFormatter.formatEta(59))
+        assertEquals("2m 5s", UiFormatter.formatEta(125))
+        assertEquals("1h 1m", UiFormatter.formatEta(3665))
+    }
+
+    @Test
+    fun formatDuration_formatsMinuteAndHourDurations() {
+        assertNull(UiFormatter.formatDuration(null))
+        assertNull(UiFormatter.formatDuration(0))
+        assertEquals("0:59", UiFormatter.formatDuration(59))
+        assertEquals("1:05", UiFormatter.formatDuration(65))
+        assertEquals("1:01:05", UiFormatter.formatDuration(3665))
+    }
+
+    @Test
+    fun formatLastCheckedTime_returnsNever_whenMillisIsNotPositive() {
+        val context = mock(Context::class.java)
+        `when`(context.getString(R.string.never)).thenReturn("Never")
+
+        assertEquals("Never", UiFormatter.formatLastCheckedTime(context, 0L))
+    }
+
+    @Test
+    fun formatLastCheckedTime_combinesRelativeAndExactFormats() {
+        val context = mock(Context::class.java)
+        val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
+        val timeFormat = SimpleDateFormat("hh:mm a", Locale.US)
+        val millis = 1234L
+
+        mockStatic(DateUtils::class.java).use { dateUtilsMock ->
+            mockStatic(DateFormat::class.java).use { dateFormatMock ->
+                dateUtilsMock.`when`<CharSequence> {
+                    DateUtils.getRelativeTimeSpanString(anyLong(), anyLong(), anyLong(), anyInt())
+                }.thenReturn("moments ago")
+                dateFormatMock.`when`<java.text.DateFormat> { DateFormat.getMediumDateFormat(context) }
+                    .thenReturn(dateFormat)
+                dateFormatMock.`when`<java.text.DateFormat> { DateFormat.getTimeFormat(context) }
+                    .thenReturn(timeFormat)
+
+                val result = UiFormatter.formatLastCheckedTime(context, millis)
+                val exact = "${dateFormat.format(java.util.Date(millis))}, ${
+                    timeFormat.format(
+                        java.util.Date(millis)
+                    )
+                }"
+                assertEquals("moments ago ($exact)", result)
+            }
+        }
+    }
+
+    @Test
+    fun formatCompletedAtTime_returnsTimeOnly_forTodayIn24HourFormat() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"))
+        val context = mock(Context::class.java)
+        val millis = LocalDate.now(ZoneId.of("UTC"))
+            .atStartOfDay(ZoneId.of("UTC"))
+            .plusHours(13)
+            .plusMinutes(5)
+            .toInstant()
+            .toEpochMilli()
+
+        mockStatic(DateFormat::class.java).use { dateFormatMock ->
+            dateFormatMock.`when`<Boolean> { DateFormat.is24HourFormat(context) }.thenReturn(true)
+            dateFormatMock.`when`<String> {
+                DateFormat.getBestDateTimePattern(
+                    Locale.US,
+                    "EEE, MMM d"
+                )
+            }
+                .thenReturn("EEE, MMM d")
+
+            val result = UiFormatter.formatCompletedAtTime(context, millis)
+            assertEquals("13:05", result)
+        }
+    }
+
+    @Test
+    fun formatCompletedAtTime_includesDate_forNonTodayIn12HourFormat() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"))
+        val context = mock(Context::class.java)
+        val millis = LocalDate.now(ZoneId.of("UTC"))
+            .minusDays(1)
+            .atStartOfDay(ZoneId.of("UTC"))
+            .plusHours(1)
+            .plusMinutes(30)
+            .toInstant()
+            .toEpochMilli()
+
+        mockStatic(DateFormat::class.java).use { dateFormatMock ->
+            dateFormatMock.`when`<Boolean> { DateFormat.is24HourFormat(context) }
+                .thenReturn(false)
+            dateFormatMock.`when`<String> {
+                DateFormat.getBestDateTimePattern(
+                    Locale.US,
+                    "EEE, MMM d"
+                )
+            }
+                .thenReturn("EEE, MMM d")
+
+            val result = UiFormatter.formatCompletedAtTime(context, millis)
+            assertTrue(result.contains("AM"))
+            assertTrue(result.contains(","))
+        }
+    }
+
+    @Test
+    fun formatCompletedAtDetail_formats24HourDetail() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"))
+        val context = mock(Context::class.java)
+        val millis = LocalDate.of(2024, 1, 2)
+            .atStartOfDay(ZoneId.of("UTC"))
+            .plusHours(21)
+            .plusMinutes(45)
+            .toInstant()
+            .toEpochMilli()
+
+        mockStatic(DateFormat::class.java).use { dateFormatMock ->
+            dateFormatMock.`when`<Boolean> { DateFormat.is24HourFormat(context) }
+                .thenReturn(true)
+
+            val result = UiFormatter.formatCompletedAtDetail(context, millis)
+            assertEquals("2024-01-02 21:45", result)
+        }
+    }
+
+    @Test
+    fun formatCompletedAtDetail_formats12HourDetail() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("UTC"))
+        val context = mock(Context::class.java)
+        val millis = LocalDate.of(2024, 1, 2)
+            .atStartOfDay(ZoneId.of("UTC"))
+            .plusHours(21)
+            .plusMinutes(45)
+            .toInstant()
+            .toEpochMilli()
+
+        mockStatic(DateFormat::class.java).use { dateFormatMock ->
+            dateFormatMock.`when`<Boolean> { DateFormat.is24HourFormat(context) }
+                .thenReturn(false)
+
+            val result = UiFormatter.formatCompletedAtDetail(context, millis)
+            assertEquals("2024-01-02 09:45 PM", result)
+        }
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -227,10 +227,7 @@ class DownloadViewModelTest {
             waitForUiState(viewModel)
 
             assertEquals(30L, viewModel.selectedId.value)
-            assertEquals(
-                30L,
-                (viewModel.uiState.value as DownloadUiState.Data).data.id,
-            )
+            assertEquals(30L, (viewModel.uiState.value as DownloadUiState.Data).data.id)
 
             collector.cancel()
         }

--- a/app/src/test/kotlin/org/strigate/ferrot/util/HashUtilTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/util/HashUtilTest.kt
@@ -1,0 +1,25 @@
+package org.strigate.ferrot.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.nio.file.Files
+
+class HashUtilTest {
+    @Test
+    fun sha256_returnsNull_whenPathDoesNotPointToAFile() {
+        assertNull(sha256("/definitely/missing/file.txt"))
+    }
+
+    @Test
+    fun sha256_returnsExpectedDigest_forKnownFileContents() {
+        val file = Files.createTempFile("hash-util-test", ".txt")
+        Files.write(file, "hello world".toByteArray())
+
+        val result = sha256(file.toString())
+        assertEquals(
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+            result,
+        )
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/util/VersionsTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/util/VersionsTest.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.util
+
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VersionsTest {
+    @Test
+    fun sdkChecks_matchPlatformComparisons() {
+        assertEquals(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S, isAtLeastS())
+        assertEquals(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU, isAtLeastTiramisu())
+    }
+}


### PR DESCRIPTION
- Add `DownloadRepositoryImplTest`
- Add `DownloadVideoRepositoryImplTest`
- Add `DownloadAudioRepositoryImplTest`
- Add `DownloadMetadataRepositoryImplTest`
- Add `DownloadProgressRepositoryImplTest`
- Add `DownloadWithMetadataRepositoryImplTest`
- Add `DownloadWithMetadataMappersTest`
- Add `DownloadMappersTest`
- Add `DownloadStatusUiMappersTest`
- Add `UiFormatterTest`
- Add `HashUtilTest`
- Add `VersionsTest`
- Add `StringTest`

- Verify entity to domain mappings in repository implementations
- Verify DAO delegation behavior in repository methods
- Test Flow mapping behavior including `null` emissions
- Test filename, extension, MIME type, and sanitization helpers
- Test progress calculation and clamping logic
- Test UI mapping for `DownloadStatus`
- Test UI formatting utilities for bytes, ETA, duration, and timestamps
- Test SHA-256 hashing behavior for file paths
- Verify platform SDK helper functions