### PR TITLE
feat: Add download notification actions and delayed delete flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,11 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".app.receiver.DownloadNotificationActionReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -30,6 +30,10 @@ object Constants {
     }
 
     object Notifications {
+        object Ids {
+            const val ID_ACTIVE_DOWNLOAD_FOREGROUND = 1
+        }
+
         object ChannelGroups {
             private const val CHANNEL_GROUP_ID = "$APP_ID.notification.channel.group.id"
             const val CHANNEL_GROUP_ID_FOREGROUND = "$CHANNEL_GROUP_ID.FOREGROUND"
@@ -75,6 +79,8 @@ object Constants {
                 "$ONETIME.DELETE_DOWNLOADS"
             const val ONETIME_DELETE_PENDING_DOWNLOADS_DELAYED =
                 "$ONETIME.DELETE_PENDING_DOWNLOADS_DELAYED"
+            const val ONETIME_DELETE_PENDING_DOWNLOAD_DELAYED =
+                "$ONETIME.DELETE_PENDING_DOWNLOAD_DELAYED"
             const val ONETIME_DELETE_PENDING_DOWNLOADS_IMMEDIATE =
                 "$ONETIME.DELETE_PENDING_DOWNLOADS_IMMEDIATE"
             const val ONETIME_DELETE_DUPLICATE_DOWNLOADS =
@@ -112,6 +118,7 @@ object Constants {
         private const val EXTRA = "$APP_ID.intent.extra"
 
         const val EXTRA_ACTION = "$EXTRA.ACTION"
+        const val EXTRA_NOTIFICATION_ACTION = "$EXTRA.NOTIFICATION_ACTION"
         const val EXTRA_AVAILABLE_UPDATE_APK_FILE_PATH = "$EXTRA.AVAILABLE_UPDATE_APK_FILE_PATH"
         const val EXTRA_AVAILABLE_UPDATE_VERSION_TAG = "$EXTRA.AVAILABLE_UPDATE_VERSION_TAG"
 
@@ -127,5 +134,6 @@ object Constants {
         const val ACTION_INSTALL_AVAILABLE_UPDATE = "$ACTION.INSTALL_AVAILABLE_UPDATE"
         const val ACTION_START_DOWNLOAD_FROM_SHARE = "$ACTION.START_DOWNLOAD_FROM_SHARE"
         const val ACTION_NAVIGATE_DOWNLOAD = "$ACTION.NAVIGATE_DOWNLOAD"
+        const val ACTION_DOWNLOAD_NOTIFICATION = "$ACTION.DOWNLOAD_NOTIFICATION"
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
@@ -4,7 +4,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
-import androidx.work.WorkManager
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.Action.ACTION_DOWNLOAD_NOTIFICATION
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
@@ -12,7 +11,6 @@ import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_NOTIFICATION_ACTION
 import org.strigate.ferrot.app.receiver.DownloadNotificationActionReceiver
-import java.util.UUID
 
 enum class DownloadNotificationActionType {
     MARK_SEEN,
@@ -58,16 +56,5 @@ fun buildDownloadNotificationAction(
         R.drawable.ic_logo,
         context.getString(titleResource),
         pendingIntent,
-    ).build()
-}
-
-fun buildCancelDownloadNotificationAction(
-    context: Context,
-    workId: UUID,
-): NotificationCompat.Action {
-    return NotificationCompat.Action.Builder(
-        R.drawable.ic_logo,
-        context.getString(R.string.notification_action_stop),
-        WorkManager.getInstance(context).createCancelPendingIntent(workId),
     ).build()
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
@@ -4,6 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import androidx.work.WorkManager
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.Action.ACTION_DOWNLOAD_NOTIFICATION
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
@@ -11,6 +12,7 @@ import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_NOTIFICATION_ACTION
 import org.strigate.ferrot.app.receiver.DownloadNotificationActionReceiver
+import java.util.UUID
 
 enum class DownloadNotificationActionType {
     MARK_SEEN,
@@ -56,5 +58,16 @@ fun buildDownloadNotificationAction(
         R.drawable.ic_logo,
         context.getString(titleResource),
         pendingIntent,
+    ).build()
+}
+
+fun buildCancelDownloadNotificationAction(
+    context: Context,
+    workId: UUID,
+): NotificationCompat.Action {
+    return NotificationCompat.Action.Builder(
+        R.drawable.ic_logo,
+        context.getString(R.string.notification_action_stop),
+        WorkManager.getInstance(context).createCancelPendingIntent(workId),
     ).build()
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
@@ -1,0 +1,60 @@
+package org.strigate.ferrot.app
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import org.strigate.ferrot.R
+import org.strigate.ferrot.app.Constants.Action.ACTION_DOWNLOAD_NOTIFICATION
+import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_NOTIFICATION_ACTION
+import org.strigate.ferrot.app.receiver.DownloadNotificationActionReceiver
+
+enum class DownloadNotificationActionType {
+    MARK_SEEN,
+    DELETE,
+    UNDO_DELETE,
+    RETRY,
+    STOP,
+}
+
+fun downloadNotificationTag(downloadId: Long): String = "download:$downloadId"
+
+fun activeDownloadNotificationTag(downloadId: Long): String = "active-download:$downloadId"
+
+fun downloadNotificationExtras(downloadId: Long): Map<String, String> = mapOf(
+    EXTRA_ACTION to ACTION_NAVIGATE_DOWNLOAD,
+    EXTRA_DOWNLOAD_ID to downloadId.toString(),
+)
+
+fun buildDownloadNotificationAction(
+    context: Context,
+    downloadId: Long,
+    actionType: DownloadNotificationActionType,
+): NotificationCompat.Action {
+    val titleResource = when (actionType) {
+        DownloadNotificationActionType.MARK_SEEN -> R.string.notification_action_mark_seen
+        DownloadNotificationActionType.DELETE -> R.string.notification_action_delete
+        DownloadNotificationActionType.UNDO_DELETE -> R.string.notification_action_undo
+        DownloadNotificationActionType.RETRY -> R.string.notification_action_retry
+        DownloadNotificationActionType.STOP -> R.string.notification_action_stop
+    }
+    val intent = Intent(context, DownloadNotificationActionReceiver::class.java).apply {
+        action = ACTION_DOWNLOAD_NOTIFICATION
+        putExtra(EXTRA_DOWNLOAD_ID, downloadId.toString())
+        putExtra(EXTRA_NOTIFICATION_ACTION, actionType.name)
+    }
+    val pendingIntent = PendingIntent.getBroadcast(
+        context,
+        (downloadId.toString() + actionType.name).hashCode(),
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+    return NotificationCompat.Action.Builder(
+        R.drawable.ic_logo,
+        context.getString(titleResource),
+        pendingIntent,
+    ).build()
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
@@ -26,6 +26,7 @@ abstract class ForegroundCoroutineWorker(
         indeterminate: Boolean = false,
         contentText: String? = null,
         extras: Map<String, String>? = null,
+        actions: List<NotificationCompat.Action> = emptyList(),
     ) {
         currentNotificationId = notificationId
         currentExtras = extras
@@ -37,6 +38,7 @@ abstract class ForegroundCoroutineWorker(
                 indeterminate = indeterminate,
                 contentText = contentText,
                 extras = extras,
+                actions = actions,
             ),
         )
     }
@@ -47,6 +49,7 @@ abstract class ForegroundCoroutineWorker(
         indeterminate: Boolean = false,
         contentText: String? = null,
         extras: Map<String, String>? = null,
+        actions: List<NotificationCompat.Action> = emptyList(),
     ) {
         if (extras != null) {
             currentExtras = extras
@@ -59,6 +62,7 @@ abstract class ForegroundCoroutineWorker(
                 indeterminate = indeterminate,
                 contentText = contentText,
                 extras = currentExtras,
+                actions = actions,
             ),
         )
     }
@@ -70,6 +74,7 @@ abstract class ForegroundCoroutineWorker(
         indeterminate: Boolean = false,
         contentText: String? = null,
         extras: Map<String, String>? = null,
+        actions: List<NotificationCompat.Action> = emptyList(),
     ): ForegroundInfo {
         val intent = Intent(context, MainActivity::class.java).apply {
             extras?.forEach { (key, value) ->
@@ -91,6 +96,7 @@ abstract class ForegroundCoroutineWorker(
             .setContentTitle(notificationText)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
+            .setOnlyAlertOnce(true)
 
         if (contentText != null) {
             builder.setContentText(contentText)
@@ -98,6 +104,10 @@ abstract class ForegroundCoroutineWorker(
                 NotificationCompat.BigTextStyle().bigText(contentText),
             )
         }
+        extras?.forEach { (key, value) ->
+            builder.extras.putString(key, value)
+        }
+        actions.forEach(builder::addAction)
         if (progress != null || indeterminate) {
             builder.setProgress(100, progress?.coerceIn(0, 100) ?: 0, indeterminate)
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
@@ -1,5 +1,6 @@
 package org.strigate.ferrot.app
 
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
@@ -18,6 +19,10 @@ abstract class ForegroundCoroutineWorker(
 ) : CoroutineWorker(context, workerParameters) {
     private var currentNotificationId: Long = 1L
     private var currentExtras: Map<String, String>? = null
+
+    private fun notificationManager(): NotificationManager {
+        return context.getSystemService(NotificationManager::class.java)
+    }
 
     suspend fun enableForeground(
         notificationId: Long = 1,
@@ -88,6 +93,10 @@ abstract class ForegroundCoroutineWorker(
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
+        val existingNotification = notificationManager()
+            .activeNotifications
+            .firstOrNull { it.id == id.toInt() }
+            ?.notification
         val builder = NotificationCompat.Builder(context, CHANNEL_ID_ACTIVE_TASKS)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
@@ -97,6 +106,7 @@ abstract class ForegroundCoroutineWorker(
             .setOngoing(true)
             .setContentIntent(pendingIntent)
             .setOnlyAlertOnce(true)
+            .setShowWhen(existingNotification?.`when`?.let { it > 0L } ?: true)
 
         if (contentText != null) {
             builder.setContentText(contentText)
@@ -104,6 +114,10 @@ abstract class ForegroundCoroutineWorker(
                 NotificationCompat.BigTextStyle().bigText(contentText),
             )
         }
+        existingNotification?.`when`
+            ?.takeIf { it > 0L }
+            ?.let(builder::setWhen)
+        existingNotification?.sortKey?.let(builder::setSortKey)
         extras?.forEach { (key, value) ->
             builder.extras.putString(key, value)
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
@@ -13,6 +13,7 @@ import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_ACTIV
 import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_DOWNLOADED
 import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_UPDATES
 import org.strigate.ferrot.app.Constants.Notifications.Groups.GROUP_ID_DOWNLOADED
+import org.strigate.ferrot.util.NotificationOps.cancel
 import org.strigate.ferrot.util.NotificationOps.createNotificationChannel
 import org.strigate.ferrot.util.NotificationOps.createNotificationChannelGroup
 import org.strigate.ferrot.util.NotificationOps.deleteNotificationChannelGroupsOtherThan
@@ -95,11 +96,47 @@ class NotificationService @Inject constructor(
         )
     }
 
+    fun notifyActiveDownload(
+        contentTitle: String,
+        contentText: String,
+        extras: Map<String, String> = emptyMap(),
+        tag: String? = null,
+        actions: List<NotificationCompat.Action> = emptyList(),
+        notificationId: Int? = null,
+        progress: Int? = null,
+        indeterminate: Boolean = false,
+    ) {
+        notify(
+            context = appContext,
+            channelId = CHANNEL_ID_ACTIVE_TASKS,
+            groupId = null,
+            summaryTitleResource = R.string.notification_download_title,
+            contentTitle = contentTitle,
+            contentText = contentText,
+            colorResource = R.color.coral,
+            iconResource = R.drawable.ic_logo,
+            largeIcon = null,
+            priority = NotificationCompat.PRIORITY_HIGH,
+            tag = tag,
+            extras = extras,
+            actions = actions,
+            notificationId = notificationId,
+            autoCancel = false,
+            ongoing = true,
+            progress = progress,
+            indeterminate = indeterminate,
+        )
+    }
+
     fun notifyDownloaded(
         contentTitle: String,
         contentText: String,
         extras: Map<String, String> = emptyMap(),
         tag: String? = null,
+        actions: List<NotificationCompat.Action> = emptyList(),
+        notificationId: Int? = null,
+        autoCancel: Boolean = true,
+        ongoing: Boolean = false,
     ) {
         notify(
             context = appContext,
@@ -114,6 +151,21 @@ class NotificationService @Inject constructor(
             priority = NotificationCompat.PRIORITY_HIGH,
             tag = tag,
             extras = extras,
+            actions = actions,
+            notificationId = notificationId,
+            autoCancel = autoCancel,
+            ongoing = ongoing,
+        )
+    }
+
+    fun clearNotification(
+        notificationId: Int,
+        tag: String? = null,
+    ) {
+        cancel(
+            context = appContext,
+            notificationId = notificationId,
+            tag = tag,
         )
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -21,9 +21,11 @@ import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.domain.usecase.combined.GetPendingDownloadsCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
+import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.work.DeleteAllDuplicateDownloadsWorker
 import org.strigate.ferrot.work.DeleteAllOrphanDownloadFilesWorker
 import org.strigate.ferrot.work.DeleteDownloadsWorker
+import org.strigate.ferrot.work.DeletePendingDownloadDelayedWorker
 import org.strigate.ferrot.work.DeletePendingDownloadsDelayedWorker
 import org.strigate.ferrot.work.DeletePendingDownloadsImmediateWorker
 import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
@@ -44,6 +46,7 @@ class WorkerFactory @Inject constructor(
     private val downloadPathProvider: DownloadPathProvider,
     private val availableUpdateUseCase: AvailableUpdateUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
+    private val stopDownloadUseCase: StopDownloadUseCase,
     private val getPendingDownloadsCombinedUseCase: GetPendingDownloadsCombinedUseCase,
     private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
     private val youtubeDlAndroidUseCase: YoutubeDlAndroidUseCase,
@@ -110,6 +113,7 @@ class WorkerFactory @Inject constructor(
                     appContext = appContext,
                     workerParameters = workerParameters,
                     deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
+                    stopDownloadUseCase = stopDownloadUseCase,
                 )
             }
 
@@ -119,6 +123,7 @@ class WorkerFactory @Inject constructor(
                     workerParameters = workerParameters,
                     downloadUseCase = downloadUseCase,
                     deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
+                    stopDownloadUseCase = stopDownloadUseCase,
                 )
             }
 
@@ -128,6 +133,17 @@ class WorkerFactory @Inject constructor(
                     workerParameters = workerParameters,
                     downloadUseCase = downloadUseCase,
                     deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
+                    stopDownloadUseCase = stopDownloadUseCase,
+                )
+            }
+
+            DeletePendingDownloadDelayedWorker::class.java.name -> {
+                DeletePendingDownloadDelayedWorker(
+                    appContext = appContext,
+                    workerParameters = workerParameters,
+                    downloadUseCase = downloadUseCase,
+                    deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
+                    stopDownloadUseCase = stopDownloadUseCase,
                 )
             }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
@@ -1,0 +1,238 @@
+package org.strigate.ferrot.app.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.strigate.ferrot.R
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_NOTIFICATION_ACTION
+import org.strigate.ferrot.app.DownloadNotificationActionType
+import org.strigate.ferrot.app.DownloadNotificationActionType.DELETE
+import org.strigate.ferrot.app.DownloadNotificationActionType.MARK_SEEN
+import org.strigate.ferrot.app.DownloadNotificationActionType.RETRY
+import org.strigate.ferrot.app.DownloadNotificationActionType.STOP
+import org.strigate.ferrot.app.DownloadNotificationActionType.UNDO_DELETE
+import org.strigate.ferrot.app.NotificationService
+import org.strigate.ferrot.app.activeDownloadNotificationTag
+import org.strigate.ferrot.app.buildDownloadNotificationAction
+import org.strigate.ferrot.app.downloadNotificationExtras
+import org.strigate.ferrot.app.downloadNotificationTag
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
+import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class DownloadNotificationActionReceiver : BroadcastReceiver() {
+    @Inject
+    @ApplicationContext
+    lateinit var appContext: Context
+
+    @Inject
+    lateinit var notificationService: NotificationService
+
+    @Inject
+    lateinit var downloadUseCase: DownloadUseCase
+
+    @Inject
+    lateinit var downloadMetadataUseCase: DownloadMetadataUseCase
+
+    @Inject
+    lateinit var downloadProgressUseCase: DownloadProgressUseCase
+
+    @Inject
+    lateinit var startDownloadUseCase: StartDownloadUseCase
+
+    @Inject
+    lateinit var stopDownloadUseCase: StopDownloadUseCase
+
+    @Inject
+    lateinit var clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val downloadId = intent.getStringExtra(EXTRA_DOWNLOAD_ID)?.toLongOrNull()
+                val action = intent.getStringExtra(EXTRA_NOTIFICATION_ACTION)
+                    ?.let { runCatching { DownloadNotificationActionType.valueOf(it) }.getOrNull() }
+
+                if (downloadId == null || downloadId <= 0L || action == null) {
+                    return@launch
+                }
+                when (action) {
+                    MARK_SEEN -> handleMarkSeen(downloadId)
+                    DELETE -> handleDelete(downloadId)
+                    UNDO_DELETE -> handleUndoDelete(downloadId)
+                    RETRY -> handleRetry(downloadId)
+                    STOP -> handleStop(downloadId)
+                }
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private suspend fun handleMarkSeen(downloadId: Long) {
+        downloadUseCase.updateDownloadsSeenUseCase(setOf(downloadId), seen = true)
+        clearNotificationsByDownloadIdUseCase(downloadId)
+    }
+
+    private suspend fun handleDelete(downloadId: Long) {
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return
+        downloadUseCase.updateDownloadsPendingDeleteUseCase(setOf(downloadId), pendingDelete = true)
+        downloadUseCase.requestDeletePendingDownloadDelayedUseCase(downloadId)
+        showDeletePendingNotification(download)
+    }
+
+    private suspend fun handleUndoDelete(downloadId: Long) {
+        downloadUseCase.updateDownloadsPendingDeleteUseCase(
+            setOf(downloadId),
+            pendingDelete = false
+        )
+        showNotificationForDownload(downloadId)
+    }
+
+    private suspend fun handleRetry(downloadId: Long) {
+        clearNotificationsByDownloadIdUseCase(downloadId)
+        startDownloadUseCase(downloadId)
+    }
+
+    private suspend fun handleStop(downloadId: Long) {
+        runCatching {
+            downloadUseCase.updateDownloadStatusUseCase(downloadId, DownloadStatus.STOPPED)
+            downloadProgressUseCase.updateDownloadProgressUseCase(
+                id = downloadId,
+                progressPercent = 0F,
+                bytesDownloaded = 0L,
+                etaSeconds = null,
+            )
+        }
+        val tag = activeDownloadNotificationTag(downloadId)
+        notificationService.clearNotification(
+            notificationId = tag.hashCode(),
+            tag = tag,
+        )
+        stopDownloadUseCase(downloadId)
+    }
+
+    private suspend fun showNotificationForDownload(downloadId: Long) {
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return
+        when (download.status) {
+            DownloadStatus.COMPLETED -> showCompletedNotification(download)
+            DownloadStatus.FAILED -> showFailedNotification(download)
+            DownloadStatus.METADATA,
+            DownloadStatus.DOWNLOADING -> Unit
+
+            else -> clearNotificationsByDownloadIdUseCase(downloadId)
+        }
+    }
+
+    private suspend fun showCompletedNotification(download: Download) {
+        notificationService.notifyDownloaded(
+            contentTitle = appContext.getString(R.string.download_complete),
+            contentText = notificationText(download),
+            extras = downloadNotificationExtras(download.id),
+            tag = downloadNotificationTag(download.id),
+            actions = buildCompletedActions(download),
+        )
+    }
+
+    private suspend fun showFailedNotification(download: Download) {
+        notificationService.notifyDownloaded(
+            contentTitle = appContext.getString(R.string.download_failed),
+            contentText = notificationText(download),
+            extras = downloadNotificationExtras(download.id),
+            tag = downloadNotificationTag(download.id),
+            actions = buildFailedActions(download),
+        )
+    }
+
+    private fun showDeletePendingNotification(download: Download) {
+        if (download.status == DownloadStatus.METADATA || download.status == DownloadStatus.DOWNLOADING) {
+            return
+        }
+        val actions = listOf(
+            buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = download.id,
+                actionType = UNDO_DELETE,
+            ),
+        )
+        notificationService.notifyDownloaded(
+            contentTitle = appContext.getString(R.string.notification_deleted_title),
+            contentText = "",
+            extras = downloadNotificationExtras(download.id),
+            tag = downloadNotificationTag(download.id),
+            actions = actions,
+        )
+    }
+
+    private fun buildCompletedActions(download: Download): List<NotificationCompat.Action> {
+        if (download.pendingDelete) {
+            return listOf(
+                buildDownloadNotificationAction(
+                    context = appContext,
+                    downloadId = download.id,
+                    actionType = UNDO_DELETE,
+                ),
+            )
+        }
+        val actions = mutableListOf<NotificationCompat.Action>()
+        if (!download.seen) {
+            actions += buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = download.id,
+                actionType = MARK_SEEN,
+            )
+        }
+        actions += buildDownloadNotificationAction(
+            context = appContext,
+            downloadId = download.id,
+            actionType = DELETE,
+        )
+        return actions
+    }
+
+    private fun buildFailedActions(download: Download): List<NotificationCompat.Action> {
+        if (download.pendingDelete) {
+            return listOf(
+                buildDownloadNotificationAction(
+                    context = appContext,
+                    downloadId = download.id,
+                    actionType = UNDO_DELETE,
+                ),
+            )
+        }
+        return listOf(
+            buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = download.id,
+                actionType = RETRY,
+            ),
+            buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = download.id,
+                actionType = DELETE,
+            ),
+        )
+    }
+
+    private suspend fun notificationText(download: Download): String {
+        val metadata = downloadMetadataUseCase
+            .getDownloadMetadataByIdAsFlowUseCase(download.id).first()
+        return metadata?.title?.takeIf { it.isNotBlank() } ?: download.url
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
@@ -20,7 +20,6 @@ import org.strigate.ferrot.app.DownloadNotificationActionType.RETRY
 import org.strigate.ferrot.app.DownloadNotificationActionType.STOP
 import org.strigate.ferrot.app.DownloadNotificationActionType.UNDO_DELETE
 import org.strigate.ferrot.app.NotificationService
-import org.strigate.ferrot.app.activeDownloadNotificationTag
 import org.strigate.ferrot.app.buildDownloadNotificationAction
 import org.strigate.ferrot.app.downloadNotificationExtras
 import org.strigate.ferrot.app.downloadNotificationTag
@@ -120,11 +119,6 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
                 etaSeconds = null,
             )
         }
-        val tag = activeDownloadNotificationTag(downloadId)
-        notificationService.clearNotification(
-            notificationId = tag.hashCode(),
-            tag = tag,
-        )
         stopDownloadUseCase(downloadId)
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/DownloadUseCase.kt
@@ -6,6 +6,7 @@ import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeleteDownloadsUseCase
+import org.strigate.ferrot.domain.usecase.download.RequestDeletePendingDownloadDelayedUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeletePendingDownloadsDelayedUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeletePendingDownloadsImmediateUseCase
 import org.strigate.ferrot.domain.usecase.download.SaveDownloadUseCase
@@ -29,6 +30,7 @@ class DownloadUseCase @Inject constructor(
     val updateDownloadStartedAtUseCase: UpdateDownloadStartedAtUseCase,
     val updateDownloadStatusUseCase: UpdateDownloadStatusUseCase,
     val requestDeleteDownloadsUseCase: RequestDeleteDownloadsUseCase,
+    val requestDeletePendingDownloadDelayedUseCase: RequestDeletePendingDownloadDelayedUseCase,
     val requestDeletePendingDownloadsDelayedUseCase: RequestDeletePendingDownloadsDelayedUseCase,
     val requestDeletePendingDownloadsImmediateUseCase: RequestDeletePendingDownloadsImmediateUseCase,
     val deleteDownloadByIdUseCase: DeleteDownloadByIdUseCase,

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadDelayedUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadDelayedUseCase.kt
@@ -1,0 +1,17 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.strigate.ferrot.work.DeletePendingDownloadDelayedWorker
+import javax.inject.Inject
+
+class RequestDeletePendingDownloadDelayedUseCase @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
+) {
+    operator fun invoke(downloadId: Long) {
+        DeletePendingDownloadDelayedWorker.enqueueOneTimeReplace(
+            context = appContext,
+            downloadId = downloadId,
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCase.kt
@@ -5,6 +5,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
+import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_DOWNLOADED
 import org.strigate.ferrot.util.NotificationOps
 import javax.inject.Inject
 
@@ -16,6 +17,10 @@ class ClearNotificationsByDownloadIdUseCase @Inject constructor(
             EXTRA_ACTION to ACTION_NAVIGATE_DOWNLOAD,
             EXTRA_DOWNLOAD_ID to downloadId.toString(),
         )
-        NotificationOps.clearNotificationsByExtraValue(appContext, extras)
+        NotificationOps.clearNotificationsByExtraValue(
+            context = appContext,
+            stringExtras = extras,
+            channelId = CHANNEL_ID_DOWNLOADED,
+        )
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainViewModel.kt
@@ -34,6 +34,12 @@ class MainViewModel @Inject constructor(
     fun navigateToDownload(downloadId: Long) {
         viewModelScope.launch {
             downloadUseCase.getDownloadByIdUseCase(downloadId)?.let { download ->
+                if (download.pendingDelete) {
+                    downloadUseCase.updateDownloadsPendingDeleteUseCase(
+                        downloadIds = setOf(download.id),
+                        pendingDelete = false,
+                    )
+                }
                 navigateTo(
                     route = Screen.Download.route(download.id),
                     popUpToDownloads = true,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -181,6 +181,7 @@ class DownloadViewModel @Inject constructor(
         val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return@launch
         if (download.status == DownloadStatus.COMPLETED && !download.seen) {
             downloadUseCase.updateDownloadsSeenUseCase(setOf(downloadId))
+            clearNotificationsByDownloadIdUseCase(downloadId)
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -24,6 +24,7 @@ import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
@@ -40,6 +41,7 @@ class DownloadsViewModel @Inject constructor(
     private val availableUpdateUseCase: AvailableUpdateUseCase,
     private val downloadProgressUseCase: DownloadProgressUseCase,
     private val downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
+    private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
 ) : ViewModel() {
     private val _searchQuery = MutableStateFlow(
         TextFieldValue(text = "", selection = TextRange(0))
@@ -128,6 +130,9 @@ class DownloadsViewModel @Inject constructor(
         val shouldMarkSeen = selectedDownloads.any { !it.seen }
         viewModelScope.launch {
             downloadUseCase.updateDownloadsSeenUseCase(downloadIds, shouldMarkSeen)
+            if (shouldMarkSeen) {
+                downloadIds.forEach(clearNotificationsByDownloadIdUseCase::invoke)
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.service.notification.StatusBarNotification
 import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -20,6 +21,16 @@ import kotlin.reflect.KClass
 object NotificationOps {
     private fun notificationManager(context: Context): NotificationManager {
         return context.getSystemService(NotificationManager::class.java)
+    }
+
+    private fun findActiveNotification(
+        context: Context,
+        tag: String?,
+        id: Int,
+    ): StatusBarNotification? {
+        return notificationManager(context)
+            .activeNotifications
+            .firstOrNull { it.id == id && it.tag == tag }
     }
 
     fun createNotificationChannelGroup(
@@ -93,6 +104,12 @@ object NotificationOps {
         groupId: String? = null,
         tag: String? = null,
         extras: Map<String, String> = emptyMap(),
+        actions: List<NotificationCompat.Action> = emptyList(),
+        notificationId: Int? = null,
+        autoCancel: Boolean = true,
+        ongoing: Boolean = false,
+        progress: Int? = null,
+        indeterminate: Boolean = false,
     ) = CoroutineScope(Dispatchers.Main).launch {
         notifyInternal(
             context = context,
@@ -107,6 +124,12 @@ object NotificationOps {
             largeIcon = largeIcon,
             priority = priority,
             extras = extras,
+            actions = actions,
+            notificationId = notificationId,
+            autoCancel = autoCancel,
+            ongoing = ongoing,
+            progress = progress,
+            indeterminate = indeterminate,
             activityClass = MainActivity::class,
         )
     }
@@ -124,9 +147,21 @@ object NotificationOps {
         largeIcon: Bitmap?,
         priority: Int,
         extras: Map<String, String>,
+        actions: List<NotificationCompat.Action>,
+        notificationId: Int?,
+        autoCancel: Boolean,
+        ongoing: Boolean,
+        progress: Int?,
+        indeterminate: Boolean,
         activityClass: KClass<out Activity>,
     ) {
-        val id = tag?.hashCode() ?: (System.currentTimeMillis() + System.nanoTime()).toInt()
+        val id = notificationId ?: tag?.hashCode()
+        ?: (System.currentTimeMillis() + System.nanoTime()).toInt()
+        val existingNotification = findActiveNotification(
+            context = context,
+            tag = tag,
+            id = id,
+        )?.notification
         val notification = buildNotification(
             context = context,
             notificationId = id,
@@ -139,6 +174,14 @@ object NotificationOps {
             largeIcon = largeIcon,
             priority = priority,
             extras = extras,
+            actions = actions,
+            autoCancel = autoCancel,
+            ongoing = ongoing,
+            progress = progress,
+            indeterminate = indeterminate,
+            whenMillis = existingNotification?.`when`,
+            sortKey = existingNotification?.sortKey,
+            showWhen = existingNotification?.`when`?.let { it > 0L } ?: true,
             activityClass = activityClass,
         )
         val notificationManager = notificationManager(context)
@@ -174,6 +217,14 @@ object NotificationOps {
         largeIcon: Bitmap?,
         priority: Int,
         extras: Map<String, String>,
+        actions: List<NotificationCompat.Action>,
+        autoCancel: Boolean,
+        ongoing: Boolean,
+        progress: Int?,
+        indeterminate: Boolean,
+        whenMillis: Long?,
+        sortKey: String?,
+        showWhen: Boolean,
         activityClass: KClass<out Activity>,
     ): Notification {
         val notificationIntent = Intent(context, activityClass.java).apply {
@@ -198,9 +249,13 @@ object NotificationOps {
             .setLargeIcon(largeIcon)
             .setOnlyAlertOnce(true)
             .setPriority(priority)
-            .setAutoCancel(true)
+            .setAutoCancel(autoCancel)
+            .setOngoing(ongoing)
             .setGroup(groupId)
+            .setShowWhen(showWhen)
             .apply {
+                whenMillis?.takeIf { it > 0L }?.let(::setWhen)
+                sortKey?.let(::setSortKey)
                 if (largeIcon != null) {
                     setStyle(
                         NotificationCompat.BigPictureStyle()
@@ -217,6 +272,10 @@ object NotificationOps {
 
         extras.forEach { (key, value) ->
             notificationBuilder.extras.putString(key, value)
+        }
+        actions.forEach(notificationBuilder::addAction)
+        if (progress != null || indeterminate) {
+            notificationBuilder.setProgress(100, progress?.coerceIn(0, 100) ?: 0, indeterminate)
         }
         return notificationBuilder.build()
     }
@@ -272,6 +331,19 @@ object NotificationOps {
                     notificationManager.cancel(statusBarNotification.id)
                 }
             }
+        }
+    }
+
+    fun cancel(
+        context: Context,
+        notificationId: Int,
+        tag: String? = null,
+    ) {
+        val notificationManager = notificationManager(context)
+        if (tag != null) {
+            notificationManager.cancel(tag, notificationId)
+        } else {
+            notificationManager.cancel(notificationId)
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
@@ -313,9 +313,13 @@ object NotificationOps {
     fun clearNotificationsByExtraValue(
         context: Context,
         stringExtras: Map<String, String>,
+        channelId: String? = null,
     ) {
         val notificationManager = notificationManager(context)
         for (statusBarNotification in notificationManager.activeNotifications) {
+            if (channelId != null && statusBarNotification.notification.channelId != channelId) {
+                continue
+            }
             val extras = statusBarNotification.notification.extras
             var match = true
             for ((key, value) in stringExtras) {

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeleteDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeleteDownloadsWorker.kt
@@ -16,6 +16,7 @@ import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DELETE_DOWNLOADS
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
+import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.util.setExpeditedIfAllowed
 import java.util.concurrent.TimeUnit
 
@@ -23,6 +24,7 @@ class DeleteDownloadsWorker(
     appContext: Context,
     workerParameters: WorkerParameters,
     private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
+    private val stopDownloadUseCase: StopDownloadUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         val downloadIds = inputData
@@ -43,6 +45,7 @@ class DeleteDownloadsWorker(
         Log.d(LOG_TAG, "Starting delete worker for ${downloadIds.size} download(s)")
         downloadIds.forEach { downloadId ->
             runCatching {
+                stopDownloadUseCase(downloadId)
                 deleteDownloadAndRelatedCombinedUseCase(downloadId)
                 Log.d(LOG_TAG, "Deleted downloadId=$downloadId")
             }.onFailure {

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeletePendingDownloadDelayedWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeletePendingDownloadDelayedWorker.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DELETE_PENDING_DOWNLOADS_DELAYED
+import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
+import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DELETE_PENDING_DOWNLOAD_DELAYED
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
@@ -22,7 +23,7 @@ import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.util.setExpeditedIfAllowed
 import java.util.concurrent.TimeUnit
 
-class DeletePendingDownloadsDelayedWorker(
+class DeletePendingDownloadDelayedWorker(
     appContext: Context,
     workerParameters: WorkerParameters,
     private val downloadUseCase: DownloadUseCase,
@@ -30,47 +31,43 @@ class DeletePendingDownloadsDelayedWorker(
     private val stopDownloadUseCase: StopDownloadUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val downloadId = inputData.getLong(KEY_ID, -1L)
+        if (downloadId <= 0L) {
+            Log.w(LOG_TAG, "No valid download ID provided for single delayed delete worker")
+            return@withContext Result.success()
+        }
+
         val delayMillis = inputData
             .getLong(KEY_DELAY_MILLIS, DEFAULT_DELAY_MILLIS)
             .coerceAtLeast(0L)
 
         if (delayMillis > 0L) {
-            Log.d(LOG_TAG, "Delayed pending delete worker waiting ${delayMillis}ms")
+            Log.d(LOG_TAG, "Single delayed delete worker waiting ${delayMillis}ms for $downloadId")
             delay(delayMillis)
         }
-
-        val pendingDeleteIds = downloadUseCase
-            .getAllDownloadsUseCase()
-            .asSequence()
-            .filter { it.pendingDelete }
-            .map { it.id }
-            .toList()
-
-        if (pendingDeleteIds.isEmpty()) {
-            Log.d(LOG_TAG, "No pending deletes found after delayed wait")
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId)
+        if (download == null) {
+            Log.d(LOG_TAG, "Download already gone before single delayed delete fired: $downloadId")
+            return@withContext Result.success()
+        }
+        if (!download.pendingDelete) {
+            Log.d(LOG_TAG, "Pending delete was cleared before timeout for $downloadId")
             return@withContext Result.success()
         }
 
         enableForeground(
             notificationText = applicationContext.resources.getQuantityString(
                 R.plurals.worker_notification_text_deleting_downloads,
-                pendingDeleteIds.size,
+                1,
             ),
         )
-        val message =
-            "Starting delayed delete worker for ${pendingDeleteIds.size} pending download(s)"
-        Log.d(LOG_TAG, message)
-
-        pendingDeleteIds.forEach { downloadId ->
-            runCatching {
-                stopDownloadUseCase(downloadId)
-                deleteDownloadAndRelatedCombinedUseCase(downloadId)
-                Log.d(LOG_TAG, "Delayed deleted pending downloadId=$downloadId")
-            }.onFailure {
-                Log.w(LOG_TAG, "Delayed pending delete failed for downloadId=$downloadId", it)
-            }
+        runCatching {
+            stopDownloadUseCase(downloadId)
+            deleteDownloadAndRelatedCombinedUseCase(downloadId)
+            Log.d(LOG_TAG, "Single delayed delete completed for $downloadId")
+        }.onFailure {
+            Log.w(LOG_TAG, "Single delayed delete failed for $downloadId", it)
         }
-        Log.d(LOG_TAG, "Finished delayed pending delete worker")
         Result.success()
     }
 
@@ -80,8 +77,12 @@ class DeletePendingDownloadsDelayedWorker(
 
         fun enqueueOneTimeReplace(
             context: Context,
+            downloadId: Long,
             delayMillis: Long = DEFAULT_DELAY_MILLIS,
         ) {
+            if (downloadId <= 0L) {
+                return
+            }
             val constraints = Constraints.Builder()
                 .setRequiresBatteryNotLow(false)
                 .setRequiresCharging(false)
@@ -89,10 +90,11 @@ class DeletePendingDownloadsDelayedWorker(
                 .build()
 
             val oneTimeWorkRequest =
-                OneTimeWorkRequestBuilder<DeletePendingDownloadsDelayedWorker>()
+                OneTimeWorkRequestBuilder<DeletePendingDownloadDelayedWorker>()
                     .setConstraints(constraints)
                     .setInputData(
                         workDataOf(
+                            KEY_ID to downloadId,
                             KEY_DELAY_MILLIS to delayMillis.coerceAtLeast(0L),
                         ),
                     )
@@ -105,10 +107,14 @@ class DeletePendingDownloadsDelayedWorker(
                     .build()
 
             WorkManager.getInstance(context).enqueueUniqueWork(
-                ONETIME_DELETE_PENDING_DOWNLOADS_DELAYED,
+                uniqueWorkName(downloadId),
                 ExistingWorkPolicy.REPLACE,
                 oneTimeWorkRequest,
             )
+        }
+
+        private fun uniqueWorkName(downloadId: Long): String {
+            return "$ONETIME_DELETE_PENDING_DOWNLOAD_DELAYED-$downloadId"
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeletePendingDownloadsImmediateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeletePendingDownloadsImmediateWorker.kt
@@ -16,6 +16,7 @@ import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DELETE_PENDING_DOWNLO
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
+import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.util.setExpeditedIfAllowed
 import java.util.concurrent.TimeUnit
 
@@ -24,6 +25,7 @@ class DeletePendingDownloadsImmediateWorker(
     workerParameters: WorkerParameters,
     private val downloadUseCase: DownloadUseCase,
     private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
+    private val stopDownloadUseCase: StopDownloadUseCase,
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         val pendingDeleteIds = downloadUseCase
@@ -50,6 +52,7 @@ class DeletePendingDownloadsImmediateWorker(
 
         pendingDeleteIds.forEach { downloadId ->
             runCatching {
+                stopDownloadUseCase(downloadId)
                 deleteDownloadAndRelatedCombinedUseCase(downloadId)
                 Log.d(LOG_TAG, "Immediately deleted pending downloadId=$downloadId")
             }.onFailure {

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -3,6 +3,7 @@ package org.strigate.ferrot.work
 import android.content.Context
 import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.Data
@@ -21,15 +22,18 @@ import kotlinx.coroutines.withContext
 import org.strigate.ferrot.R
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
-import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
-import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
-import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.Constants.Notifications.Ids.ID_ACTIVE_DOWNLOAD_FOREGROUND
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_WIFI_ONLY
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD
+import org.strigate.ferrot.app.DownloadNotificationActionType
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
+import org.strigate.ferrot.app.activeDownloadNotificationTag
+import org.strigate.ferrot.app.buildDownloadNotificationAction
+import org.strigate.ferrot.app.downloadNotificationExtras
+import org.strigate.ferrot.app.downloadNotificationTag
 import org.strigate.ferrot.app.provider.DownloadPathProvider
 import org.strigate.ferrot.domain.model.DownloadAudio
 import org.strigate.ferrot.domain.model.DownloadMediaType
@@ -91,12 +95,9 @@ class DownloadWorker(
         val download = downloadUseCase.getDownloadByIdUseCase(downloadId)
             ?: return handleDownloadFailedResult()
 
-        val notificationExtras = mapOf(
-            EXTRA_ACTION to ACTION_NAVIGATE_DOWNLOAD,
-            EXTRA_DOWNLOAD_ID to download.id.toString(),
-        )
-        enableForeground(
-            notificationId = downloadId,
+        val notificationExtras = downloadNotificationExtras(download.id)
+        enableDownloadForeground(
+            downloadId = downloadId,
             notificationText = appContext.getString(R.string.worker_notification_text_download_in_progress),
             indeterminate = true,
             contentText = download.url,
@@ -163,7 +164,7 @@ class DownloadWorker(
 
                 videoTitle = videoInfoTitle ?: "Download_$downloadId"
 
-                updateForeground(
+                updateDownloadForeground(
                     notificationText = appContext.getString(R.string.worker_notification_text_download_in_progress),
                     indeterminate = true,
                     contentText = videoTitle,
@@ -361,7 +362,7 @@ class DownloadWorker(
                 }
 
                 val finalPercent = 100
-                updateForeground(
+                updateDownloadForeground(
                     notificationText = appContext.getString(R.string.download_complete),
                     progress = finalPercent,
                     indeterminate = false,
@@ -393,10 +394,13 @@ class DownloadWorker(
 
                 Log.d(LOG_TAG, "$tag $downloadComplete")
                 appContext.toast("$downloadComplete: $contentText", true)
+                clearActiveDownloadNotification(downloadId)
                 notificationService.notifyDownloaded(
                     contentText = contentText,
                     contentTitle = downloadComplete,
                     extras = notificationExtras,
+                    tag = downloadNotificationTag(downloadId),
+                    actions = buildCompletedNotificationActions(downloadId),
                 )
                 Result.success()
 
@@ -455,11 +459,13 @@ class DownloadWorker(
         }
         val downloadFailed = appContext.getString(R.string.download_failed)
         appContext.toast(downloadFailed, true)
+        clearActiveDownloadNotification(downloadId)
         notificationService.notifyDownloaded(
             contentTitle = downloadFailed,
             contentText = notificationText,
             extras = notificationExtras,
-            tag = notificationText,
+            tag = downloadNotificationTag(downloadId),
+            actions = buildFailedNotificationActions(downloadId),
         )
         return handleDownloadFailedResult()
     }
@@ -467,6 +473,7 @@ class DownloadWorker(
     private suspend fun handleDownloadStoppedResult(): Result {
         val downloadId = _downloadId
         if (downloadId > 0L) {
+            clearActiveDownloadNotification(downloadId)
             withContext(NonCancellable) {
                 val status = runCatching {
                     downloadUseCase.getDownloadByIdUseCase(downloadId)?.status
@@ -492,6 +499,7 @@ class DownloadWorker(
     private suspend fun handleDownloadFailedResult(): Result {
         val downloadId = _downloadId
         if (downloadId > 0L) {
+            clearActiveDownloadNotification(downloadId)
             withContext(NonCancellable) {
                 resetProgressAndCleanup()
                 runCatching {
@@ -511,10 +519,140 @@ class DownloadWorker(
         if (downloadId <= 0L) {
             return Result.success()
         }
+        clearActiveDownloadNotification(downloadId)
         runCatching {
             deleteDownloadAndRelatedCombinedUseCase(downloadId)
         }
         return Result.success()
+    }
+
+    private suspend fun enableDownloadForeground(
+        downloadId: Long,
+        notificationText: String,
+        progress: Int? = null,
+        indeterminate: Boolean = false,
+        contentText: String? = null,
+        extras: Map<String, String>? = null,
+    ) {
+        enableForeground(
+            notificationId = ID_ACTIVE_DOWNLOAD_FOREGROUND.toLong(),
+            notificationText = notificationText,
+            progress = progress,
+            indeterminate = indeterminate,
+            contentText = contentText,
+            extras = extras,
+            actions = emptyList(),
+        )
+        showActiveDownloadNotification(
+            downloadId = downloadId,
+            notificationText = notificationText,
+            progress = progress,
+            indeterminate = indeterminate,
+            contentText = contentText,
+            extras = extras,
+        )
+    }
+
+    private fun updateDownloadForeground(
+        notificationText: String,
+        progress: Int? = null,
+        indeterminate: Boolean = false,
+        contentText: String? = null,
+        extras: Map<String, String>? = null,
+    ) {
+        updateForeground(
+            notificationText = notificationText,
+            progress = progress,
+            indeterminate = indeterminate,
+            contentText = contentText,
+            extras = extras,
+            actions = emptyList(),
+        )
+        showActiveDownloadNotification(
+            downloadId = _downloadId,
+            notificationText = notificationText,
+            progress = progress,
+            indeterminate = indeterminate,
+            contentText = contentText,
+            extras = extras,
+        )
+    }
+
+    private fun showActiveDownloadNotification(
+        downloadId: Long,
+        notificationText: String,
+        progress: Int?,
+        indeterminate: Boolean,
+        contentText: String?,
+        extras: Map<String, String>?,
+    ) {
+        if (downloadId <= 0L) {
+            return
+        }
+        notificationService.notifyActiveDownload(
+            contentTitle = notificationText,
+            contentText = contentText.orEmpty(),
+            extras = extras.orEmpty(),
+            tag = activeDownloadNotificationTag(downloadId),
+            actions = buildActiveNotificationActions(downloadId),
+            progress = progress,
+            indeterminate = indeterminate,
+        )
+    }
+
+    private fun clearActiveDownloadNotification(downloadId: Long) {
+        if (downloadId <= 0L) {
+            return
+        }
+        val tag = activeDownloadNotificationTag(downloadId)
+        notificationService.clearNotification(
+            notificationId = tag.hashCode(),
+            tag = tag,
+        )
+    }
+
+    private fun buildActiveNotificationActions(
+        downloadId: Long,
+    ): List<NotificationCompat.Action> {
+        return listOf(
+            buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = downloadId,
+                actionType = DownloadNotificationActionType.STOP,
+            ),
+        )
+    }
+
+    private fun buildCompletedNotificationActions(downloadId: Long): List<NotificationCompat.Action> {
+        val actions = mutableListOf<NotificationCompat.Action>()
+        actions += buildDownloadNotificationAction(
+            context = appContext,
+            downloadId = downloadId,
+            actionType = DownloadNotificationActionType.MARK_SEEN,
+        )
+        actions += buildDownloadNotificationAction(
+            context = appContext,
+            downloadId = downloadId,
+            actionType = DownloadNotificationActionType.DELETE,
+        )
+        return actions
+    }
+
+    private fun buildFailedNotificationActions(
+        downloadId: Long,
+    ): List<NotificationCompat.Action> {
+        return listOf(
+            buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = downloadId,
+                actionType = DownloadNotificationActionType.RETRY,
+            ),
+            buildDownloadNotificationAction(
+                context = appContext,
+                downloadId = downloadId,
+                actionType = DownloadNotificationActionType.DELETE,
+            ),
+        )
     }
 
     private suspend fun resetProgressAndCleanup() {
@@ -693,7 +831,7 @@ class DownloadWorker(
                 if (throttle.shouldNotify(percentInt)) {
                     val etaLine = formatEta(tick.etaSeconds)
                     val contentLine = buildNotifLine(percentInt, etaLine, phaseContext.title)
-                    updateForeground(
+                    updateDownloadForeground(
                         notificationText = appContext.getString(R.string.worker_notification_text_download_in_progress),
                         progress = percentInt,
                         indeterminate = false,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -23,14 +23,13 @@ import org.strigate.ferrot.R
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.app.Constants.Notifications.Ids.ID_ACTIVE_DOWNLOAD_FOREGROUND
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_WIFI_ONLY
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD
 import org.strigate.ferrot.app.DownloadNotificationActionType
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
-import org.strigate.ferrot.app.activeDownloadNotificationTag
+import org.strigate.ferrot.app.buildCancelDownloadNotificationAction
 import org.strigate.ferrot.app.buildDownloadNotificationAction
 import org.strigate.ferrot.app.downloadNotificationExtras
 import org.strigate.ferrot.app.downloadNotificationTag
@@ -394,7 +393,6 @@ class DownloadWorker(
 
                 Log.d(LOG_TAG, "$tag $downloadComplete")
                 appContext.toast("$downloadComplete: $contentText", true)
-                clearActiveDownloadNotification(downloadId)
                 notificationService.notifyDownloaded(
                     contentText = contentText,
                     contentTitle = downloadComplete,
@@ -459,7 +457,6 @@ class DownloadWorker(
         }
         val downloadFailed = appContext.getString(R.string.download_failed)
         appContext.toast(downloadFailed, true)
-        clearActiveDownloadNotification(downloadId)
         notificationService.notifyDownloaded(
             contentTitle = downloadFailed,
             contentText = notificationText,
@@ -473,7 +470,6 @@ class DownloadWorker(
     private suspend fun handleDownloadStoppedResult(): Result {
         val downloadId = _downloadId
         if (downloadId > 0L) {
-            clearActiveDownloadNotification(downloadId)
             withContext(NonCancellable) {
                 val status = runCatching {
                     downloadUseCase.getDownloadByIdUseCase(downloadId)?.status
@@ -499,7 +495,6 @@ class DownloadWorker(
     private suspend fun handleDownloadFailedResult(): Result {
         val downloadId = _downloadId
         if (downloadId > 0L) {
-            clearActiveDownloadNotification(downloadId)
             withContext(NonCancellable) {
                 resetProgressAndCleanup()
                 runCatching {
@@ -519,7 +514,6 @@ class DownloadWorker(
         if (downloadId <= 0L) {
             return Result.success()
         }
-        clearActiveDownloadNotification(downloadId)
         runCatching {
             deleteDownloadAndRelatedCombinedUseCase(downloadId)
         }
@@ -535,21 +529,13 @@ class DownloadWorker(
         extras: Map<String, String>? = null,
     ) {
         enableForeground(
-            notificationId = ID_ACTIVE_DOWNLOAD_FOREGROUND.toLong(),
+            notificationId = downloadId,
             notificationText = notificationText,
             progress = progress,
             indeterminate = indeterminate,
             contentText = contentText,
             extras = extras,
-            actions = emptyList(),
-        )
-        showActiveDownloadNotification(
-            downloadId = downloadId,
-            notificationText = notificationText,
-            progress = progress,
-            indeterminate = indeterminate,
-            contentText = contentText,
-            extras = extras,
+            actions = buildActiveNotificationActions(),
         )
     }
 
@@ -566,59 +552,15 @@ class DownloadWorker(
             indeterminate = indeterminate,
             contentText = contentText,
             extras = extras,
-            actions = emptyList(),
-        )
-        showActiveDownloadNotification(
-            downloadId = _downloadId,
-            notificationText = notificationText,
-            progress = progress,
-            indeterminate = indeterminate,
-            contentText = contentText,
-            extras = extras,
+            actions = buildActiveNotificationActions(),
         )
     }
 
-    private fun showActiveDownloadNotification(
-        downloadId: Long,
-        notificationText: String,
-        progress: Int?,
-        indeterminate: Boolean,
-        contentText: String?,
-        extras: Map<String, String>?,
-    ) {
-        if (downloadId <= 0L) {
-            return
-        }
-        notificationService.notifyActiveDownload(
-            contentTitle = notificationText,
-            contentText = contentText.orEmpty(),
-            extras = extras.orEmpty(),
-            tag = activeDownloadNotificationTag(downloadId),
-            actions = buildActiveNotificationActions(downloadId),
-            progress = progress,
-            indeterminate = indeterminate,
-        )
-    }
-
-    private fun clearActiveDownloadNotification(downloadId: Long) {
-        if (downloadId <= 0L) {
-            return
-        }
-        val tag = activeDownloadNotificationTag(downloadId)
-        notificationService.clearNotification(
-            notificationId = tag.hashCode(),
-            tag = tag,
-        )
-    }
-
-    private fun buildActiveNotificationActions(
-        downloadId: Long,
-    ): List<NotificationCompat.Action> {
+    private fun buildActiveNotificationActions(): List<NotificationCompat.Action> {
         return listOf(
-            buildDownloadNotificationAction(
+            buildCancelDownloadNotificationAction(
                 context = appContext,
-                downloadId = downloadId,
-                actionType = DownloadNotificationActionType.STOP,
+                workId = id,
             ),
         )
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -29,7 +29,6 @@ import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD
 import org.strigate.ferrot.app.DownloadNotificationActionType
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
-import org.strigate.ferrot.app.buildCancelDownloadNotificationAction
 import org.strigate.ferrot.app.buildDownloadNotificationAction
 import org.strigate.ferrot.app.downloadNotificationExtras
 import org.strigate.ferrot.app.downloadNotificationTag
@@ -558,9 +557,10 @@ class DownloadWorker(
 
     private fun buildActiveNotificationActions(): List<NotificationCompat.Action> {
         return listOf(
-            buildCancelDownloadNotificationAction(
+            buildDownloadNotificationAction(
                 context = appContext,
-                workId = id,
+                downloadId = _downloadId,
+                actionType = DownloadNotificationActionType.STOP,
             ),
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,12 @@
     <string name="notification_summary_title">You have new notifications</string>
     <string name="notification_download_title">Downloading</string>
     <string name="notification_app_update_title">App update</string>
+    <string name="notification_deleted_title">Deleted</string>
+    <string name="notification_action_mark_seen">Mark as seen</string>
+    <string name="notification_action_delete">Delete</string>
+    <string name="notification_action_retry">Retry</string>
+    <string name="notification_action_stop">Stop</string>
+    <string name="notification_action_undo">Undo</string>
 
     <string name="worker_notification_text_updating_dependencies">Updating dependencies</string>
     <string name="worker_notification_text_downloading_app_update">Downloading app update</string>

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
@@ -32,6 +32,7 @@ import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
 import org.strigate.ferrot.domain.usecase.download.SaveDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
+import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsPendingDeleteUseCase
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
@@ -116,6 +117,34 @@ class MainViewModelTest {
     }
 
     @Test
+    fun navigateToDownload_clearsPendingDeleteBeforeNavigation_whenDownloadIsPendingDelete() =
+        runTest(testDispatcher) {
+            val download = Download(
+                id = 42L,
+                uid = "uid-42",
+                url = "https://example.com",
+                status = DownloadStatus.COMPLETED,
+                seen = false,
+                pendingDelete = true,
+            )
+            val viewModel = createViewModel()
+            `when`(downloadRepository.getById(42L))
+                .thenReturn(download)
+
+            viewModel.navigateToDownload(42L)
+            advanceUntilIdle()
+
+            verify(downloadRepository).updatePendingDeleteByIds(setOf(42L), false)
+            assertEquals(
+                NavigationEvent.Route(
+                    route = Screen.Download.route(42L),
+                    popUpToDownloads = true,
+                ),
+                viewModel.navigateRoute.value,
+            )
+        }
+
+    @Test
     fun navigateToDownload_keepsNavigationEmpty_whenDownloadDoesNotExist() =
         runTest(testDispatcher) {
             val viewModel = createViewModel()
@@ -180,11 +209,15 @@ class MainViewModelTest {
     private fun createViewModel(): MainViewModel {
         val saveDownloadUseCase = SaveDownloadUseCase(downloadRepository)
         val getDownloadByIdUseCase = GetDownloadByIdUseCase(downloadRepository)
+        val updateDownloadsPendingDeleteUseCase =
+            UpdateDownloadsPendingDeleteUseCase(downloadRepository)
 
         `when`(downloadUseCase.saveDownloadUseCase)
             .thenReturn(saveDownloadUseCase)
         `when`(downloadUseCase.getDownloadByIdUseCase)
             .thenReturn(getDownloadByIdUseCase)
+        `when`(downloadUseCase.updateDownloadsPendingDeleteUseCase)
+            .thenReturn(updateDownloadsPendingDeleteUseCase)
 
         return MainViewModel(
             downloadUseCase = downloadUseCase,

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -377,6 +377,7 @@ class DownloadViewModelTest {
         advanceUntilIdle()
 
         verify(updateDownloadsSeenUseCase).invoke(setOf(7L))
+        verify(clearNotificationsByDownloadIdUseCase).invoke(7L)
     }
 
     @Test

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -44,6 +44,7 @@ import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsPendingDeleteU
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
 import org.strigate.ferrot.domain.usecase.downloadprogress.UpdateDownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import kotlin.time.Duration.Companion.seconds
 
@@ -96,6 +97,9 @@ class DownloadsViewModelTest {
 
     @Mock
     private lateinit var updateDownloadsSeenUseCase: UpdateDownloadsSeenUseCase
+
+    @Mock
+    private lateinit var clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase
 
     @Before
     fun setUp() {
@@ -306,6 +310,9 @@ class DownloadsViewModelTest {
             advanceUntilIdle()
 
             verify(updateDownloadsSeenUseCase).invoke(setOf(1L, 2L, 3L), true)
+            verify(clearNotificationsByDownloadIdUseCase).invoke(1L)
+            verify(clearNotificationsByDownloadIdUseCase).invoke(2L)
+            verify(clearNotificationsByDownloadIdUseCase).invoke(3L)
             collector.cancel()
         }
 
@@ -331,6 +338,8 @@ class DownloadsViewModelTest {
             advanceUntilIdle()
 
             verify(updateDownloadsSeenUseCase).invoke(setOf(1L, 2L), false)
+            verify(clearNotificationsByDownloadIdUseCase, never()).invoke(1L)
+            verify(clearNotificationsByDownloadIdUseCase, never()).invoke(2L)
             collector.cancel()
         }
 
@@ -412,6 +421,7 @@ class DownloadsViewModelTest {
             availableUpdateUseCase = availableUpdateUseCase,
             downloadProgressUseCase = downloadProgressUseCase,
             downloadWithMetadataUseCase = downloadWithMetadataUseCase,
+            clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
         )
     }
 


### PR DESCRIPTION
- Add `DownloadNotificationActionReceiver` and `DownloadNotificationActionType`
- Add helpers for notification actions and tags
- Update `DownloadWorker` to show active notifications, add actions, and clear notifications
- Extend `ForegroundCoroutineWorker`, `NotificationService`, and `NotificationOps` for actions, progress, and cancellation
- Add `DeletePendingDownloadDelayedWorker` and `RequestDeletePendingDownloadDelayedUseCase`
- Wire `StopDownloadUseCase` into delete workers
- Update `WorkerFactory` and `DownloadUseCase`
- Add notification action string resources