### PR TITLE
refactor: Migrate workers to trigger-based scheduling and reorganize …

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,8 +21,8 @@
     <application
         android:name=".Ferrot"
         android:allowBackup="false"
-        android:fullBackupContent="@xml/full_backup_content"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/full_backup_content"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_launcher"
@@ -84,6 +84,14 @@
 
         <receiver
             android:name=".app.receiver.DownloadNotificationActionReceiver"
+            android:enabled="true"
+            android:exported="false" />
+        <receiver
+            android:name=".work.trigger.AvailableUpdateDailyTriggerReceiver"
+            android:enabled="true"
+            android:exported="false" />
+        <receiver
+            android:name=".work.trigger.DependencyUpdateDailyTriggerReceiver"
             android:enabled="true"
             android:exported="false" />
 

--- a/app/src/main/kotlin/org/strigate/ferrot/Ferrot.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/Ferrot.kt
@@ -16,10 +16,10 @@ import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.di.WorkerFactory
 import org.strigate.ferrot.app.receiver.AirplaneModeReceiver
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
-import org.strigate.ferrot.work.DeleteAllDuplicateDownloadsWorker
-import org.strigate.ferrot.work.DeleteAllOrphanDownloadFilesWorker
-import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
-import org.strigate.ferrot.work.UpdateDependenciesWorker
+import org.strigate.ferrot.work.trigger.AvailableUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.trigger.DependencyUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.worker.DeleteAllDuplicateDownloadsWorker
+import org.strigate.ferrot.work.worker.DeleteAllOrphanDownloadFilesWorker
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -75,14 +75,14 @@ class Ferrot : Application(), Configuration.Provider, DefaultLifecycleObserver {
             .first()
 
         if (automaticUpdatesSetting) {
-            DownloadAvailableUpdateWorker.enqueuePeriodicKeep(appContext)
+            AvailableUpdateDailyTriggerReceiver.schedule(appContext)
         } else {
-            DownloadAvailableUpdateWorker.cancelPeriodic(appContext)
+            AvailableUpdateDailyTriggerReceiver.cancel(appContext)
         }
         if (automaticDependencyUpdatesSetting) {
-            UpdateDependenciesWorker.enqueuePeriodicKeep(appContext)
+            DependencyUpdateDailyTriggerReceiver.schedule(appContext)
         } else {
-            UpdateDependenciesWorker.cancelPeriodic(appContext)
+            DependencyUpdateDailyTriggerReceiver.cancel(appContext)
         }
         if (automaticDuplicateDownloadDeletionSetting) {
             DeleteAllDuplicateDownloadsWorker.enqueuePeriodicKeep(appContext)

--- a/app/src/main/kotlin/org/strigate/ferrot/app/alarm/DailyWorkAlarmScheduler.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/alarm/DailyWorkAlarmScheduler.kt
@@ -1,0 +1,84 @@
+package org.strigate.ferrot.app.alarm
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.util.calculateDailyTriggerAtMillis
+
+internal object DailyWorkAlarmScheduler {
+    fun schedule(
+        context: Context,
+        receiverClass: Class<out BroadcastReceiver>,
+        requestCode: Int,
+        targetHour: Int,
+    ) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java) ?: return
+        val pendingIntent = createPendingIntent(
+            context = context,
+            receiverClass = receiverClass,
+            requestCode = requestCode,
+            flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        ) ?: return
+
+        val triggerAtMillis = calculateDailyTriggerAtMillis(targetHour)
+        try {
+            alarmManager.setAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerAtMillis,
+                pendingIntent,
+            )
+            Log.d(LOG_TAG, "Scheduled idle-allowed daily alarm for ${receiverClass.simpleName}")
+        } catch (securityException: SecurityException) {
+            Log.w(
+                LOG_TAG,
+                "Failed to schedule alarm for ${receiverClass.simpleName}",
+                securityException
+            )
+        }
+    }
+
+    fun cancel(
+        context: Context,
+        receiverClass: Class<out BroadcastReceiver>,
+        requestCode: Int,
+    ) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java) ?: return
+        val pendingIntent = createPendingIntent(
+            context = context,
+            receiverClass = receiverClass,
+            requestCode = requestCode,
+            flags = PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        ) ?: return
+
+        try {
+            alarmManager.cancel(pendingIntent)
+            pendingIntent.cancel()
+            Log.d(LOG_TAG, "Cancelled daily alarm for ${receiverClass.simpleName}")
+        } catch (securityException: SecurityException) {
+            Log.w(
+                LOG_TAG,
+                "Failed to cancel alarm for ${receiverClass.simpleName}",
+                securityException
+            )
+        }
+    }
+
+    private fun createPendingIntent(
+        context: Context,
+        receiverClass: Class<out BroadcastReceiver>,
+        requestCode: Int,
+        flags: Int,
+    ): PendingIntent? {
+        val intent = Intent(context, receiverClass)
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            flags,
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -22,16 +22,16 @@ import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombi
 import org.strigate.ferrot.domain.usecase.combined.GetPendingDownloadsCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
-import org.strigate.ferrot.work.DeleteAllDuplicateDownloadsWorker
-import org.strigate.ferrot.work.DeleteAllOrphanDownloadFilesWorker
-import org.strigate.ferrot.work.DeleteDownloadsWorker
-import org.strigate.ferrot.work.DeletePendingDownloadDelayedWorker
-import org.strigate.ferrot.work.DeletePendingDownloadsDelayedWorker
-import org.strigate.ferrot.work.DeletePendingDownloadsImmediateWorker
-import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
-import org.strigate.ferrot.work.DownloadWorker
-import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
-import org.strigate.ferrot.work.UpdateDependenciesWorker
+import org.strigate.ferrot.work.worker.DeleteAllDuplicateDownloadsWorker
+import org.strigate.ferrot.work.worker.DeleteAllOrphanDownloadFilesWorker
+import org.strigate.ferrot.work.worker.DeleteDownloadsWorker
+import org.strigate.ferrot.work.worker.DeletePendingDownloadDelayedWorker
+import org.strigate.ferrot.work.worker.DeletePendingDownloadsDelayedWorker
+import org.strigate.ferrot.work.worker.DeletePendingDownloadsImmediateWorker
+import org.strigate.ferrot.work.worker.DownloadAvailableUpdateWorker
+import org.strigate.ferrot.work.worker.DownloadWorker
+import org.strigate.ferrot.work.worker.RequeuePendingDownloadsWorker
+import org.strigate.ferrot.work.worker.UpdateDependenciesWorker
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/AirplaneModeReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/AirplaneModeReceiver.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.util.Log
 import dagger.hilt.android.AndroidEntryPoint
 import org.strigate.ferrot.app.Constants.LOG_TAG
-import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
+import org.strigate.ferrot.work.worker.RequeuePendingDownloadsWorker
 
 @AndroidEntryPoint
 class AirplaneModeReceiver : BroadcastReceiver() {
@@ -17,7 +17,7 @@ class AirplaneModeReceiver : BroadcastReceiver() {
         val state = intent.getBooleanExtra("state", false)
         Log.d(LOG_TAG, "Airplane mode: $state")
         if (!state) {
-            RequeuePendingDownloadsWorker.enqueueOneItem(context)
+            RequeuePendingDownloadsWorker.enqueueOneTime(context)
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/BootCompletedReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/BootCompletedReceiver.kt
@@ -14,8 +14,10 @@ import kotlinx.coroutines.launch
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.StateUseCase
-import org.strigate.ferrot.work.DeleteAllDuplicateDownloadsWorker
-import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
+import org.strigate.ferrot.work.trigger.AvailableUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.trigger.DependencyUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.worker.DeleteAllDuplicateDownloadsWorker
+import org.strigate.ferrot.work.worker.RequeuePendingDownloadsWorker
 import javax.inject.Inject
 import kotlin.math.abs
 
@@ -28,7 +30,10 @@ class BootCompletedReceiver : BroadcastReceiver() {
     lateinit var settingsUseCase: SettingsUseCase
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != Intent.ACTION_BOOT_COMPLETED) {
+        if (
+            intent.action != Intent.ACTION_BOOT_COMPLETED &&
+            intent.action != "android.intent.action.QUICKBOOT_POWERON"
+        ) {
             return
         }
         val currentBootTimeMillis = System.currentTimeMillis() - SystemClock.elapsedRealtime()
@@ -38,10 +43,27 @@ class BootCompletedReceiver : BroadcastReceiver() {
                 stateUseCase.saveBootTimeMillisUseCase(currentBootTimeMillis)
                 Log.d(LOG_TAG, "Boot completed received")
 
-                RequeuePendingDownloadsWorker.enqueueOneItem(context)
+                RequeuePendingDownloadsWorker.enqueueOneTime(context)
+                val automaticUpdatesSetting = settingsUseCase
+                    .getAutomaticUpdatesSettingAsFlowUseCase()
+                    .first()
+                val automaticDependencyUpdatesSetting = settingsUseCase
+                    .getAutomaticDependencyUpdatesSettingAsFlowUseCase()
+                    .first()
                 val automaticDuplicateDownloadDeletionSetting = settingsUseCase
                     .getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase()
                     .first()
+
+                if (automaticUpdatesSetting) {
+                    AvailableUpdateDailyTriggerReceiver.schedule(context)
+                } else {
+                    AvailableUpdateDailyTriggerReceiver.cancel(context)
+                }
+                if (automaticDependencyUpdatesSetting) {
+                    DependencyUpdateDailyTriggerReceiver.schedule(context)
+                } else {
+                    DependencyUpdateDailyTriggerReceiver.cancel(context)
+                }
                 if (automaticDuplicateDownloadDeletionSetting) {
                     DeleteAllDuplicateDownloadsWorker.enqueueDebouncedReplace(context)
                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/MyPackageReplacedReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/MyPackageReplacedReceiver.kt
@@ -14,13 +14,17 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.provider.UpdatePathProvider
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
-import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
-import org.strigate.ferrot.work.UpdateDependenciesWorker
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.work.trigger.AvailableUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.trigger.DependencyUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.worker.RequeuePendingDownloadsWorker
+import org.strigate.ferrot.work.worker.UpdateDependenciesWorker
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -32,6 +36,9 @@ class MyPackageReplacedReceiver : BroadcastReceiver() {
     @Inject
     lateinit var availableUpdateUseCase: AvailableUpdateUseCase
 
+    @Inject
+    lateinit var settingsUseCase: SettingsUseCase
+
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) {
             return
@@ -42,6 +49,23 @@ class MyPackageReplacedReceiver : BroadcastReceiver() {
             try {
                 availableUpdateUseCase.clearAvailableUpdateUseCase()
                 updatePathProvider.updatesDir().deleteRecursively()
+                val automaticUpdatesSetting = settingsUseCase
+                    .getAutomaticUpdatesSettingAsFlowUseCase()
+                    .first()
+                val automaticDependencyUpdatesSetting = settingsUseCase
+                    .getAutomaticDependencyUpdatesSettingAsFlowUseCase()
+                    .first()
+
+                if (automaticUpdatesSetting) {
+                    AvailableUpdateDailyTriggerReceiver.schedule(appContext)
+                } else {
+                    AvailableUpdateDailyTriggerReceiver.cancel(appContext)
+                }
+                if (automaticDependencyUpdatesSetting) {
+                    DependencyUpdateDailyTriggerReceiver.schedule(appContext)
+                } else {
+                    DependencyUpdateDailyTriggerReceiver.cancel(appContext)
+                }
 
                 val constraints = Constraints.Builder()
                     .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyAutomaticDuplicateDownloadDeletionSettingUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyAutomaticDuplicateDownloadDeletionSettingUseCase.kt
@@ -2,7 +2,7 @@ package org.strigate.ferrot.domain.usecase.apply
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import org.strigate.ferrot.work.DeleteAllDuplicateDownloadsWorker
+import org.strigate.ferrot.work.worker.DeleteAllDuplicateDownloadsWorker
 import javax.inject.Inject
 
 class ApplyAutomaticDuplicateDownloadDeletionSettingUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCase.kt
@@ -10,7 +10,7 @@ import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadErrorMessageUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
 import org.strigate.ferrot.util.NetworkOps
-import org.strigate.ferrot.work.DownloadWorker
+import org.strigate.ferrot.work.worker.DownloadWorker
 import javax.inject.Inject
 
 class ApplyWifiOnlyPolicyUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeleteDownloadsUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeleteDownloadsUseCase.kt
@@ -2,7 +2,7 @@ package org.strigate.ferrot.domain.usecase.download
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import org.strigate.ferrot.work.DeleteDownloadsWorker
+import org.strigate.ferrot.work.worker.DeleteDownloadsWorker
 import javax.inject.Inject
 
 class RequestDeleteDownloadsUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadDelayedUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadDelayedUseCase.kt
@@ -2,7 +2,7 @@ package org.strigate.ferrot.domain.usecase.download
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import org.strigate.ferrot.work.DeletePendingDownloadDelayedWorker
+import org.strigate.ferrot.work.worker.DeletePendingDownloadDelayedWorker
 import javax.inject.Inject
 
 class RequestDeletePendingDownloadDelayedUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadsDelayedUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadsDelayedUseCase.kt
@@ -2,7 +2,7 @@ package org.strigate.ferrot.domain.usecase.download
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import org.strigate.ferrot.work.DeletePendingDownloadsDelayedWorker
+import org.strigate.ferrot.work.worker.DeletePendingDownloadsDelayedWorker
 import javax.inject.Inject
 
 class RequestDeletePendingDownloadsDelayedUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadsImmediateUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestDeletePendingDownloadsImmediateUseCase.kt
@@ -2,7 +2,7 @@ package org.strigate.ferrot.domain.usecase.download
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import org.strigate.ferrot.work.DeletePendingDownloadsImmediateWorker
+import org.strigate.ferrot.work.worker.DeletePendingDownloadsImmediateWorker
 import javax.inject.Inject
 
 class RequestDeletePendingDownloadsImmediateUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCase.kt
@@ -12,7 +12,7 @@ import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.util.NetworkOps
-import org.strigate.ferrot.work.DownloadWorker
+import org.strigate.ferrot.work.worker.DownloadWorker
 import javax.inject.Inject
 
 class StartDownloadUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StopDownloadUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StopDownloadUseCase.kt
@@ -2,7 +2,7 @@ package org.strigate.ferrot.domain.usecase.download
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import org.strigate.ferrot.work.DownloadWorker
+import org.strigate.ferrot.work.worker.DownloadWorker
 import javax.inject.Inject
 
 class StopDownloadUseCase @Inject constructor(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -21,8 +21,10 @@ import org.strigate.ferrot.presentation.model.UpdatesInfoUiData
 import org.strigate.ferrot.presentation.model.UpdatesSettingsUiData
 import org.strigate.ferrot.presentation.model.UpdatesUiData
 import org.strigate.ferrot.presentation.state.UpdatesUiState
-import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
-import org.strigate.ferrot.work.UpdateDependenciesWorker
+import org.strigate.ferrot.work.trigger.AvailableUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.trigger.DependencyUpdateDailyTriggerReceiver
+import org.strigate.ferrot.work.worker.DownloadAvailableUpdateWorker
+import org.strigate.ferrot.work.worker.UpdateDependenciesWorker
 import javax.inject.Inject
 
 @HiltViewModel
@@ -66,9 +68,9 @@ class UpdatesViewModel @Inject constructor(
         viewModelScope.launch {
             settingsUseCase.saveAutomaticUpdatesSettingUseCase(enabled)
             if (enabled) {
-                DownloadAvailableUpdateWorker.enqueuePeriodicKeep(appContext)
+                AvailableUpdateDailyTriggerReceiver.schedule(appContext)
             } else {
-                DownloadAvailableUpdateWorker.cancelPeriodic(appContext)
+                AvailableUpdateDailyTriggerReceiver.cancel(appContext)
             }
         }
     }
@@ -84,9 +86,9 @@ class UpdatesViewModel @Inject constructor(
         viewModelScope.launch {
             settingsUseCase.saveAutomaticDependencyUpdatesSettingUseCase(enabled)
             if (enabled) {
-                UpdateDependenciesWorker.enqueuePeriodicKeep(appContext)
+                DependencyUpdateDailyTriggerReceiver.schedule(appContext)
             } else {
-                UpdateDependenciesWorker.cancelPeriodic(appContext)
+                DependencyUpdateDailyTriggerReceiver.cancel(appContext)
             }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/util/WorkSchedule.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/WorkSchedule.kt
@@ -22,3 +22,15 @@ internal fun calculateDailyInitialDelayMillis(
     }
     return between(now, firstRun).toMillis()
 }
+
+internal fun calculateDailyTriggerAtMillis(
+    targetHour: Int,
+    zoneId: ZoneId = ZoneId.systemDefault(),
+    now: ZonedDateTime = ZonedDateTime.now(zoneId),
+): Long {
+    return now.toInstant().toEpochMilli() + calculateDailyInitialDelayMillis(
+        targetHour = targetHour,
+        zoneId = zoneId,
+        now = now,
+    )
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/trigger/AvailableUpdateDailyTriggerReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/trigger/AvailableUpdateDailyTriggerReceiver.kt
@@ -1,0 +1,42 @@
+package org.strigate.ferrot.work.trigger
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.WorkManager
+import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_DOWNLOAD_AVAILABLE_UPDATE
+import org.strigate.ferrot.app.alarm.DailyWorkAlarmScheduler
+import org.strigate.ferrot.work.worker.DownloadAvailableUpdateWorker
+
+class AvailableUpdateDailyTriggerReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        DownloadAvailableUpdateWorker.enqueueOneTimeReplace(context)
+        schedule(context)
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 3001
+        private const val TARGET_HOUR = 3
+
+        fun schedule(context: Context) {
+            WorkManager.getInstance(context)
+                .cancelUniqueWork(PERIODIC_DOWNLOAD_AVAILABLE_UPDATE)
+            DailyWorkAlarmScheduler.schedule(
+                context = context,
+                receiverClass = AvailableUpdateDailyTriggerReceiver::class.java,
+                requestCode = REQUEST_CODE,
+                targetHour = TARGET_HOUR,
+            )
+        }
+
+        fun cancel(context: Context) {
+            DailyWorkAlarmScheduler.cancel(
+                context = context,
+                receiverClass = AvailableUpdateDailyTriggerReceiver::class.java,
+                requestCode = REQUEST_CODE,
+            )
+            WorkManager.getInstance(context)
+                .cancelUniqueWork(PERIODIC_DOWNLOAD_AVAILABLE_UPDATE)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/trigger/DependencyUpdateDailyTriggerReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/trigger/DependencyUpdateDailyTriggerReceiver.kt
@@ -1,0 +1,42 @@
+package org.strigate.ferrot.work.trigger
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.WorkManager
+import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
+import org.strigate.ferrot.app.alarm.DailyWorkAlarmScheduler
+import org.strigate.ferrot.work.worker.UpdateDependenciesWorker
+
+class DependencyUpdateDailyTriggerReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        UpdateDependenciesWorker.enqueueOneTimeReplace(context)
+        schedule(context)
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 3002
+        private const val TARGET_HOUR = 4
+
+        fun schedule(context: Context) {
+            WorkManager.getInstance(context)
+                .cancelUniqueWork(PERIODIC_UPDATE_DEPENDENCIES)
+            DailyWorkAlarmScheduler.schedule(
+                context = context,
+                receiverClass = DependencyUpdateDailyTriggerReceiver::class.java,
+                requestCode = REQUEST_CODE,
+                targetHour = TARGET_HOUR,
+            )
+        }
+
+        fun cancel(context: Context) {
+            DailyWorkAlarmScheduler.cancel(
+                context = context,
+                receiverClass = DependencyUpdateDailyTriggerReceiver::class.java,
+                requestCode = REQUEST_CODE,
+            )
+            WorkManager.getInstance(context)
+                .cancelUniqueWork(PERIODIC_UPDATE_DEPENDENCIES)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeleteAllDuplicateDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeleteAllDuplicateDownloadsWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeleteAllOrphanDownloadFilesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeleteAllOrphanDownloadFilesWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeleteDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeleteDownloadsWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeletePendingDownloadDelayedWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeletePendingDownloadDelayedWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeletePendingDownloadsDelayedWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeletePendingDownloadsDelayedWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeletePendingDownloadsImmediateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DeletePendingDownloadsImmediateWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DownloadAvailableUpdateWorker.kt
@@ -1,14 +1,12 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
-import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.Dispatchers
@@ -25,14 +23,12 @@ import org.strigate.ferrot.app.Constants.Extras.EXTRA_AVAILABLE_UPDATE_APK_FILE_
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_AVAILABLE_UPDATE_VERSION_TAG
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_DOWNLOAD_AVAILABLE_UPDATE
-import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_DOWNLOAD_AVAILABLE_UPDATE
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.provider.UpdatePathProvider
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.extensions.toast
-import org.strigate.ferrot.util.calculateDailyInitialDelayMillis
 import org.strigate.ferrot.util.isAppInForeground
 import org.strigate.ferrot.util.setExpeditedIfAllowed
 import java.io.File
@@ -446,38 +442,6 @@ class DownloadAvailableUpdateWorker(
     }
 
     companion object {
-        fun enqueuePeriodicKeep(
-            context: Context,
-            targetHour: Int = 3,
-            flexHours: Long = 1,
-        ) {
-            val initialDelayMillis = calculateDailyInitialDelayMillis(targetHour)
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .setRequiresCharging(false)
-                .setRequiresBatteryNotLow(false)
-                .setRequiresStorageNotLow(true)
-                .build()
-
-            val periodicWorkRequest = PeriodicWorkRequestBuilder<DownloadAvailableUpdateWorker>(
-                repeatInterval = 1,
-                repeatIntervalTimeUnit = TimeUnit.DAYS,
-                flexTimeInterval = flexHours,
-                flexTimeIntervalUnit = TimeUnit.HOURS,
-            )
-                .setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
-                .setConstraints(constraints)
-                .addTag(Constants.Work.Tag.DOWNLOAD_AVAILABLE_UPDATE)
-                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-                .build()
-
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                PERIODIC_DOWNLOAD_AVAILABLE_UPDATE,
-                ExistingPeriodicWorkPolicy.KEEP,
-                periodicWorkRequest,
-            )
-        }
-
         fun enqueueOneTimeReplace(
             context: Context,
         ) {
@@ -500,10 +464,6 @@ class DownloadAvailableUpdateWorker(
                 ExistingWorkPolicy.REPLACE,
                 oneTimeWorkRequest,
             )
-        }
-
-        fun cancelPeriodic(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_DOWNLOAD_AVAILABLE_UPDATE)
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/DownloadWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.os.Build

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/RequeuePendingDownloadsWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/RequeuePendingDownloadsWorker.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log
@@ -29,7 +29,7 @@ class RequeuePendingDownloadsWorker(
     }
 
     companion object {
-        fun enqueueOneItem(context: Context) {
+        fun enqueueOneTime(context: Context) {
             val oneTimeWorkRequestBuilder =
                 OneTimeWorkRequestBuilder<RequeuePendingDownloadsWorker>()
             val oneTimeWorkRequest = oneTimeWorkRequestBuilder

--- a/app/src/main/kotlin/org/strigate/ferrot/work/worker/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/worker/UpdateDependenciesWorker.kt
@@ -1,25 +1,21 @@
-package org.strigate.ferrot.work
+package org.strigate.ferrot.work.worker
 
 import android.content.Context
 import android.util.Log
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
-import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.yausername.youtubedl_android.YoutubeDL
 import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_UPDATE_DEPENDENCIES
-import org.strigate.ferrot.app.Constants.Work.Name.PERIODIC_UPDATE_DEPENDENCIES
 import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.extensions.toast
-import org.strigate.ferrot.util.calculateDailyInitialDelayMillis
 import org.strigate.ferrot.util.isAppInForeground
 import org.strigate.ferrot.util.setExpeditedIfAllowed
 import java.util.concurrent.TimeUnit
@@ -81,39 +77,6 @@ class UpdateDependenciesWorker(
     }
 
     companion object {
-        fun enqueuePeriodicKeep(
-            context: Context,
-            repeatIntervalDays: Long = 3,
-            targetHour: Int = 4,
-            flexHours: Long = 2,
-        ) {
-            val initialDelayMillis = calculateDailyInitialDelayMillis(targetHour)
-
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .setRequiresCharging(false)
-                .setRequiresBatteryNotLow(false)
-                .setRequiresStorageNotLow(true)
-                .build()
-
-            val periodicWorkRequest = PeriodicWorkRequestBuilder<UpdateDependenciesWorker>(
-                repeatInterval = repeatIntervalDays,
-                repeatIntervalTimeUnit = TimeUnit.DAYS,
-                flexTimeInterval = flexHours,
-                flexTimeIntervalUnit = TimeUnit.HOURS,
-            )
-                .setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
-                .setConstraints(constraints)
-                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
-                .build()
-
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-                PERIODIC_UPDATE_DEPENDENCIES,
-                ExistingPeriodicWorkPolicy.KEEP,
-                periodicWorkRequest,
-            )
-        }
-
         fun enqueueOneTimeReplace(
             context: Context,
         ) {
@@ -135,10 +98,6 @@ class UpdateDependenciesWorker(
                 ExistingWorkPolicy.REPLACE,
                 oneTimeWorkRequest,
             )
-        }
-
-        fun cancelPeriodic(context: Context) {
-            WorkManager.getInstance(context).cancelUniqueWork(PERIODIC_UPDATE_DEPENDENCIES)
         }
     }
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/util/WorkScheduleTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/util/WorkScheduleTest.kt
@@ -44,4 +44,21 @@ class WorkScheduleTest {
         )
         assertEquals(24 * 60 * 60 * 1000L, result)
     }
+
+    @Test
+    fun calculateDailyTriggerAtMillis_returnsExpectedTimestamp_whenBeforeTargetHour() {
+        val zoneId = ZoneId.of("UTC")
+        val now = ZonedDateTime.of(2026, 3, 4, 2, 15, 0, 0, zoneId)
+
+        val result = calculateDailyTriggerAtMillis(
+            targetHour = 3,
+            zoneId = zoneId,
+            now = now,
+        )
+
+        assertEquals(
+            ZonedDateTime.of(2026, 3, 4, 3, 0, 0, 0, zoneId).toInstant().toEpochMilli(),
+            result,
+        )
+    }
 }


### PR DESCRIPTION
…packages

- Replace periodic work in `Ferrot` with trigger scheduling via `AvailableUpdateDailyTriggerReceiver` and `DependencyUpdateDailyTriggerReceiver
- Update `UpdatesViewModel` to use trigger-based scheduling instead of worker periodic APIs
- Update `MyPackageReplacedReceiver` to reschedule triggers based on settings
- Inject `SettingsUseCase` into `MyPackageReplacedReceiver` and use flows with `first`
- Move worker classes into `work.worker` package
- Introduce `work.trigger` package for scheduling receivers
- Remove periodic scheduling logic from `UpdateDependenciesWorker`
- Delete legacy `UpdateDependenciesWorker` and recreate simplified version under new package
- Delete legacy `RequeuePendingDownloadsWorker` and recreate under new package
- Rename `RequeuePendingDownloadsWorker.enqueueOneItem` to `enqueueOneTime`
- Update all imports to reflect new worker package structure
- Add `calculateDailyTriggerAtMillis` utility for trigger scheduling
- Add unit test for `calculateDailyTriggerAtMillis`