### PR TITLE
feat: Add retry failed downloads action

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Settings
@@ -156,10 +157,15 @@ fun DownloadsScreen(
     val pendingDeleteIds = (uiState as? DownloadsUiState.Data)?.data?.pendingDeleteIds ?: emptySet()
     val hasPendingDeletes = pendingDeleteIds.isNotEmpty()
 
+    val hasFailedDownloads = remember(uiState) {
+        val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
+        downloads.any { it.status == DownloadStatusUiData.FAILED }
+    }
     val shouldMarkSelectionSeen = remember(uiState, selectedIds) {
         val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
         downloads.any { it.id in selectedIds && !it.seen }
     }
+
     val snackbarUndoActionLabel = stringResource(R.string.snackbar_delete_undo)
 
     BackHandler(enabled = selectionMode) {
@@ -391,6 +397,25 @@ fun DownloadsScreen(
                                     },
                                     onClick = {
                                         selectedIds = allIds
+                                        menuExpanded = false
+                                    },
+                                )
+                            }
+                            if (hasFailedDownloads) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            text = stringResource(R.string.retry_failed),
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Filled.Refresh,
+                                            contentDescription = stringResource(R.string.content_description_retry),
+                                        )
+                                    },
+                                    onClick = {
+                                        viewModel.retryFailedDownloads()
                                         menuExpanded = false
                                     },
                                 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -411,7 +411,7 @@ fun DownloadsScreen(
                                     leadingIcon = {
                                         Icon(
                                             imageVector = Icons.Filled.Refresh,
-                                            contentDescription = stringResource(R.string.content_description_retry),
+                                            contentDescription = stringResource(R.string.content_description_retry_failed),
                                         )
                                     },
                                     onClick = {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -27,6 +27,7 @@ import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
+import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import javax.inject.Inject
@@ -119,6 +120,24 @@ class DownloadsViewModel @Inject constructor(
 
     fun retryDownload(downloadId: Long) = viewModelScope.launch {
         startDownloadUseCase(downloadId)
+    }
+
+    fun retryFailedDownloads() {
+        val data = uiState.value as? DownloadsUiState.Data ?: return
+        val failedDownloadIds = data.data.downloads
+            .asSequence()
+            .filter { it.status == DownloadStatusUiData.FAILED }
+            .map { it.id }
+            .toList()
+
+        if (failedDownloadIds.isEmpty()) {
+            return
+        }
+        viewModelScope.launch {
+            failedDownloadIds.forEach { downloadId ->
+                startDownloadUseCase(downloadId)
+            }
+        }
     }
 
     fun toggleDownloadsSeen(downloadIds: Set<Long>) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="content_description_back">Back</string>
     <string name="content_description_thumbnail">Preview</string>
     <string name="content_description_retry">Retry</string>
+    <string name="content_description_retry_failed">Retry failed</string>
     <string name="content_description_play">Play</string>
     <string name="content_description_stop_download">Stop download</string>
     <string name="content_description_resume_download">Resume download</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="percent_0">0%</string>
     <string name="share_to">Share to…</string>
     <string name="select_all">Select all</string>
+    <string name="retry_failed">Retry failed</string>
     <string name="never">Never</string>
     <string name="video">Video</string>
     <string name="audio">Audio</string>

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -288,6 +288,35 @@ class DownloadsViewModelTest {
     }
 
     @Test
+    fun retryFailedDownloads_startsOnlyFailedDownloads() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(
+                listOf(
+                    createDownload(id = 1L, title = "Failed", status = DownloadStatus.FAILED),
+                    createDownload(id = 2L, title = "Stopped", status = DownloadStatus.STOPPED),
+                    createDownload(id = 3L, title = "Completed", status = DownloadStatus.COMPLETED),
+                    createDownload(id = 4L, title = "Failed 2", status = DownloadStatus.FAILED),
+                )
+            ),
+            updateFlow = MutableStateFlow(null),
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { it is DownloadsUiState.Data }
+
+        viewModel.retryFailedDownloads()
+        advanceUntilIdle()
+
+        verify(startDownloadUseCase).invoke(1L)
+        verify(startDownloadUseCase).invoke(4L)
+        verify(startDownloadUseCase, never()).invoke(2L)
+        verify(startDownloadUseCase, never()).invoke(3L)
+        collector.cancel()
+    }
+
+    @Test
     fun toggleDownloadsSeen_marksAllSeen_whenAnySelectedDownloadIsUnseen() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(
@@ -440,6 +469,7 @@ class DownloadsViewModelTest {
         id: Long,
         title: String,
         url: String = "https://example.com/$id",
+        status: DownloadStatus = DownloadStatus.DOWNLOADING,
         seen: Boolean = false,
         pendingDelete: Boolean = false,
     ) = DownloadWithMetadata(
@@ -447,7 +477,7 @@ class DownloadsViewModelTest {
         url = url,
         title = title,
         thumbnailFilePath = null,
-        status = DownloadStatus.DOWNLOADING,
+        status = status,
         seen = seen,
         pendingDelete = pendingDelete,
         progressPercent = 50f,


### PR DESCRIPTION
- Add `retry_failed` string resource
- Add `hasFailedDownloads` state in `DownloadsScreen`
- Show retry menu item when failed downloads exist
- Add retry action with `Icons.Filled.Refresh`
- Implement `retryFailedDownloads` in `DownloadsViewModel`
- Filter downloads by `DownloadStatusUiData.FAILED`
- Trigger `startDownloadUseCase` for each failed download
- Add unit test `retryFailedDownloads_startsOnlyFailedDownloads`
- Update `createDownload` helper to accept `status` parameter