### PR TITLE
feat: Add restore animation for previously dismissed downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Ferrot is a clean and minimal downloader for video and audio on Android.
 
-When viewing a video or post on social media or in your browser, tap **Share** and choose **Ferrot**. Ferrot will try to download it straight to your device.
+Share a video or post from any app. Tap **Share** and pick **Ferrot**.
 
-Download videos from [1000+](https://ytdl-org.github.io/youtube-dl/supportedsites.html) sites supported by youtube-dl
+Download videos from [1000+](https://ytdl-org.github.io/youtube-dl/supportedsites.html) sites
+supported by youtube-dl
 
 ## Installation
-Download the latest APK from the [**Latest Release**](https://github.com/strigate/ferrot/releases/latest/download/ferrot-release.apk).
+Download the latest APK from the [**Latest Release
+**](https://github.com/strigate/ferrot/releases/latest/download/ferrot-release.apk).
 
 Previous versions are available on the [Releases page](https://github.com/strigate/ferrot/releases).
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -503,6 +503,11 @@ private fun DownloadsList(
     var previousPendingDeleteIds by remember {
         mutableStateOf<Set<Long>>(emptySet())
     }
+    val restoringItemIds = getRestoredItemIds(
+        previousPendingDeleteIds = previousPendingDeleteIds,
+        currentItemIds = itemIds,
+        currentPendingDeleteIds = pendingDeleteIds,
+    )
     val visibleCount by remember(items) {
         derivedStateOf {
             items.size
@@ -556,6 +561,7 @@ private fun DownloadsList(
                 DownloadsListRow(
                     item = item,
                     selectedIds = selectedIds,
+                    isRestoring = item.id in restoringItemIds,
                     onItemClick = onItemClick,
                     onPauseResume = { clickedItem ->
                         if (selectedIds.isNotEmpty()) {
@@ -606,6 +612,7 @@ private fun DownloadsListRow(
     item: DownloadItemUiData,
     selectedIds: Set<Long>,
     isPendingDismiss: Boolean,
+    isRestoring: Boolean,
     onItemClick: (DownloadItemUiData) -> Unit,
     onPauseResume: (DownloadItemUiData) -> Unit,
     onSelectionChange: (Set<Long>) -> Unit,
@@ -613,13 +620,19 @@ private fun DownloadsListRow(
     onDismissAnimationFinished: (Long) -> Unit,
 ) {
     val dimens = LocalDimens.current
+
     val isSelected = selectedIds.contains(item.id)
     val dismissState = rememberSwipeToDismissBoxState()
     var rowWidthPx by remember { mutableFloatStateOf(0f) }
-    val visibilityState = remember(item.id) { MutableTransitionState<Boolean>(true) }
+    val visibilityState = remember(item.id) {
+        MutableTransitionState(!isRestoring)
+    }
 
-    LaunchedEffect(isPendingDismiss) {
+    LaunchedEffect(isPendingDismiss, isRestoring) {
         visibilityState.targetState = !isPendingDismiss
+        if (isRestoring) {
+            visibilityState.targetState = true
+        }
         if (!isPendingDismiss) {
             runCatching {
                 dismissState.snapTo(SwipeToDismissBoxValue.Settled)
@@ -788,6 +801,19 @@ internal fun hasNewItemAtTop(
     }
     val previousIdsSet = previousItemIds.toSet()
     return currentItemIds.any { it !in previousIdsSet && it !in previousPendingDeleteIds }
+}
+
+internal fun getRestoredItemIds(
+    previousPendingDeleteIds: Set<Long>,
+    currentItemIds: List<Long>,
+    currentPendingDeleteIds: Set<Long>,
+): Set<Long> {
+    if (previousPendingDeleteIds.isEmpty()) {
+        return emptySet()
+    }
+    return previousPendingDeleteIds
+        .intersect(currentItemIds.toSet())
+        .minus(currentPendingDeleteIds)
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,8 +25,8 @@
     <string name="screen_title_updates">Updates</string>
     <string name="screen_title_about">About</string>
 
-    <string name="downloads_intro_title">Share to %1$s</string>
-    <string name="downloads_intro_body">When viewing a video or post on social media or in your browser, tap Share and choose %1$s. %1$s will try to download it straight to your device and list it here.</string>
+    <string name="downloads_intro_title">No downloads yet</string>
+    <string name="downloads_intro_body">Share a video or post from any app. Tap Share and pick %1$s.</string>
 
     <string name="available_update_ready">Update %1$s is ready to install</string>
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
@@ -1,5 +1,6 @@
 package org.strigate.ferrot.presentation.screen
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -75,5 +76,16 @@ class DownloadsScreenScrollBehaviorTest {
         )
 
         assertFalse(shouldScroll)
+    }
+
+    @Test
+    fun getRestoredItemIds_returnsOnlyDownloadsThatWerePendingDeleteAndAreVisibleAgain() {
+        val restoredIds = getRestoredItemIds(
+            previousPendingDeleteIds = setOf(2L, 3L, 4L),
+            currentItemIds = listOf(1L, 2L, 4L, 5L),
+            currentPendingDeleteIds = setOf(4L),
+        )
+
+        assertEquals(setOf(2L), restoredIds)
     }
 }


### PR DESCRIPTION
- Add `getRestoredItemIds` to detect restored downloads
- Pass `isRestoring` to `DownloadsListRow`
- Update `DownloadsListRow` to handle restoring visibility state
- Initialize `visibilityState` based on `isRestoring`
- Update `LaunchedEffect` to support restore animation behavior
- Add test `getRestoredItemIds_returnsOnlyDownloadsThatWerePendingDeleteAndAreVisibleAgain`
- Update downloads intro strings to simplified copy
- Update README intro and installation formatting