### PR TITLE
feat: Improve downloads UI and progress behavior

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -80,7 +80,7 @@ fun DownloadPrimaryActionButton(
     ) {
         Box(
             modifier = Modifier
-                .size(dimens.iconLarge),
+                .size(dimens.downloadListThumbnailSize),
             contentAlignment = Alignment.Center,
         ) {
             thumbnailFile?.let {
@@ -102,7 +102,7 @@ fun DownloadPrimaryActionButton(
             }
             Box(
                 modifier = Modifier
-                    .size(dimens.overlayButtonSmall)
+                    .size(dimens.downloadListOverlayButtonSize)
                     .clip(CircleShape)
                     .background(overlayScrim),
                 contentAlignment = Alignment.Center,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,6 +30,7 @@ fun DownloadProgressSection(
     completedAtMillis: Long?,
     modifier: Modifier = Modifier,
     forcePrimaryBar: Boolean = false,
+    alwaysShowBar: Boolean = true,
 ) {
     val dimens = LocalDimens.current
     val running = when (status) {
@@ -44,18 +46,21 @@ fun DownloadProgressSection(
         DownloadStatusUiData.STOPPED -> 0f
         else -> null
     }
+    val showBar = running || alwaysShowBar
     Column(
         modifier = modifier,
     ) {
-        DownloadProgressBar(
-            progress = progress,
-            running = running,
-            forcePrimary = forcePrimaryBar,
-        )
-        Spacer(modifier = Modifier.height(dimens.spacingXSmall))
+        if (showBar) {
+            DownloadProgressBar(
+                progress = progress,
+                running = running,
+                forcePrimary = forcePrimaryBar,
+            )
+            Spacer(modifier = Modifier.height(dimens.spacingXSmall))
+        }
         Box(
             modifier = Modifier
-                .height(dimens.spacingLarge),
+                .heightIn(min = dimens.spacingLarge),
         ) {
             StatusSizeEtaRow(
                 status = status,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -473,7 +474,15 @@ fun DownloadsScreen(
             }
         },
         snackbarHost = {
-            SnackbarHost(snackbarHostState)
+            SnackbarHost(snackbarHostState) { snackbarData ->
+                Snackbar(
+                    snackbarData = snackbarData,
+                    containerColor = MaterialTheme.colorScheme.inverseSurface,
+                    contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                    actionColor = MaterialTheme.colorScheme.inversePrimary,
+                    dismissActionContentColor = MaterialTheme.colorScheme.inverseOnSurface,
+                )
+            }
         },
     ) { contentPadding ->
         Surface(
@@ -962,6 +971,13 @@ private fun DownloadItem(
                 modifier = Modifier
                     .weight(1f),
             ) {
+                val showInlineProgressBar = when (item.status) {
+                    DownloadStatusUiData.QUEUED,
+                    DownloadStatusUiData.METADATA,
+                    DownloadStatusUiData.DOWNLOADING -> true
+
+                    else -> false
+                }
                 val showUnseen = !item.seen && item.status == DownloadStatusUiData.COMPLETED
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -992,13 +1008,22 @@ private fun DownloadItem(
                         )
                     }
                 }
-                Spacer(modifier = Modifier.height(dimens.spacingMediumAlt))
+                Spacer(
+                    modifier = Modifier.height(
+                        if (showInlineProgressBar) {
+                            dimens.spacingMediumAlt
+                        } else {
+                            dimens.spacingXXSmall
+                        },
+                    ),
+                )
                 DownloadProgressSection(
                     status = item.status,
                     progressFraction = item.progressFraction,
                     etaSeconds = item.etaSeconds,
                     bytesDownloaded = item.bytesDownloaded,
                     completedAtMillis = item.completedAtMillis,
+                    alwaysShowBar = false,
                 )
             }
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Dimens.kt
@@ -46,6 +46,9 @@ data class Dimens(
     val overlayButton: Dp = 56.dp,
     val overlayIcon: Dp = 48.dp,
 
+    val downloadListThumbnailSize: Dp = 68.dp,
+    val downloadListOverlayButtonSize: Dp = 28.dp,
+
     val thumbnailHeight: Dp = 240.dp,
     val actionIconSize: Dp = 38.dp,
     val dotSize: Dp = 8.dp,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Theme.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Theme.kt
@@ -34,6 +34,9 @@ private val LightColorScheme = lightColorScheme(
     surfaceVariant = Color(0xFFF6ECE9),
     onSurfaceVariant = Color(0xFF51423D),
     surfaceContainer = Color(0xFFFAF6F4),
+    inverseSurface = Color(0xFF2F2B2A),
+    inverseOnSurface = Color(0xFFF8EEEA),
+    inversePrimary = FerrotCoral,
 
     error = Color(0xFFB3261E),
     onError = Color.White,
@@ -65,6 +68,9 @@ private val DarkColorScheme = darkColorScheme(
     surfaceVariant = Color(0xFF2A2220),
     onSurfaceVariant = Color(0xFFD5C5BF),
     surfaceContainer = Color(0xFF1A1615),
+    inverseSurface = Color(0xFFF8EEEA),
+    inverseOnSurface = Color(0xFF2A1F1B),
+    inversePrimary = Color(0xFFFF6F3C),
 
     error = Color(0xFFF2B8B5),
     onError = Color(0xFF601410),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
@@ -26,7 +26,7 @@ val Typography = Typography(
     bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
+        fontSize = 17.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp,
     ),


### PR DESCRIPTION
- Add custom `Snackbar` styling using `inverseSurface`, `inverseOnSurface`, and `inversePrimary`
- Introduce `showInlineProgressBar` logic in `DownloadsScreen`
- Adjust spacing dynamically based on inline progress visibility
- Add `alwaysShowBar` parameter to `DownloadProgressSection`
- Hide progress bar when not needed unless explicitly forced
- Replace fixed height with `heightIn` for flexible layout
- Update thumbnail size to use `downloadListThumbnailSize`
- Update overlay button size to use `downloadListOverlayButtonSize`
- Add new dimens `downloadListThumbnailSize` and `downloadListOverlayButtonSize`
- Increase `bodyLarge` font size from `16.sp` to `17.sp`
- Add `inverseSurface`, `inverseOnSurface`, and `inversePrimary` colors to theme