### PR TITLE
refactor: Simplify foreground notification handling for downloads

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -30,10 +30,6 @@ object Constants {
     }
 
     object Notifications {
-        object Ids {
-            const val ID_ACTIVE_DOWNLOAD_FOREGROUND = 1
-        }
-
         object ChannelGroups {
             private const val CHANNEL_GROUP_ID = "$APP_ID.notification.channel.group.id"
             const val CHANNEL_GROUP_ID_FOREGROUND = "$CHANNEL_GROUP_ID.FOREGROUND"

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ForegroundCoroutineWorker.kt
@@ -12,12 +12,19 @@ import androidx.work.WorkerParameters
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_ACTIVE_TASKS
 import org.strigate.ferrot.presentation.MainActivity
+import kotlin.math.abs
 
 abstract class ForegroundCoroutineWorker(
     private val context: Context,
     workerParameters: WorkerParameters,
 ) : CoroutineWorker(context, workerParameters) {
-    private var currentNotificationId: Long = 1L
+    private val defaultForegroundNotificationId: Int = workerParameters.id.hashCode()
+        .let {
+            if (it == Int.MIN_VALUE) 0 else abs(it)
+        }
+        .coerceAtLeast(1)
+
+    private var currentNotificationId: Int = defaultForegroundNotificationId
     private var currentExtras: Map<String, String>? = null
 
     private fun notificationManager(): NotificationManager {
@@ -25,7 +32,7 @@ abstract class ForegroundCoroutineWorker(
     }
 
     suspend fun enableForeground(
-        notificationId: Long = 1,
+        notificationId: Int = defaultForegroundNotificationId,
         notificationText: String,
         progress: Int? = null,
         indeterminate: Boolean = false,
@@ -73,7 +80,7 @@ abstract class ForegroundCoroutineWorker(
     }
 
     private fun buildForegroundInfo(
-        id: Long,
+        id: Int,
         notificationText: String,
         progress: Int? = null,
         indeterminate: Boolean = false,
@@ -86,7 +93,7 @@ abstract class ForegroundCoroutineWorker(
                 putExtra(key, value)
             }
         }
-        val requestCode = if (extras == null) 0 else id.toInt()
+        val requestCode = if (extras == null) 0 else id
         val pendingIntent = PendingIntent.getActivity(
             context,
             requestCode,
@@ -95,8 +102,9 @@ abstract class ForegroundCoroutineWorker(
         )
         val existingNotification = notificationManager()
             .activeNotifications
-            .firstOrNull { it.id == id.toInt() }
+            .firstOrNull { it.id == id }
             ?.notification
+
         val builder = NotificationCompat.Builder(context, CHANNEL_ID_ACTIVE_TASKS)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
@@ -117,6 +125,7 @@ abstract class ForegroundCoroutineWorker(
         existingNotification?.`when`
             ?.takeIf { it > 0L }
             ?.let(builder::setWhen)
+
         existingNotification?.sortKey?.let(builder::setSortKey)
         extras?.forEach { (key, value) ->
             builder.extras.putString(key, value)
@@ -127,7 +136,7 @@ abstract class ForegroundCoroutineWorker(
         }
         val notification = builder.build()
         return ForegroundInfo(
-            id.toInt(),
+            id,
             notification,
             ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
         )

--- a/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
@@ -96,38 +96,6 @@ class NotificationService @Inject constructor(
         )
     }
 
-    fun notifyActiveDownload(
-        contentTitle: String,
-        contentText: String,
-        extras: Map<String, String> = emptyMap(),
-        tag: String? = null,
-        actions: List<NotificationCompat.Action> = emptyList(),
-        notificationId: Int? = null,
-        progress: Int? = null,
-        indeterminate: Boolean = false,
-    ) {
-        notify(
-            context = appContext,
-            channelId = CHANNEL_ID_ACTIVE_TASKS,
-            groupId = null,
-            summaryTitleResource = R.string.notification_title_download,
-            contentTitle = contentTitle,
-            contentText = contentText,
-            colorResource = R.color.coral,
-            iconResource = R.drawable.ic_logo,
-            largeIcon = null,
-            priority = NotificationCompat.PRIORITY_HIGH,
-            tag = tag,
-            extras = extras,
-            actions = actions,
-            notificationId = notificationId,
-            autoCancel = false,
-            ongoing = true,
-            progress = progress,
-            indeterminate = indeterminate,
-        )
-    }
-
     fun notifyDownloaded(
         contentTitle: String,
         contentText: String,

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCase.kt
@@ -10,6 +10,7 @@ import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.util.NetworkOps
 import org.strigate.ferrot.work.DownloadWorker
 import javax.inject.Inject
@@ -18,6 +19,7 @@ class StartDownloadUseCase @Inject constructor(
     @param:ApplicationContext private val appContext: Context,
     private val settingsUseCase: SettingsUseCase,
     private val downloadUseCase: DownloadUseCase,
+    private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
 ) {
     suspend operator fun invoke(downloadId: Long) = withContext(Dispatchers.IO) {
         val wifiOnly = settingsUseCase
@@ -31,6 +33,7 @@ class StartDownloadUseCase @Inject constructor(
             wifiOnly && !isOnWifi -> DownloadStatus.WAITING_FOR_WIFI
             else -> DownloadStatus.QUEUED
         }
+        clearNotificationsByDownloadIdUseCase(downloadId)
         downloadUseCase.updateDownloadStatusUseCase(
             status = downloadStatus,
             downloadId = downloadId,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -106,6 +106,7 @@ import org.strigate.ferrot.presentation.viewmodel.DownloadsViewModel
 import kotlin.math.abs
 
 private const val SEARCH_FOCUS_DELAY_MILLIS = 357L
+private const val RETRY_FAILED_SCROLL_DELAY_MILLIS = 357L
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -417,6 +418,7 @@ fun DownloadsScreen(
                                     onClick = {
                                         viewModel.retryFailedDownloads()
                                         coroutineScope.launch {
+                                            delay(RETRY_FAILED_SCROLL_DELAY_MILLIS)
                                             lazyListState.animateScrollToItem(0)
                                         }
                                         menuExpanded = false

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -152,7 +152,6 @@ class DownloadAvailableUpdateWorker(
             Log.d(LOG_TAG, "Downloading update to ${partFile.absolutePath}")
 
             enableForeground(
-                notificationId = NOTIFICATION_ID,
                 notificationText = appContext.getString(R.string.notification_text_downloading_app_update),
             )
             if (isAppInForeground()) {
@@ -447,8 +446,6 @@ class DownloadAvailableUpdateWorker(
     }
 
     companion object {
-        private const val NOTIFICATION_ID = 2001L
-
         fun enqueuePeriodicKeep(
             context: Context,
             targetHour: Int = 3,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -23,14 +23,12 @@ import org.strigate.ferrot.R
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.app.Constants.Notifications.Ids.ID_ACTIVE_DOWNLOAD_FOREGROUND
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
 import org.strigate.ferrot.app.Constants.Work.Name.KEY_WIFI_ONLY
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD
 import org.strigate.ferrot.app.DownloadNotificationActionType
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
-import org.strigate.ferrot.app.activeDownloadNotificationTag
 import org.strigate.ferrot.app.buildDownloadNotificationAction
 import org.strigate.ferrot.app.downloadNotificationExtras
 import org.strigate.ferrot.app.downloadNotificationTag
@@ -385,7 +383,6 @@ class DownloadWorker(
 
                 Log.d(LOG_TAG, "$tag $downloadComplete")
                 appContext.toast("$downloadComplete: $contentText", true)
-                clearActiveDownloadNotification(downloadId)
                 notificationService.notifyDownloaded(
                     contentText = contentText,
                     contentTitle = downloadComplete,
@@ -450,7 +447,6 @@ class DownloadWorker(
         }
         val downloadFailed = appContext.getString(R.string.download_failed)
         appContext.toast(downloadFailed, true)
-        clearActiveDownloadNotification(downloadId)
         notificationService.notifyDownloaded(
             contentTitle = downloadFailed,
             contentText = notificationText,
@@ -474,7 +470,6 @@ class DownloadWorker(
 
                 if (!shouldPreserve && status != DownloadStatus.COMPLETED && status != DownloadStatus.FAILED) {
                     resetProgressAndCleanup()
-                    clearActiveDownloadNotification(downloadId)
                     runCatching {
                         downloadUseCase.updateDownloadStatusUseCase(
                             downloadId,
@@ -492,7 +487,6 @@ class DownloadWorker(
         if (downloadId > 0L) {
             withContext(NonCancellable) {
                 resetProgressAndCleanup()
-                clearActiveDownloadNotification(downloadId)
                 runCatching {
                     analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_FAILED)
                     downloadUseCase.updateDownloadStatusUseCase(
@@ -510,7 +504,6 @@ class DownloadWorker(
         if (downloadId <= 0L) {
             return Result.success()
         }
-        clearActiveDownloadNotification(downloadId)
         runCatching {
             deleteDownloadAndRelatedCombinedUseCase(downloadId)
         }
@@ -525,18 +518,14 @@ class DownloadWorker(
         contentText: String? = null,
         extras: Map<String, String>? = null,
     ) {
-        syncActiveDownloadNotification(
-            downloadId = downloadId,
+        enableForeground(
+            notificationId = downloadId.toInt(),
             notificationText = notificationText,
             progress = progress,
             indeterminate = indeterminate,
             contentText = contentText,
             extras = extras,
-        )
-        enableForeground(
-            notificationId = ID_ACTIVE_DOWNLOAD_FOREGROUND.toLong(),
-            notificationText = appContext.getString(R.string.notification_title_downloads_in_progress),
-            actions = buildForegroundNotificationActions(),
+            actions = buildActiveNotificationActions(),
         )
     }
 
@@ -547,50 +536,13 @@ class DownloadWorker(
         contentText: String? = null,
         extras: Map<String, String>? = null,
     ) {
-        syncActiveDownloadNotification(
-            downloadId = _downloadId,
+        updateForeground(
             notificationText = notificationText,
             progress = progress,
             indeterminate = indeterminate,
             contentText = contentText,
             extras = extras,
-        )
-        updateForeground(
-            notificationText = appContext.getString(R.string.notification_title_downloads_in_progress),
-            actions = buildForegroundNotificationActions(),
-        )
-    }
-
-    private fun syncActiveDownloadNotification(
-        downloadId: Long,
-        notificationText: String,
-        progress: Int? = null,
-        indeterminate: Boolean = false,
-        contentText: String? = null,
-        extras: Map<String, String>? = null,
-    ) {
-        if (downloadId <= 0L) {
-            return
-        }
-        notificationService.notifyActiveDownload(
-            contentTitle = notificationText,
-            contentText = contentText.orEmpty(),
-            extras = extras.orEmpty(),
-            tag = activeDownloadNotificationTag(downloadId),
             actions = buildActiveNotificationActions(),
-            notificationId = downloadId.toInt(),
-            progress = progress,
-            indeterminate = indeterminate,
-        )
-    }
-
-    private fun clearActiveDownloadNotification(downloadId: Long = _downloadId) {
-        if (downloadId <= 0L) {
-            return
-        }
-        notificationService.clearNotification(
-            notificationId = downloadId.toInt(),
-            tag = activeDownloadNotificationTag(downloadId),
         )
     }
 
@@ -600,16 +552,6 @@ class DownloadWorker(
                 context = appContext,
                 downloadId = _downloadId,
                 actionType = DownloadNotificationActionType.STOP,
-            ),
-        )
-    }
-
-    private fun buildForegroundNotificationActions(): List<NotificationCompat.Action> {
-        return listOf(
-            buildDownloadNotificationAction(
-                context = appContext,
-                downloadId = -1L,
-                actionType = DownloadNotificationActionType.STOP_ALL,
             ),
         )
     }


### PR DESCRIPTION
- Replace `Long` notification ids with `Int` in `ForegroundCoroutineWorker`
- Introduce `defaultForegroundNotificationId` derived from `workerParameters.id`
- Remove `Constants.Notifications.Ids`
- Remove `NotificationService.notifyActiveDownload`
- Remove `syncActiveDownloadNotification`
- Remove `clearActiveDownloadNotification`
- Remove `buildForegroundNotificationActions`
- Update `enableForeground` and `updateForeground` usage in `DownloadWorker`
- Use `downloadId.toInt()` directly for foreground notifications
- Simplify `PendingIntent` request code handling
- Preserve existing notification metadata when updating foreground state