### PR TITLE
feat: Add thumbnail support to download notifications

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/NotificationService.kt
@@ -2,6 +2,8 @@ package org.strigate.ferrot.app
 
 import android.app.NotificationManager
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.strigate.ferrot.R
@@ -19,6 +21,7 @@ import org.strigate.ferrot.util.NotificationOps.createNotificationChannelGroup
 import org.strigate.ferrot.util.NotificationOps.deleteNotificationChannelGroupsOtherThan
 import org.strigate.ferrot.util.NotificationOps.deleteNotificationChannelsOtherThan
 import org.strigate.ferrot.util.NotificationOps.notify
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -99,6 +102,7 @@ class NotificationService @Inject constructor(
     fun notifyDownloaded(
         contentTitle: String,
         contentText: String,
+        thumbnailFilePath: String? = null,
         extras: Map<String, String> = emptyMap(),
         tag: String? = null,
         actions: List<NotificationCompat.Action> = emptyList(),
@@ -106,6 +110,7 @@ class NotificationService @Inject constructor(
         autoCancel: Boolean = true,
         ongoing: Boolean = false,
     ) {
+        val thumbnailBitmap = thumbnailFilePath.toNotificationBitmap()
         notify(
             context = appContext,
             channelId = CHANNEL_ID_DOWNLOADED,
@@ -116,6 +121,7 @@ class NotificationService @Inject constructor(
             colorResource = R.color.coral,
             iconResource = R.drawable.ic_logo,
             largeIcon = null,
+            bigPicture = thumbnailBitmap,
             priority = NotificationCompat.PRIORITY_HIGH,
             tag = tag,
             extras = extras,
@@ -135,5 +141,14 @@ class NotificationService @Inject constructor(
             notificationId = notificationId,
             tag = tag,
         )
+    }
+
+    private fun String?.toNotificationBitmap(): Bitmap? {
+        val thumbnailPath = this?.takeIf { it.isNotBlank() } ?: return null
+        val thumbnailFile = File(thumbnailPath)
+        if (!thumbnailFile.exists()) {
+            return null
+        }
+        return BitmapFactory.decodeFile(thumbnailFile.absolutePath)
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
@@ -159,9 +159,12 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
     }
 
     private suspend fun showCompletedNotification(download: Download) {
+        val metadata = downloadMetadataUseCase
+            .getDownloadMetadataByIdAsFlowUseCase(download.id).first()
         notificationService.notifyDownloaded(
             contentTitle = appContext.getString(R.string.download_complete),
-            contentText = notificationText(download),
+            contentText = metadata?.title?.takeIf { it.isNotBlank() } ?: download.url,
+            thumbnailFilePath = metadata?.thumbnailFilePath,
             extras = downloadNotificationExtras(download.id),
             tag = downloadNotificationTag(download.id),
             actions = buildCompletedActions(download),

--- a/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/NotificationOps.kt
@@ -98,6 +98,7 @@ object NotificationOps {
         contentTitle: String? = null,
         contentText: String? = null,
         largeIcon: Bitmap? = null,
+        bigPicture: Bitmap? = null,
         groupId: String? = null,
         tag: String? = null,
         extras: Map<String, String> = emptyMap(),
@@ -119,6 +120,7 @@ object NotificationOps {
             colorResource = colorResource,
             iconResource = iconResource,
             largeIcon = largeIcon,
+            bigPicture = bigPicture,
             priority = priority,
             extras = extras,
             actions = actions,
@@ -142,6 +144,7 @@ object NotificationOps {
         colorResource: Int,
         iconResource: Int,
         largeIcon: Bitmap?,
+        bigPicture: Bitmap?,
         priority: Int,
         extras: Map<String, String>,
         actions: List<NotificationCompat.Action>,
@@ -169,6 +172,7 @@ object NotificationOps {
             colorResource = colorResource,
             iconResource = iconResource,
             largeIcon = largeIcon,
+            bigPicture = bigPicture,
             priority = priority,
             extras = extras,
             actions = actions,
@@ -212,6 +216,7 @@ object NotificationOps {
         colorResource: Int,
         iconResource: Int,
         largeIcon: Bitmap?,
+        bigPicture: Bitmap?,
         priority: Int,
         extras: Map<String, String>,
         actions: List<NotificationCompat.Action>,
@@ -253,9 +258,10 @@ object NotificationOps {
             .apply {
                 whenMillis?.takeIf { it > 0L }?.let(::setWhen)
                 sortKey?.let(::setSortKey)
-                if (largeIcon != null) {
+                if (bigPicture != null) {
                     setStyle(
                         NotificationCompat.BigPictureStyle()
+                            .bigPicture(bigPicture)
                             .setSummaryText(contentText)
                             .bigLargeIcon(largeIcon)
                     )

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -74,7 +74,6 @@ class DownloadWorker(
 ) : ForegroundCoroutineWorker(appContext, workerParameters) {
     private var _downloadId: Long = -1L
 
-    private var videoTitle: String? = null
     private var lastForegroundProgress: Int = -1
     private val qualityProfile: QualityProfile = QualityProfile.MAX
 
@@ -105,6 +104,7 @@ class DownloadWorker(
         var wasDownloadDeleted = false
         return coroutineScope mainScope@{
             try {
+                var thumbnailFilePath: String? = null
                 val canStart = when (download.status) {
                     DownloadStatus.QUEUED,
                     DownloadStatus.WAITING_FOR_NETWORK,
@@ -120,7 +120,6 @@ class DownloadWorker(
                     Log.w(LOG_TAG, "$tag Cannot start in status: ${download.status}")
                     return@mainScope Result.failure()
                 }
-
                 analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_STARTED)
 
                 resetProgressAndCleanup()
@@ -160,8 +159,7 @@ class DownloadWorker(
                         ?.fileSizeApproximate
                         ?.takeIf { it > 0L }
 
-                videoTitle = videoInfoTitle ?: "Download_$downloadId"
-
+                val videoTitle = videoInfoTitle ?: "Download_$downloadId"
                 updateDownloadForeground(
                     notificationText = appContext.getString(R.string.notification_text_downloading),
                     indeterminate = true,
@@ -173,7 +171,7 @@ class DownloadWorker(
                 if (videoInfo?.id != null) {
                     withContext(Dispatchers.IO) {
                         runCatching {
-                            val thumbnailFilePath = youtubeDlAndroidUseCase
+                            thumbnailFilePath = youtubeDlAndroidUseCase
                                 .downloadThumbnailUseCase(
                                     url = download.url,
                                     outputDir = uidDir,
@@ -233,14 +231,14 @@ class DownloadWorker(
                     maxBytes = max(maxBytes, directoryBytesSum(uidDir))
                     maxBytes
                 }
-                val title = (videoInfoTitle ?: videoTitle ?: "Download").toSafeFileName()
+                val title = videoTitle.toSafeFileName()
                 val videoTemplate = "${uidDir.absolutePath}/${title} [%(id)s] - Video.%(ext)s"
                 val audioTemplate = "${uidDir.absolutePath}/${title} [%(id)s] - Audio.%(ext)s"
 
                 val phaseContext = PhaseContext(
                     phase = DownloadMediaType.VIDEO,
                     weights = weights,
-                    title = videoTitle ?: download.url,
+                    title = videoTitle,
                     notificationExtras = notificationExtras,
                 )
 
@@ -379,16 +377,16 @@ class DownloadWorker(
                 DeleteAllOrphanDownloadFilesWorker.enqueueDebouncedReplace(appContext)
 
                 val downloadComplete = appContext.getString(R.string.download_complete)
-                val contentText = videoTitle ?: download.url
-
                 Log.d(LOG_TAG, "$tag $downloadComplete")
-                appContext.toast("$downloadComplete: $contentText", true)
+                appContext.toast("$downloadComplete: $videoTitle", true)
+
                 notificationService.notifyDownloaded(
-                    contentText = contentText,
+                    contentText = videoTitle,
                     contentTitle = downloadComplete,
                     extras = notificationExtras,
                     tag = downloadNotificationTag(downloadId),
                     actions = buildCompletedNotificationActions(downloadId),
+                    thumbnailFilePath = thumbnailFilePath,
                 )
                 Result.success()
 


### PR DESCRIPTION
- Add `thumbnailFilePath` parameter to `notifyDownloaded`
- Decode thumbnail via `toNotificationBitmap`
- Pass `bigPicture` through `NotificationOps`
- Apply `BigPictureStyle` when thumbnail is available
- Fetch metadata in `DownloadNotificationActionReceiver` using `getDownloadMetadataByIdAsFlowUseCase`
- Use metadata `title` and `thumbnailFilePath` for notification content
- Replace `videoTitle` property with local variable in `DownloadWorker`
- Capture thumbnail path during download via `downloadThumbnailUseCase`
- Use `videoTitle` consistently for notification and toast
- Remove redundant fallback logic for title handling