### PR TITLE
refactor: Align data layer naming

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/AvailableUpdateDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/AvailableUpdateDao.kt
@@ -13,7 +13,7 @@ interface AvailableUpdateDao {
     fun get(): Flow<AvailableUpdateEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertReplace(row: AvailableUpdateEntity)
+    suspend fun insertReplace(availableUpdateEntity: AvailableUpdateEntity)
 
     @Query("DELETE FROM available_update")
     suspend fun delete(): Int

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadAudioDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadAudioDao.kt
@@ -10,7 +10,7 @@ import org.strigate.ferrot.data.local.entity.DownloadAudioEntity
 @Dao
 interface DownloadAudioDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertReplace(entity: DownloadAudioEntity): Long
+    suspend fun insertReplace(downloadAudioEntity: DownloadAudioEntity): Long
 
     @Query("SELECT * FROM download_audio WHERE downloadId = :downloadId LIMIT 1")
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadAudioEntity?>

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadVideoDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadVideoDao.kt
@@ -10,7 +10,7 @@ import org.strigate.ferrot.data.local.entity.DownloadVideoEntity
 @Dao
 interface DownloadVideoDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertReplace(entity: DownloadVideoEntity): Long
+    suspend fun insertReplace(downloadVideoEntity: DownloadVideoEntity): Long
 
     @Query("SELECT * FROM download_video WHERE downloadId = :downloadId LIMIT 1")
     fun getByDownloadIdAsFlow(downloadId: Long): Flow<DownloadVideoEntity?>

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImpl.kt
@@ -20,8 +20,8 @@ class AvailableUpdateRepositoryImpl @Inject constructor(
             .map { it?.toDomain() }
     }
 
-    override suspend fun save(update: AvailableUpdate) {
-        availableUpdateDao.insertReplace(update.toEntity())
+    override suspend fun save(availableUpdate: AvailableUpdate) {
+        availableUpdateDao.insertReplace(availableUpdate.toEntity())
     }
 
     override suspend fun delete(): Int {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/repository/AvailableUpdateRepository.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/repository/AvailableUpdateRepository.kt
@@ -5,6 +5,6 @@ import org.strigate.ferrot.domain.model.AvailableUpdate
 
 interface AvailableUpdateRepository {
     fun getAsFlow(): Flow<AvailableUpdate?>
-    suspend fun save(update: AvailableUpdate)
+    suspend fun save(availableUpdate: AvailableUpdate)
     suspend fun delete(): Int
 }


### PR DESCRIPTION
- Rename generic DAO insert parameters to descriptive entity names
- Rename `AvailableUpdateRepository.save` parameter to `availableUpdate`