### PR TITLE
test: Add notification action helper tests

### DIFF
--- a/app/src/test/kotlin/org/strigate/ferrot/app/actions/AvailableUpdateNotificationActionsTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/app/actions/AvailableUpdateNotificationActionsTest.kt
@@ -1,0 +1,17 @@
+package org.strigate.ferrot.app.actions
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOADS
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
+
+class AvailableUpdateNotificationActionsTest {
+    @Test
+    fun availableUpdateNotificationHelpers_returnExpectedStaticValues() {
+        assertEquals("update_available", availableUpdateNotificationTag())
+        assertEquals(
+            mapOf(EXTRA_ACTION to ACTION_NAVIGATE_DOWNLOADS),
+            availableUpdateNotificationExtras(),
+        )
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/app/actions/DownloadNotificationActionsTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/app/actions/DownloadNotificationActionsTest.kt
@@ -1,0 +1,26 @@
+package org.strigate.ferrot.app.actions
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
+
+class DownloadNotificationActionsTest {
+    @Test
+    fun downloadNotificationTag_formatsTag() {
+        assertEquals("download:42", downloadNotificationTag(42L))
+        assertEquals("active-download:42", activeDownloadNotificationTag(42L))
+    }
+
+    @Test
+    fun downloadNotificationExtras_returnsNavigationPayload() {
+        assertEquals(
+            mapOf(
+                EXTRA_ACTION to ACTION_NAVIGATE_DOWNLOAD,
+                EXTRA_DOWNLOAD_ID to "7",
+            ),
+            downloadNotificationExtras(7L),
+        )
+    }
+}


### PR DESCRIPTION
- Add `DownloadNotificationActionsTest`
- Verify `downloadNotificationTag` formats the expected tag values
- Verify `activeDownloadNotificationTag` formats the expected tag values
- Verify `downloadNotificationExtras` returns the expected navigation payload
- Add `AvailableUpdateNotificationActionsTest`
- Verify `availableUpdateNotificationTag` returns the expected static tag
- Verify `availableUpdateNotificationExtras` returns the expected navigation payload