### PR TITLE
feat: Add install update event and polish downloads UI

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/AvailableUpdateBanner.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/AvailableUpdateBanner.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import org.strigate.ferrot.R
@@ -34,10 +35,10 @@ fun AvailableUpdateBanner(
                 .clickable {
                     onClick(localFilePath)
                 },
-            shape = MaterialTheme.shapes.medium,
+            shape = RectangleShape,
             color = MaterialTheme.colorScheme.secondaryContainer,
-            tonalElevation = dimens.tonalElevationHigh,
-            shadowElevation = dimens.shadowElevationLow,
+            tonalElevation = dimens.zero,
+            shadowElevation = dimens.zero,
         ) {
             Row(
                 modifier = Modifier

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/event/DownloadsEvent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/event/DownloadsEvent.kt
@@ -1,0 +1,5 @@
+package org.strigate.ferrot.presentation.event
+
+sealed interface DownloadsEvent {
+    data class InstallUpdate(val path: String) : DownloadsEvent
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -5,8 +5,10 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -96,6 +98,7 @@ import org.strigate.ferrot.presentation.component.DownloadProgressSection
 import org.strigate.ferrot.presentation.component.state.EmptyState
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
+import org.strigate.ferrot.presentation.event.DownloadsEvent
 import org.strigate.ferrot.presentation.model.DownloadItemUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.isActive
@@ -119,6 +122,7 @@ fun DownloadsScreen(
     viewModel: DownloadsViewModel = hiltViewModel(),
 ) {
     val dimens = LocalDimens.current
+    val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
 
     val lazyListState = rememberLazyListState()
@@ -181,6 +185,15 @@ fun DownloadsScreen(
     }
     LaunchedEffect(Unit) {
         viewModel.logShown()
+    }
+    LaunchedEffect(Unit) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is DownloadsEvent.InstallUpdate -> {
+                    InstallHelper.requestInstallApkIfExists(context, event.path)
+                }
+            }
+        }
     }
     LifecycleEffect {
         on(Lifecycle.Event.ON_START) {
@@ -506,16 +519,13 @@ fun DownloadsScreen(
                                 .fillMaxSize(),
                         ) {
                             availableUpdate?.let {
-                                val context = LocalContext.current
                                 AvailableUpdateBanner(
                                     modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = dimens.spacingMedium)
-                                        .padding(bottom = dimens.spacingSmall),
+                                        .fillMaxWidth(),
                                     tag = it.tag,
                                     localFilePath = it.localFilePath,
-                                    onClick = { filePath ->
-                                        InstallHelper.requestInstallApkIfExists(context, filePath)
+                                    onClick = {
+                                        viewModel.installAvailableUpdate()
                                     },
                                 )
                             }
@@ -633,6 +643,7 @@ private fun DownloadsList(
     onBulkDismissAnimationFinished: (Long) -> Unit,
     onMarkPendingDelete: (Set<Long>) -> Unit,
 ) {
+    val dimens = LocalDimens.current
     val coroutineScope = rememberCoroutineScope()
     val itemIds = remember(items) { items.map(DownloadItemUiData::id) }
     val animatingOutIds = remember { mutableStateMapOf<Long, Boolean>() }
@@ -731,6 +742,8 @@ private fun DownloadsList(
             modifier = Modifier
                 .fillMaxSize(),
             state = lazyListState,
+            contentPadding = PaddingValues(vertical = dimens.spacingXSmall),
+            verticalArrangement = Arrangement.spacedBy(dimens.spacingXXSmall),
         ) {
             items(
                 items = items,
@@ -838,67 +851,64 @@ private fun DownloadsListRow(
         enter = Transitions.listItemEnter,
         exit = Transitions.listItemExit,
     ) {
-        Column {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .onGloballyPositioned { coordinates ->
-                        rowWidthPx = coordinates.size.width.toFloat()
-                    },
-            ) {
-                SwipeToDismissBox(
-                    state = dismissState,
-                    enableDismissFromStartToEnd = false,
-                    enableDismissFromEndToStart = swipeEnabled,
-                    backgroundContent = {
-                        Surface(
-                            color = MaterialTheme.colorScheme.errorContainer,
-                            shape = MaterialTheme.shapes.medium,
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .onGloballyPositioned { coordinates ->
+                    rowWidthPx = coordinates.size.width.toFloat()
+                },
+        ) {
+            SwipeToDismissBox(
+                state = dismissState,
+                enableDismissFromStartToEnd = false,
+                enableDismissFromEndToStart = swipeEnabled,
+                backgroundContent = {
+                    Surface(
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        shape = MaterialTheme.shapes.medium,
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize(),
+                            contentAlignment = Alignment.CenterEnd,
                         ) {
-                            Box(
+                            Icon(
                                 modifier = Modifier
-                                    .fillMaxSize(),
-                                contentAlignment = Alignment.CenterEnd,
-                            ) {
-                                Icon(
-                                    modifier = Modifier
-                                        .padding(end = dimens.spacingMedium),
-                                    imageVector = Icons.Filled.Delete,
-                                    tint = MaterialTheme.colorScheme.onErrorContainer,
-                                    contentDescription = null,
-                                )
-                            }
+                                    .padding(end = dimens.spacingMedium),
+                                imageVector = Icons.Filled.Delete,
+                                tint = MaterialTheme.colorScheme.onErrorContainer,
+                                contentDescription = null,
+                            )
+                        }
+                    }
+                },
+            ) {
+                DownloadItem(
+                    item = item,
+                    isSelected = isSelected,
+                    longClickEnabled = swipeEnabled,
+                    onClick = {
+                        if (selectedIds.isNotEmpty()) {
+                            onSelectionChange(toggleSelection(selectedIds, item.id))
+                        } else {
+                            onItemClick(item)
                         }
                     },
-                ) {
-                    DownloadItem(
-                        item = item,
-                        isSelected = isSelected,
-                        longClickEnabled = swipeEnabled,
-                        onClick = {
-                            if (selectedIds.isNotEmpty()) {
-                                onSelectionChange(toggleSelection(selectedIds, item.id))
-                            } else {
-                                onItemClick(item)
-                            }
-                        },
-                        onLongClick = {
-                            onSelectionChange(selectedIds + item.id)
-                        },
-                        onPauseResume = {
-                            onPauseResume(item)
-                        },
-                        onOpen = {
-                            if (selectedIds.isNotEmpty()) {
-                                onSelectionChange(toggleSelection(selectedIds, item.id))
-                            } else {
-                                onItemClick(item)
-                            }
-                        },
-                    )
-                }
+                    onLongClick = {
+                        onSelectionChange(selectedIds + item.id)
+                    },
+                    onPauseResume = {
+                        onPauseResume(item)
+                    },
+                    onOpen = {
+                        if (selectedIds.isNotEmpty()) {
+                            onSelectionChange(toggleSelection(selectedIds, item.id))
+                        } else {
+                            onItemClick(item)
+                        }
+                    },
+                )
             }
-            Spacer(modifier = Modifier.height(dimens.spacingXXSmall))
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -8,9 +8,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
@@ -25,6 +27,7 @@ import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
+import org.strigate.ferrot.presentation.event.DownloadsEvent
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
@@ -49,6 +52,12 @@ class DownloadsViewModel @Inject constructor(
         TextFieldValue(text = "", selection = TextRange(0))
     )
     val searchQuery: StateFlow<TextFieldValue> = _searchQuery
+
+    private val _events = MutableSharedFlow<DownloadsEvent>(
+        replay = 0,
+        extraBufferCapacity = 1,
+    )
+    val events = _events.asSharedFlow()
 
     val uiState: StateFlow<DownloadsUiState> = getUiState().stateIn(
         scope = viewModelScope,
@@ -177,6 +186,17 @@ class DownloadsViewModel @Inject constructor(
     fun requestDeletePendingDownloadsImmediate() {
         viewModelScope.launch {
             downloadUseCase.requestDeletePendingDownloadsImmediateUseCase()
+        }
+    }
+
+    fun installAvailableUpdate() {
+        val data = uiState.value as? DownloadsUiState.Data ?: return
+        val localFilePath = data.data.availableUpdate?.localFilePath
+        if (localFilePath.isNullOrBlank()) {
+            return
+        }
+        viewModelScope.launch {
+            _events.emit(DownloadsEvent.InstallUpdate(localFilePath))
         }
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -4,8 +4,10 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -45,6 +47,7 @@ import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
 import org.strigate.ferrot.domain.usecase.downloadprogress.UpdateDownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
+import org.strigate.ferrot.presentation.event.DownloadsEvent
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import kotlin.time.Duration.Companion.seconds
 
@@ -453,6 +456,70 @@ class DownloadsViewModelTest {
         advanceUntilIdle()
 
         verify(requestDeletePendingDownloadsImmediateUseCase).invoke()
+    }
+
+    @Test
+    fun installAvailableUpdate_emitsInstallEvent() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(emptyList()),
+            updateFlow = MutableStateFlow(
+                AvailableUpdate(
+                    tag = "v1.2.3",
+                    localFilePath = "/tmp/update.apk",
+                )
+            ),
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadsUiState.Data ?: return@waitForUiState false
+            data.data.availableUpdate?.localFilePath == "/tmp/update.apk"
+        }
+
+        val eventDeferred = backgroundScope.async { viewModel.events.first() }
+
+        viewModel.installAvailableUpdate()
+        advanceUntilIdle()
+
+        assertEquals(
+            DownloadsEvent.InstallUpdate("/tmp/update.apk"),
+            eventDeferred.await(),
+        )
+        collector.cancel()
+    }
+
+    @Test
+    fun installAvailableUpdate_doesNothingWithoutLocalFilePath() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(emptyList()),
+            updateFlow = MutableStateFlow(
+                AvailableUpdate(
+                    tag = "v1.2.3",
+                    localFilePath = null,
+                )
+            ),
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { it is DownloadsUiState.Data }
+
+        var emittedEvent: DownloadsEvent? = null
+        val eventCollector = backgroundScope.launch {
+            viewModel.events.collect { event ->
+                emittedEvent = event
+            }
+        }
+
+        viewModel.installAvailableUpdate()
+        advanceUntilIdle()
+
+        assertNull(emittedEvent)
+        eventCollector.cancel()
+        collector.cancel()
     }
 
     private fun createViewModel(


### PR DESCRIPTION
- Add `DownloadsEvent` sealed interface with `InstallUpdate`
- Add `_events` `MutableSharedFlow` and expose as `events`
- Add `installAvailableUpdate()` to emit `InstallUpdate` event
- Collect `events` in `DownloadsScreen` and trigger `InstallHelper`
- Update `AvailableUpdateBanner` click to call `viewModel.installAvailableUpdate()`
- Remove direct `InstallHelper` call from UI layer
- Add vertical spacing and `contentPadding` to downloads list
- Replace `Column` wrapper with single `Box` in list item
- Remove trailing `Spacer` from list item layout
- Update `AvailableUpdateBanner` to use `RectangleShape`
- Remove elevation from `AvailableUpdateBanner`
- Add tests for `installAvailableUpdate()` event emission
- Add test for no-op when `localFilePath` is null