### PR TITLE
refactor: Expand PathProvider methods into block bodies

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/provider/DownloadPathProvider.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/provider/DownloadPathProvider.kt
@@ -16,6 +16,11 @@ interface DownloadPathProvider {
 class DownloadPathProviderImpl @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
 ) : DownloadPathProvider {
-    override fun outputDir(): File = File(appContext.filesDir, DOWNLOADS).apply { mkdirs() }
-    override fun uidDir(uid: String): File = File(outputDir(), uid).apply { mkdirs() }
+    override fun outputDir(): File {
+        return File(appContext.filesDir, DOWNLOADS).apply { mkdirs() }
+    }
+
+    override fun uidDir(uid: String): File {
+        return File(outputDir(), uid).apply { mkdirs() }
+    }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/provider/UpdatePathProvider.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/provider/UpdatePathProvider.kt
@@ -16,6 +16,11 @@ interface UpdatePathProvider {
 class UpdatePathProviderImpl @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
 ) : UpdatePathProvider {
-    override fun updatesDir(): File = File(appContext.filesDir, UPDATES).apply { mkdirs() }
-    override fun apkFileFor(tag: String): File = File(updatesDir(), "ferrot-$tag.apk")
+    override fun updatesDir(): File {
+        return File(appContext.filesDir, UPDATES).apply { mkdirs() }
+    }
+
+    override fun apkFileFor(tag: String): File {
+        return File(updatesDir(), "ferrot-$tag.apk")
+    }
 }


### PR DESCRIPTION
- Convert `updatesDir` to block body with explicit `return`
- Convert `apkFileFor` to block body with explicit `return`
- Convert `outputDir` to block body with explicit `return`
- Convert `uidDir` to block body with explicit `return`