### PR TITLE
refactor: Update download progress text format

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -301,10 +301,13 @@ class DownloadAvailableUpdateWorker(
                     return
                 }
                 val contentText = if (totalBytes != null && totalBytes > 0L) {
-                    val percentText = progressPercent
-                        .takeIf { it >= 0 }?.let { " ($it%)" }.orEmpty()
+                    buildString {
+                        progressPercent
+                            .takeIf { it >= 0 }
+                            ?.let { append("$it% - ") }
 
-                    "${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)}$percentText"
+                        append("${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)}")
+                    }
                 } else {
                     formatBytes(downloadedBytes)
                 }


### PR DESCRIPTION
- Replace inline percent suffix formatting in `DownloadAvailableUpdateWorker`
- Build `contentText` with `buildString`
- Show progress as `<percent>% - <downloaded> / <total>` when `progressPercent` is available