### PR TITLE
feat: Add stop all downloads from UI

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/DownloadNotificationActions.kt
@@ -18,7 +18,6 @@ enum class DownloadNotificationActionType {
     UNDO_DELETE,
     RETRY,
     STOP,
-    STOP_ALL,
 }
 
 fun downloadNotificationTag(downloadId: Long): String = "download:$downloadId"
@@ -41,7 +40,6 @@ fun buildDownloadNotificationAction(
         DownloadNotificationActionType.UNDO_DELETE -> R.string.notification_action_undo
         DownloadNotificationActionType.RETRY -> R.string.notification_action_retry
         DownloadNotificationActionType.STOP -> R.string.notification_action_stop
-        DownloadNotificationActionType.STOP_ALL -> R.string.notification_action_stop_all
     }
     val intent = Intent(context, DownloadNotificationActionReceiver::class.java).apply {
         action = ACTION_DOWNLOAD_NOTIFICATION

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
@@ -18,7 +18,6 @@ import org.strigate.ferrot.app.DownloadNotificationActionType.DELETE
 import org.strigate.ferrot.app.DownloadNotificationActionType.MARK_SEEN
 import org.strigate.ferrot.app.DownloadNotificationActionType.RETRY
 import org.strigate.ferrot.app.DownloadNotificationActionType.STOP
-import org.strigate.ferrot.app.DownloadNotificationActionType.STOP_ALL
 import org.strigate.ferrot.app.DownloadNotificationActionType.UNDO_DELETE
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.activeDownloadNotificationTag
@@ -72,10 +71,6 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
                 if (action == null) {
                     return@launch
                 }
-                if (action == STOP_ALL) {
-                    handleStopAll()
-                    return@launch
-                }
                 val downloadId = intent.getStringExtra(EXTRA_DOWNLOAD_ID)?.toLongOrNull()
                 if (downloadId == null || downloadId <= 0L) {
                     return@launch
@@ -119,14 +114,6 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
 
     private suspend fun handleStop(downloadId: Long) {
         stopActiveDownload(downloadId)
-    }
-
-    private suspend fun handleStopAll() {
-        downloadUseCase.getAllDownloadsUseCase()
-            .asSequence()
-            .filter { it.status in ACTIVE_DOWNLOAD_STATUSES }
-            .map { it.id }
-            .forEach { downloadId -> stopActiveDownload(downloadId) }
     }
 
     private suspend fun stopActiveDownload(downloadId: Long) {
@@ -255,15 +242,5 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
         val metadata = downloadMetadataUseCase
             .getDownloadMetadataByIdAsFlowUseCase(download.id).first()
         return metadata?.title?.takeIf { it.isNotBlank() } ?: download.url
-    }
-
-    companion object {
-        private val ACTIVE_DOWNLOAD_STATUSES = setOf(
-            DownloadStatus.METADATA,
-            DownloadStatus.DOWNLOADING,
-            DownloadStatus.QUEUED,
-            DownloadStatus.WAITING_FOR_NETWORK,
-            DownloadStatus.WAITING_FOR_WIFI,
-        )
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadStatusUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadStatusUiData.kt
@@ -11,3 +11,20 @@ enum class DownloadStatusUiData {
     FAILED,
     STOPPED,
 }
+
+val DownloadStatusUiData.isActive: Boolean
+    get() = when (this) {
+        DownloadStatusUiData.QUEUED,
+        DownloadStatusUiData.WAITING_FOR_NETWORK,
+        DownloadStatusUiData.WAITING_FOR_WIFI,
+        DownloadStatusUiData.METADATA,
+        DownloadStatusUiData.DOWNLOADING -> true
+
+        DownloadStatusUiData.PAUSED,
+        DownloadStatusUiData.COMPLETED,
+        DownloadStatusUiData.FAILED,
+        DownloadStatusUiData.STOPPED -> false
+    }
+
+val DownloadStatusUiData.isFailed: Boolean
+    get() = this == DownloadStatusUiData.FAILED

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -97,6 +97,8 @@ import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.model.DownloadItemUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
+import org.strigate.ferrot.presentation.model.isActive
+import org.strigate.ferrot.presentation.model.isFailed
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.theme.TextStyles
@@ -160,7 +162,11 @@ fun DownloadsScreen(
 
     val hasFailedDownloads = remember(uiState) {
         val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
-        downloads.any { it.status == DownloadStatusUiData.FAILED }
+        downloads.any { it.status.isFailed }
+    }
+    val hasActiveDownloads = remember(uiState) {
+        val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
+        downloads.any { it.status.isActive }
     }
     val shouldMarkSelectionSeen = remember(uiState, selectedIds) {
         val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
@@ -421,6 +427,25 @@ fun DownloadsScreen(
                                             delay(RETRY_FAILED_SCROLL_DELAY_MILLIS)
                                             lazyListState.animateScrollToItem(0)
                                         }
+                                        menuExpanded = false
+                                    },
+                                )
+                            }
+                            if (hasActiveDownloads) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            text = stringResource(R.string.notification_action_stop_all),
+                                        )
+                                    },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.Filled.Close,
+                                            contentDescription = stringResource(R.string.notification_action_stop_all),
+                                        )
+                                    },
+                                    onClick = {
+                                        viewModel.stopAllDownloads()
                                         menuExpanded = false
                                     },
                                 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -29,6 +29,7 @@ import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
+import org.strigate.ferrot.presentation.model.isActive
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import javax.inject.Inject
 
@@ -106,16 +107,25 @@ class DownloadsViewModel @Inject constructor(
     }
 
     fun stopDownload(downloadId: Long) = viewModelScope.launch {
-        runCatching {
-            downloadUseCase.updateDownloadStatusUseCase(downloadId, DownloadStatus.STOPPED)
-            downloadProgressUseCase.updateDownloadProgressUseCase(
-                id = downloadId,
-                progressPercent = 0F,
-                bytesDownloaded = 0L,
-                etaSeconds = null,
-            )
+        stopDownloadAndResetProgress(downloadId)
+    }
+
+    fun stopAllDownloads() {
+        val data = uiState.value as? DownloadsUiState.Data ?: return
+        val activeDownloadIds = data.data.downloads
+            .asSequence()
+            .filter { it.status.isActive }
+            .map { it.id }
+            .toList()
+
+        if (activeDownloadIds.isEmpty()) {
+            return
         }
-        stopDownloadsUseCase(downloadId)
+        viewModelScope.launch {
+            activeDownloadIds.forEach { downloadId ->
+                stopDownloadAndResetProgress(downloadId)
+            }
+        }
     }
 
     fun retryDownload(downloadId: Long) = viewModelScope.launch {
@@ -168,6 +178,19 @@ class DownloadsViewModel @Inject constructor(
         viewModelScope.launch {
             downloadUseCase.requestDeletePendingDownloadsImmediateUseCase()
         }
+    }
+
+    private suspend fun stopDownloadAndResetProgress(downloadId: Long) {
+        runCatching {
+            downloadUseCase.updateDownloadStatusUseCase(downloadId, DownloadStatus.STOPPED)
+            downloadProgressUseCase.updateDownloadProgressUseCase(
+                id = downloadId,
+                progressPercent = 0F,
+                bytesDownloaded = 0L,
+                etaSeconds = null,
+            )
+        }
+        stopDownloadsUseCase(downloadId)
     }
 
     companion object {

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -275,6 +275,44 @@ class DownloadsViewModelTest {
     }
 
     @Test
+    fun stopAllDownloads_stopsOnlyActiveDownloads() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(
+                listOf(
+                    createDownload(id = 1L, title = "Queued", status = DownloadStatus.QUEUED),
+                    createDownload(
+                        id = 2L,
+                        title = "Downloading",
+                        status = DownloadStatus.DOWNLOADING
+                    ),
+                    createDownload(id = 3L, title = "Failed", status = DownloadStatus.FAILED),
+                    createDownload(id = 4L, title = "Stopped", status = DownloadStatus.STOPPED),
+                )
+            ),
+            updateFlow = MutableStateFlow(null),
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { it is DownloadsUiState.Data }
+
+        viewModel.stopAllDownloads()
+        advanceUntilIdle()
+
+        verify(updateDownloadStatusUseCase).invoke(1L, DownloadStatus.STOPPED)
+        verify(updateDownloadStatusUseCase).invoke(2L, DownloadStatus.STOPPED)
+        verify(updateDownloadStatusUseCase, never()).invoke(3L, DownloadStatus.STOPPED)
+        verify(updateDownloadStatusUseCase, never()).invoke(4L, DownloadStatus.STOPPED)
+        verify(stopDownloadUseCase).invoke(1L)
+        verify(stopDownloadUseCase).invoke(2L)
+        verify(stopDownloadUseCase, never()).invoke(3L)
+        verify(stopDownloadUseCase, never()).invoke(4L)
+
+        collector.cancel()
+    }
+
+    @Test
     fun retryDownload_startsDownload() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             downloadsFlow = MutableStateFlow(emptyList()),


### PR DESCRIPTION
- Remove `STOP_ALL` handling from `DownloadNotificationActionReceiver`
- Remove `STOP_ALL` from `DownloadNotificationActionType`
- Add `stopAllDownloads` to `DownloadsViewModel`
- Extract `stopDownloadAndResetProgress` helper in `DownloadsViewModel`
- Use `isActive` extension to filter active downloads
- Add `isActive` and `isFailed` extensions to `DownloadStatusUiData`
- Update `DownloadsScreen` to show stop-all option when active downloads exist
- Trigger `stopAllDownloads` from dropdown menu
- Add test `stopAllDownloads_stopsOnlyActiveDownloads`