### PR TITLE
feat: Add scroll to top on retry and simplify notification call

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -416,6 +416,9 @@ fun DownloadsScreen(
                                     },
                                     onClick = {
                                         viewModel.retryFailedDownloads()
+                                        coroutineScope.launch {
+                                            lazyListState.animateScrollToItem(0)
+                                        }
                                         menuExpanded = false
                                     },
                                 )

--- a/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
@@ -12,9 +12,6 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.service.notification.StatusBarNotification
 import androidx.core.app.NotificationCompat
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.strigate.ferrot.presentation.MainActivity
 import kotlin.reflect.KClass
 
@@ -110,7 +107,7 @@ object NotificationOps {
         ongoing: Boolean = false,
         progress: Int? = null,
         indeterminate: Boolean = false,
-    ) = CoroutineScope(Dispatchers.Main).launch {
+    ) {
         notifyInternal(
             context = context,
             channelId = channelId,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -361,15 +361,6 @@ class DownloadWorker(
                     )
                 }
 
-                val finalPercent = 100
-                updateDownloadForeground(
-                    notificationText = appContext.getString(R.string.download_complete),
-                    progress = finalPercent,
-                    indeterminate = false,
-                    contentText = videoTitle ?: download.url,
-                    extras = notificationExtras,
-                )
-
                 downloadUseCase.updateDownloadErrorMessageUseCase(downloadId, null)
                 downloadUseCase.updateDownloadStatusUseCase(
                     status = DownloadStatus.COMPLETED,


### PR DESCRIPTION
- Add `lazyListState.animateScrollToItem(0)` after `retryFailedDownloads`
- Remove coroutine usage from `notify`
- Call `notifyInternal` directly instead of launching coroutine
- Remove final completion notification update in `DownloadWorker`