### PR TITLE
feat: Use YoutubeDL reported output file path

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCase.kt
@@ -1,6 +1,7 @@
 package org.strigate.ferrot.domain.usecase.youtubedl_android
 
 import com.yausername.youtubedl_android.YoutubeDLRequest
+import org.strigate.ferrot.domain.usecase.youtubedl_android.internal.finalOutputPathPrintTemplate
 import javax.inject.Inject
 
 class BuildAudioDownloadRequestUseCase @Inject constructor() {
@@ -14,6 +15,7 @@ class BuildAudioDownloadRequestUseCase @Inject constructor() {
             addOption("-f", "ba/b")
             addOption("-o", template)
             addOption("--windows-filenames")
+            addOption("--print", finalOutputPathPrintTemplate())
             addOption("--extract-audio")
             addOption("--audio-format", "mp3")
             addOption("--audio-quality", "0")

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCase.kt
@@ -4,6 +4,7 @@ import com.yausername.youtubedl_android.YoutubeDLRequest
 import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.app.Constants.NAME
 import org.strigate.ferrot.domain.model.QualityProfile
+import org.strigate.ferrot.domain.usecase.youtubedl_android.internal.finalOutputPathPrintTemplate
 import javax.inject.Inject
 
 class BuildVideoDownloadRequestUseCase @Inject constructor() {
@@ -18,6 +19,7 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
             addOption("-f", formatSelectorFor(qualityProfile))
             addOption("-o", template)
             addOption("--windows-filenames")
+            addOption("--print", finalOutputPathPrintTemplate())
 
             val encoderString = "$NAME ${BuildConfig.VERSION}"
             addOption("--add-metadata")
@@ -52,7 +54,6 @@ class BuildVideoDownloadRequestUseCase @Inject constructor() {
         }
     }
 }
-
 
 private fun formatSelectorFor(profile: QualityProfile): String = when (profile) {
     QualityProfile.MAX -> "bv*+ba/b"

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCase.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.domain.model.QualityProfile
+import org.strigate.ferrot.domain.usecase.youtubedl_android.internal.extractFinalOutputFilePath
 import javax.inject.Inject
 import kotlin.math.abs
 import kotlin.math.max
@@ -56,6 +57,17 @@ class DownloadWithProgressUseCase @Inject constructor(
                         percent = mapped,
                         etaSeconds = rawEta.takeIf { it >= 0 },
                         bytesDownloaded = bytesProvider(),
+                    ),
+                )
+            }
+            val outputFilePath = extractFinalOutputFilePath(youtubeDlResponse.out)
+            if (!outputFilePath.isNullOrBlank()) {
+                trySend(
+                    DownloadTick(
+                        percent = 100f,
+                        etaSeconds = null,
+                        bytesDownloaded = bytesProvider(),
+                        outputFilePath = outputFilePath,
                     ),
                 )
             }
@@ -120,5 +132,6 @@ class DownloadWithProgressUseCase @Inject constructor(
         val percent: Float,
         val etaSeconds: Long?,
         val bytesDownloaded: Long,
+        val outputFilePath: String? = null,
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/internal/YoutubeDlOutputPath.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/internal/YoutubeDlOutputPath.kt
@@ -1,0 +1,17 @@
+package org.strigate.ferrot.domain.usecase.youtubedl_android.internal
+
+internal const val FINAL_OUTPUT_PATH_PREFIX = "__FINAL_OUTPUT_PATH__:"
+
+internal fun finalOutputPathPrintTemplate(): String {
+    return "after_move:${FINAL_OUTPUT_PATH_PREFIX}%(filepath)s"
+}
+
+internal fun extractFinalOutputFilePath(output: String): String? {
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.startsWith(FINAL_OUTPUT_PATH_PREFIX) }
+        .map { it.removePrefix(FINAL_OUTPUT_PATH_PREFIX).trim() }
+        .lastOrNull()
+        ?.takeIf { it.isNotBlank() }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -157,7 +157,6 @@ class DownloadWorker(
                 }
                 Log.d(LOG_TAG, "$tag $message")
 
-                val videoInfoId = videoInfo?.id
                 val videoInfoTitle = videoInfo?.title?.takeIf { it.isNotBlank() }
                 val videoInfoExtension = videoInfo?.ext?.takeIf { it.isNotBlank() }
                 val videoInfoDuration = videoInfo?.duration ?: -1
@@ -246,7 +245,7 @@ class DownloadWorker(
                 )
 
                 Log.d(LOG_TAG, "$tag Downloading video")
-                withContext(Dispatchers.IO) {
+                val videoOutputFilePath = withContext(Dispatchers.IO) {
                     collectPhase(
                         processId = videoProcessId,
                         url = download.url,
@@ -267,13 +266,16 @@ class DownloadWorker(
 
                 throwIfDownloadDeleted()
 
-                val videoOutputFile = locateOutputFileByInfoId(uidDir, videoInfoId)
-                if (videoOutputFile == null || !videoOutputFile.exists()) {
-                    Log.w(LOG_TAG, "$tag Video output file could not be located or does not exist")
+                if (videoOutputFilePath.isNullOrBlank()) {
+                    Log.w(LOG_TAG, "$tag Video output file path was not reported")
+                    return@mainScope handleDownloadFailedResult()
+                }
+                val videoOutputFile = File(videoOutputFilePath)
+                if (!videoOutputFile.exists() || videoOutputFile.length() <= 0L) {
+                    Log.w(LOG_TAG, "$tag Video output file path was reported but file is missing")
                     return@mainScope handleDownloadFailedResult()
                 }
 
-                val videoOutputFilePath = videoOutputFile.absolutePath
                 val videoOutputFileExtension = videoInfoExtension ?: videoOutputFilePath
                     .extractFileExtension()
                     .orEmpty()
@@ -310,7 +312,7 @@ class DownloadWorker(
 
                 Log.d(LOG_TAG, "$tag Downloading audio")
                 try {
-                    withContext(Dispatchers.IO) {
+                    val audioOutputFilePath = withContext(Dispatchers.IO) {
                         collectPhase(
                             processId = audioProcessId,
                             url = download.url,
@@ -328,20 +330,15 @@ class DownloadWorker(
                         )
                     }
                     Log.d(LOG_TAG, "$tag Downloaded audio")
-                } catch (throwable: Throwable) {
-                    val message = "$tag Audio download failed, continuing with video-only"
-                    Log.w(LOG_TAG, message, throwable)
-                }
 
-                val audioOutputFile = locateOutputFileByInfoId(
-                    dir = uidDir,
-                    videoInfoId = videoInfoId,
-                    audio = true,
-                )
-                if (audioOutputFile == null || !audioOutputFile.exists()) {
-                    Log.w(LOG_TAG, "$tag Audio output file could not be located or does not exist")
-                } else {
-                    val audioOutputFilePath = audioOutputFile.absolutePath
+                    if (audioOutputFilePath.isNullOrBlank()) {
+                        throw IllegalStateException("Audio output file path was not reported")
+                    }
+                    val audioOutputFile = File(audioOutputFilePath)
+                    if (!audioOutputFile.exists() || audioOutputFile.length() <= 0L) {
+                        throw IllegalStateException("Audio output file path was reported but file is missing")
+                    }
+
                     val audioOutputFileExtension = audioOutputFilePath
                         .extractFileExtension()
                         .orEmpty()
@@ -354,6 +351,9 @@ class DownloadWorker(
                             fileExtension = audioOutputFileExtension,
                         )
                     )
+                } catch (throwable: Throwable) {
+                    val message = "$tag Audio download failed, continuing with video-only"
+                    Log.w(LOG_TAG, message, throwable)
                 }
 
                 downloadUseCase.updateDownloadErrorMessageUseCase(downloadId, null)
@@ -614,35 +614,6 @@ class DownloadWorker(
         }
     }
 
-    private fun locateOutputFileByInfoId(
-        dir: File,
-        videoInfoId: String?,
-        audio: Boolean = false,
-    ): File? {
-        if (!dir.exists()) {
-            return null
-        }
-        val extensions = if (audio) {
-            listOf("mp3", "m4a", "opus")
-        } else {
-            listOf("mp4", "mkv", "webm")
-        }
-        if (!videoInfoId.isNullOrBlank()) {
-            extensions
-                .map { File(dir, "$videoInfoId.$it") }
-                .firstOrNull { it.exists() && it.length() > 0L }
-                ?.let { return it }
-        }
-        return dir.listFiles()
-            ?.filter {
-                it.isFile && !it.name.startsWith("thumb_") && it.length() > 0L
-            }
-            ?.filter {
-                extensions.any { extension -> it.name.endsWith(".$extension") }
-            }
-            ?.maxByOrNull { it.lastModified() }
-    }
-
     private fun decideWeights(videoBytes: Long?, audioBytes: Long?): Weights {
         return if (videoBytes != null && audioBytes != null && videoBytes > 0 && audioBytes > 0) {
             val total = videoBytes + audioBytes
@@ -707,8 +678,9 @@ class DownloadWorker(
         initialVideoPercent: Float,
         onCanceled: () -> Unit,
         onCombined: (Float) -> Unit,
-    ) {
+    ): String? {
         val throttle = ProgressThrottle()
+        var outputFilePath: String? = null
         val downloadTickFlow = youtubeDlAndroidUseCase.downloadWithProgressUseCase(
             url = url,
             template = template,
@@ -719,6 +691,9 @@ class DownloadWorker(
         )
         try {
             downloadTickFlow.collect { tick ->
+                if (!tick.outputFilePath.isNullOrBlank()) {
+                    outputFilePath = tick.outputFilePath
+                }
                 val status = downloadUseCase.getDownloadByIdUseCase(_downloadId)?.status
                 if (status == null) {
                     onCanceled()
@@ -771,6 +746,7 @@ class DownloadWorker(
                     lastForegroundProgress = percentInt
                 }
             }
+            return outputFilePath
         } finally {
             destroyYoutubeDlProcess(processId)
         }

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/YoutubeDlOutputPathTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/YoutubeDlOutputPathTest.kt
@@ -1,0 +1,65 @@
+package org.strigate.ferrot.domain.usecase.youtubedl_android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.strigate.ferrot.domain.model.QualityProfile
+import org.strigate.ferrot.domain.usecase.youtubedl_android.internal.FINAL_OUTPUT_PATH_PREFIX
+import org.strigate.ferrot.domain.usecase.youtubedl_android.internal.extractFinalOutputFilePath
+import org.strigate.ferrot.domain.usecase.youtubedl_android.internal.finalOutputPathPrintTemplate
+
+class YoutubeDlOutputPathTest {
+    @Test
+    fun finalOutputPathPrintTemplate_usesAfterMoveAndUniquePrefix() {
+        assertEquals(
+            "after_move:${FINAL_OUTPUT_PATH_PREFIX}%(filepath)s",
+            finalOutputPathPrintTemplate(),
+        )
+    }
+
+    @Test
+    fun extractFinalOutputFilePath_returnsLastReportedPath() {
+        val output = """
+            [download] 12.3% of 10.00MiB at 1.00MiB/s ETA 00:12
+            ${FINAL_OUTPUT_PATH_PREFIX}/data/user/0/org.strigate.ferrot/files/downloads/uid/video.mp4
+            ${FINAL_OUTPUT_PATH_PREFIX}/data/user/0/org.strigate.ferrot/files/downloads/uid/audio.mp3
+        """.trimIndent()
+
+        assertEquals(
+            "/data/user/0/org.strigate.ferrot/files/downloads/uid/audio.mp3",
+            extractFinalOutputFilePath(output),
+        )
+    }
+
+    @Test
+    fun extractFinalOutputFilePath_returnsNull_whenMarkerMissing() {
+        assertNull(extractFinalOutputFilePath("[download] 99.9%"))
+    }
+
+    @Test
+    fun buildVideoDownloadRequest_includesAfterMovePathPrintOption() {
+        val request = BuildVideoDownloadRequestUseCase().invoke(
+            url = "https://example.com/video",
+            template = "/tmp/%(title)s.%(ext)s",
+            qualityProfile = QualityProfile.MAX,
+            noProgress = false,
+        )
+
+        val command = request.buildCommand()
+        assertEquals(true, command.contains("--print"))
+        assertEquals(true, command.contains(finalOutputPathPrintTemplate()))
+    }
+
+    @Test
+    fun buildAudioDownloadRequest_includesAfterMovePathPrintOption() {
+        val request = BuildAudioDownloadRequestUseCase().invoke(
+            url = "https://example.com/video",
+            template = "/tmp/%(title)s.%(ext)s",
+            noProgress = false,
+        )
+
+        val command = request.buildCommand()
+        assertEquals(true, command.contains("--print"))
+        assertEquals(true, command.contains(finalOutputPathPrintTemplate()))
+    }
+}


### PR DESCRIPTION
- Update `collectPhase` to return `outputFilePath`
- Capture `outputFilePath` from `DownloadTick` in `DownloadWithProgressUseCase`
- Add `outputFilePath` to `DownloadTick`
- Replace `locateOutputFileByInfoId` usage with reported file path validation
- Remove `locateOutputFileByInfoId` function
- Validate file existence and size using reported path
- Add `--print` option with `finalOutputPathPrintTemplate` in download requests
- Introduce `YoutubeDlOutputPath` utilities for parsing output path
- Add `extractFinalOutputFilePath` to parse YoutubeDL output
- Add tests for output path extraction and request configuration
- Improve audio download handling with strict path validation and fallback logging