### PR TITLE
refactor: Set explicit surface color on `Surface` components

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
@@ -39,6 +39,7 @@ fun ExpandableSettingsSection(
     var expanded by remember { mutableStateOf(initialExpanded) }
     Surface(
         modifier = modifier,
+        color = MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
         tonalElevation = 4.dp,
         shadowElevation = 1.dp,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
@@ -22,6 +22,7 @@ fun StaticSettingsSection(
 ) {
     Surface(
         modifier = modifier,
+        color = MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
         tonalElevation = 4.dp,
         shadowElevation = 1.dp,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
@@ -32,6 +32,7 @@ fun TextNavigateSetting(
 ) {
     Surface(
         modifier = modifier,
+        color = MaterialTheme.colorScheme.surface,
         shape = MaterialTheme.shapes.medium,
         tonalElevation = 4.dp,
         shadowElevation = 1.dp,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -100,6 +101,7 @@ fun AboutScreen(
                 modifier = modifier
                     .fillMaxSize()
                     .padding(contentPadding),
+                color = MaterialTheme.colorScheme.surface,
             ) {
                 Column(
                     modifier = Modifier

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -78,6 +79,7 @@ fun SettingsScreen(
             Surface(
                 modifier = modifier
                     .padding(contentPadding),
+                color = MaterialTheme.colorScheme.surface,
             ) {
                 when (val state = uiState) {
                     is SettingsUiState.Loading -> {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -75,6 +76,7 @@ fun UpdatesScreen(
                 modifier = modifier
                     .fillMaxSize()
                     .padding(contentPadding),
+                color = MaterialTheme.colorScheme.surface,
             ) {
                 when (val state = uiState) {
                     is UpdatesUiState.Loading -> {


### PR DESCRIPTION
- Add `MaterialTheme` import where required
- Set `color = MaterialTheme.colorScheme.surface` on `Surface` in `UpdatesScreen`
- Set `color = MaterialTheme.colorScheme.surface` on `Surface` in `AboutScreen`
- Set `color = MaterialTheme.colorScheme.surface` on `Surface` in `SettingsScreen`
- Set `color = MaterialTheme.colorScheme.surface` on `Surface` in `StaticSettingsSection`
- Set `color = MaterialTheme.colorScheme.surface` on `Surface` in `ExpandableSettingsSection`
- Set `color = MaterialTheme.colorScheme.surface` on `Surface` in `TextNavigateSetting`