### PR TITLE
feat: Handle bulk delete differently for visible and hidden items

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -244,7 +244,15 @@ fun DownloadsScreen(
                         }
                         IconButton(
                             onClick = {
-                                dismissingIds = dismissingIds + selectedIds
+                                val visibleSelectedIds = getBulkDeleteVisibleIds(
+                                    selectedIds = selectedIds,
+                                    visibleItemKeys = lazyListState.layoutInfo.visibleItemsInfo.map { it.key },
+                                )
+                                val hiddenSelectedIds = selectedIds - visibleSelectedIds
+                                dismissingIds = dismissingIds + visibleSelectedIds
+                                if (hiddenSelectedIds.isNotEmpty()) {
+                                    viewModel.markDownloadsPendingDelete(hiddenSelectedIds)
+                                }
                                 selectedIds = emptySet()
                             },
                         ) {
@@ -982,6 +990,20 @@ private fun toggleSelection(selectedIds: Set<Long>, itemId: Long): Set<Long> {
     } else {
         selectedIds + itemId
     }
+}
+
+internal fun getBulkDeleteVisibleIds(
+    selectedIds: Set<Long>,
+    visibleItemKeys: List<Any>,
+): Set<Long> {
+    if (selectedIds.isEmpty() || visibleItemKeys.isEmpty()) {
+        return emptySet()
+    }
+    val visibleIds = visibleItemKeys
+        .mapNotNull { it as? Long }
+        .toSet()
+
+    return selectedIds.intersect(visibleIds)
 }
 
 internal fun hasNewItemAtTop(

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
@@ -7,6 +7,26 @@ import org.junit.Test
 
 class DownloadsScreenScrollBehaviorTest {
     @Test
+    fun getBulkDeleteVisibleIds_returnsOnlySelectedIdsThatAreCurrentlyVisible() {
+        val visibleSelectedIds = getBulkDeleteVisibleIds(
+            selectedIds = setOf(1L, 2L, 3L, 4L),
+            visibleItemKeys = listOf(9L, 3L, "header", 1L),
+        )
+
+        assertEquals(setOf(1L, 3L), visibleSelectedIds)
+    }
+
+    @Test
+    fun getBulkDeleteVisibleIds_returnsEmptySet_whenNothingSelectedIsVisible() {
+        val visibleSelectedIds = getBulkDeleteVisibleIds(
+            selectedIds = setOf(1L, 2L),
+            visibleItemKeys = listOf(9L, 8L),
+        )
+
+        assertTrue(visibleSelectedIds.isEmpty())
+    }
+
+    @Test
     fun hasNewItemAtTop_returnsTrue_whenNewItemIsInsertedAtTop() {
         val shouldScroll = hasNewItemAtTop(
             previousItemIds = listOf(3L, 2L, 1L),


### PR DESCRIPTION
- Add `getBulkDeleteVisibleIds` to determine which selected items are currently visible
- Update bulk delete click handler to animate dismissal only for visible items
- Mark non-visible selected items as pending delete via `viewModel.markDownloadsPendingDelete`
- Add tests for `getBulkDeleteVisibleIds` covering visible and non-visible scenarios