### PR TITLE
feat: Add share action to download notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,6 +106,12 @@
             tools:node="merge" />
 
         <activity
+            android:name=".app.ShareDownloadActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <activity
             android:name=".app.ShareReceiveActivity"
             android:exported="true"
             android:launchMode="singleInstance">

--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -128,6 +128,7 @@ object Constants {
         const val EXTRA_SHARED_URL = "$EXTRA.SHARED_URL"
 
         const val EXTRA_DOWNLOAD_ID = "$EXTRA.DOWNLOAD_ID"
+        const val EXTRA_SHARE_FILE_PATH = "$EXTRA.SHARE_FILE_PATH"
     }
 
     object Action {

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ShareDownloadActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ShareDownloadActivity.kt
@@ -1,0 +1,15 @@
+package org.strigate.ferrot.app
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARE_FILE_PATH
+import org.strigate.ferrot.helper.ShareHelper
+
+class ShareDownloadActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val filePath = intent?.getStringExtra(EXTRA_SHARE_FILE_PATH)
+        ShareHelper.shareFileIfExists(this, filePath)
+        finish()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/app/actions/DownloadNotificationActions.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/actions/DownloadNotificationActions.kt
@@ -10,9 +10,12 @@ import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_NOTIFICATION_ACTION
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARE_FILE_PATH
+import org.strigate.ferrot.app.ShareDownloadActivity
 import org.strigate.ferrot.app.receiver.DownloadNotificationActionReceiver
 
 enum class DownloadNotificationActionType {
+    SHARE,
     MARK_SEEN,
     DELETE,
     UNDO_DELETE,
@@ -35,6 +38,7 @@ fun buildDownloadNotificationAction(
     actionType: DownloadNotificationActionType,
 ): NotificationCompat.Action {
     val titleResource = when (actionType) {
+        DownloadNotificationActionType.SHARE -> R.string.notification_action_share
         DownloadNotificationActionType.MARK_SEEN -> R.string.notification_action_mark_seen
         DownloadNotificationActionType.DELETE -> R.string.notification_action_delete
         DownloadNotificationActionType.UNDO_DELETE -> R.string.notification_action_undo
@@ -55,6 +59,28 @@ fun buildDownloadNotificationAction(
     return NotificationCompat.Action.Builder(
         R.drawable.ic_logo,
         context.getString(titleResource),
+        pendingIntent,
+    ).build()
+}
+
+fun buildShareDownloadNotificationAction(
+    context: Context,
+    downloadId: Long,
+    filePath: String,
+): NotificationCompat.Action {
+    val intent = Intent(context, ShareDownloadActivity::class.java).apply {
+        putExtra(EXTRA_DOWNLOAD_ID, downloadId.toString())
+        putExtra(EXTRA_SHARE_FILE_PATH, filePath)
+    }
+    val pendingIntent = PendingIntent.getActivity(
+        context,
+        (downloadId.toString() + DownloadNotificationActionType.SHARE.name).hashCode(),
+        intent,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+    )
+    return NotificationCompat.Action.Builder(
+        R.drawable.ic_logo,
+        context.getString(R.string.notification_action_share),
         pendingIntent,
     ).build()
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
@@ -18,20 +18,25 @@ import org.strigate.ferrot.app.actions.DownloadNotificationActionType
 import org.strigate.ferrot.app.actions.DownloadNotificationActionType.DELETE
 import org.strigate.ferrot.app.actions.DownloadNotificationActionType.MARK_SEEN
 import org.strigate.ferrot.app.actions.DownloadNotificationActionType.RETRY
+import org.strigate.ferrot.app.actions.DownloadNotificationActionType.SHARE
 import org.strigate.ferrot.app.actions.DownloadNotificationActionType.STOP
 import org.strigate.ferrot.app.actions.DownloadNotificationActionType.UNDO_DELETE
 import org.strigate.ferrot.app.actions.activeDownloadNotificationTag
 import org.strigate.ferrot.app.actions.buildDownloadNotificationAction
+import org.strigate.ferrot.app.actions.buildShareDownloadNotificationAction
 import org.strigate.ferrot.app.actions.downloadNotificationExtras
 import org.strigate.ferrot.app.actions.downloadNotificationTag
 import org.strigate.ferrot.domain.model.Download
 import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.model.DownloadVideo
 import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
+import java.io.File
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -51,6 +56,9 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var downloadProgressUseCase: DownloadProgressUseCase
+
+    @Inject
+    lateinit var downloadVideoUseCase: DownloadVideoUseCase
 
     @Inject
     lateinit var startDownloadUseCase: StartDownloadUseCase
@@ -81,6 +89,7 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
                     UNDO_DELETE -> handleUndoDelete(downloadId)
                     RETRY -> handleRetry(downloadId)
                     STOP -> handleStop(downloadId)
+                    SHARE -> Unit
                 }
             } finally {
                 pendingResult.finish()
@@ -155,6 +164,7 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
             extras = downloadNotificationExtras(download.id),
             tag = downloadNotificationTag(download.id),
             actions = buildCompletedActions(download),
+            autoCancel = false,
         )
     }
 
@@ -188,7 +198,7 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
         )
     }
 
-    private fun buildCompletedActions(download: Download): List<NotificationCompat.Action> {
+    private suspend fun buildCompletedActions(download: Download): List<NotificationCompat.Action> {
         if (download.pendingDelete) {
             return listOf(
                 buildDownloadNotificationAction(
@@ -199,6 +209,13 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
             )
         }
         val actions = mutableListOf<NotificationCompat.Action>()
+        resolveSharePathIfPresent(download.id)?.let { sharePath ->
+            actions += buildShareDownloadNotificationAction(
+                context = appContext,
+                downloadId = download.id,
+                filePath = sharePath,
+            )
+        }
         if (!download.seen) {
             actions += buildDownloadNotificationAction(
                 context = appContext,
@@ -243,4 +260,19 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
             .getDownloadMetadataByIdAsFlowUseCase(download.id).first()
         return metadata?.title?.takeIf { it.isNotBlank() } ?: download.url
     }
+
+    private suspend fun resolveSharePath(downloadId: Long): String? {
+        return downloadVideoUseCase
+            .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
+            .first()
+            .pathOrNull()
+    }
+
+    private suspend fun resolveSharePathIfPresent(downloadId: Long): String? {
+        val filePath = resolveSharePath(downloadId) ?: return null
+        val file = File(filePath)
+        return filePath.takeIf { file.exists() && file.length() > 0L }
+    }
+
+    private fun DownloadVideo?.pathOrNull(): String? = this?.filePath?.takeIf { it.isNotBlank() }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/receiver/DownloadNotificationActionReceiver.kt
@@ -84,12 +84,12 @@ class DownloadNotificationActionReceiver : BroadcastReceiver() {
                     return@launch
                 }
                 when (action) {
+                    SHARE -> Unit
                     MARK_SEEN -> handleMarkSeen(downloadId)
                     DELETE -> handleDelete(downloadId)
                     UNDO_DELETE -> handleUndoDelete(downloadId)
                     RETRY -> handleRetry(downloadId)
                     STOP -> handleStop(downloadId)
-                    SHARE -> Unit
                 }
             } finally {
                 pendingResult.finish()

--- a/app/src/main/kotlin/org/strigate/ferrot/helper/ShareHelper.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/helper/ShareHelper.kt
@@ -23,22 +23,25 @@ object ShareHelper {
             Log.w(LOG_TAG, "File does not exist: ${file.absolutePath}")
             return false
         }
-        val authority = "${context.packageName}.${context.getString(R.string.file_provider)}"
-        val uri: Uri = FileProvider.getUriForFile(context, authority, file)
-        val send = Intent(Intent.ACTION_SEND).apply {
-            type = filePath.guessMimeType()
-            putExtra(Intent.EXTRA_STREAM, uri)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            clipData = ClipData.newUri(context.contentResolver, file.name, uri)
-        }
-        val chooser = Intent.createChooser(send, context.getString(R.string.share_to))
-        if (context !is Activity) {
-            chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
         return try {
+            val authority = "${context.packageName}.${context.getString(R.string.file_provider)}"
+            val uri: Uri = FileProvider.getUriForFile(context, authority, file)
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = filePath.guessMimeType()
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                clipData = ClipData.newUri(context.contentResolver, file.name, uri)
+            }
+            val chooser = Intent.createChooser(send, context.getString(R.string.share_to))
+            if (context !is Activity) {
+                chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
             context.startActivity(chooser)
             true
         } catch (_: ActivityNotFoundException) {
+            false
+        } catch (throwable: Throwable) {
+            Log.w(LOG_TAG, "Failed to share file: ${file.absolutePath}", throwable)
             false
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -30,6 +30,7 @@ import org.strigate.ferrot.app.ForegroundCoroutineWorker
 import org.strigate.ferrot.app.NotificationService
 import org.strigate.ferrot.app.actions.DownloadNotificationActionType
 import org.strigate.ferrot.app.actions.buildDownloadNotificationAction
+import org.strigate.ferrot.app.actions.buildShareDownloadNotificationAction
 import org.strigate.ferrot.app.actions.downloadNotificationExtras
 import org.strigate.ferrot.app.actions.downloadNotificationTag
 import org.strigate.ferrot.app.provider.DownloadPathProvider
@@ -391,8 +392,12 @@ class DownloadWorker(
                     contentTitle = downloadComplete,
                     extras = notificationExtras,
                     tag = downloadNotificationTag(downloadId),
-                    actions = buildCompletedNotificationActions(downloadId),
+                    actions = buildCompletedNotificationActions(
+                        downloadId = downloadId,
+                        shareFilePath = videoOutputFilePath,
+                    ),
                     thumbnailFilePath = thumbnailFilePath,
+                    autoCancel = false,
                 )
                 Result.success()
 
@@ -560,8 +565,21 @@ class DownloadWorker(
         )
     }
 
-    private fun buildCompletedNotificationActions(downloadId: Long): List<NotificationCompat.Action> {
+    private fun buildCompletedNotificationActions(
+        downloadId: Long,
+        shareFilePath: String?,
+    ): List<NotificationCompat.Action> {
         val actions = mutableListOf<NotificationCompat.Action>()
+        shareFilePath?.let { filePath ->
+            val shareFile = File(filePath)
+            if (shareFile.exists() && shareFile.length() > 0L) {
+                actions += buildShareDownloadNotificationAction(
+                    context = appContext,
+                    downloadId = downloadId,
+                    filePath = filePath,
+                )
+            }
+        }
         actions += buildDownloadNotificationAction(
             context = appContext,
             downloadId = downloadId,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="notification_title_deleted">Deleted</string>
     <string name="notification_action_install">Install</string>
     <string name="notification_action_mark_seen">Mark as seen</string>
+    <string name="notification_action_share">Share</string>
     <string name="notification_action_delete">Delete</string>
     <string name="notification_action_retry">Retry</string>
     <string name="notification_action_stop">Stop</string>


### PR DESCRIPTION
- Add `notification_action_share` string resource
- Introduce `DownloadNotificationActionType.SHARE`
- Add `buildShareDownloadNotificationAction` for share intent handling
- Create `ShareDownloadActivity` to trigger file sharing flow
- Add `EXTRA_SHARE_FILE_PATH` to `Constants`
- Update `ShareHelper` to improve error handling and logging
- Inject `DownloadVideoUseCase` into `DownloadNotificationActionReceiver`
- Resolve share file path before adding share action to completed notifications
- Update `DownloadNotificationActionReceiver` to support share action flow
- Update `DownloadWorker` to include share action when file is valid
- Set `autoCancel = false` for completed notifications
- Register `ShareDownloadActivity` in `AndroidManifest`