### PR TITLE
feat: Add refresh download metadata flow

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCase.kt
@@ -1,0 +1,78 @@
+package org.strigate.ferrot.domain.usecase.combined
+
+import android.util.Log
+import kotlinx.coroutines.flow.first
+import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.provider.DownloadPathProvider
+import org.strigate.ferrot.domain.model.DownloadMetadata
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
+import java.io.File
+import javax.inject.Inject
+
+class RefreshDownloadMetadataCombinedUseCase @Inject constructor(
+    private val downloadUseCase: DownloadUseCase,
+    private val downloadMetadataUseCase: DownloadMetadataUseCase,
+    private val youtubeDlAndroidUseCase: YoutubeDlAndroidUseCase,
+    private val downloadPathProvider: DownloadPathProvider,
+) {
+    suspend operator fun invoke(downloadId: Long): Boolean {
+        val tag = "RefreshDownloadMetadata[$downloadId]:"
+        Log.d(LOG_TAG, "$tag Start")
+
+        val download = downloadUseCase.getDownloadByIdUseCase(downloadId) ?: return false
+        val existingMetadata = downloadMetadataUseCase
+            .getDownloadMetadataByIdAsFlowUseCase(downloadId)
+            .first()
+
+        val videoInfo = runCatching {
+            youtubeDlAndroidUseCase.getVideoInfoUseCase(download.url)
+        }.onFailure {
+            Log.w(LOG_TAG, "$tag Metadata fetch failed", it)
+        }.getOrNull()
+
+        val outputDir = downloadPathProvider.uidDir(download.uid)
+        val existingThumbnailPath = existingMetadata
+            ?.thumbnailFilePath
+            ?.takeIf(::thumbnailExists)
+
+        val thumbnailFilePath = runCatching {
+            youtubeDlAndroidUseCase.downloadThumbnailUseCase(
+                url = download.url,
+                outputDir = outputDir,
+                videoId = videoInfo?.id ?: existingMetadata?.videoId,
+            )
+        }.onFailure {
+            Log.w(LOG_TAG, "$tag Thumbnail fetch failed", it)
+        }.getOrNull() ?: existingThumbnailPath
+
+        if (videoInfo == null && thumbnailFilePath == null) {
+            Log.w(LOG_TAG, "$tag Nothing recovered")
+            return false
+        }
+        val downloadMetadata = DownloadMetadata(
+            downloadId = downloadId,
+            videoId = videoInfo?.id ?: existingMetadata?.videoId,
+            source = videoInfo?.extractorKey?.lowercase() ?: existingMetadata?.source,
+            title = videoInfo?.title ?: existingMetadata?.title,
+            thumbnailFilePath = thumbnailFilePath,
+            durationSeconds = videoInfo
+                ?.duration
+                ?.takeIf { it > 0 }
+                ?: existingMetadata?.durationSeconds,
+        )
+        downloadMetadataUseCase.saveDownloadMetadataUseCase(downloadMetadata)
+        val message = buildString {
+            append("$tag Complete: ")
+            append("metadata=${videoInfo != null} ")
+            append("thumbnail=${thumbnailFilePath != null}")
+        }
+        Log.d(LOG_TAG, message)
+        return true
+    }
+
+    private fun thumbnailExists(path: String): Boolean {
+        return File(path).exists()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
@@ -89,6 +90,7 @@ import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
+import org.strigate.ferrot.presentation.model.isActive
 import org.strigate.ferrot.presentation.state.DownloadUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
@@ -233,6 +235,7 @@ fun DownloadScreen(
                         onSaveClick = viewModel::saveDownload,
                         onShareClick = viewModel::shareDownload,
                         onRetryClick = viewModel::retryDownload,
+                        onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
                         pagePadding = PaddingValues(
                             horizontal = peekPadding,
                             vertical = dimens.zero,
@@ -263,6 +266,7 @@ private fun DownloadPager(
     onSaveClick: (Long) -> Unit,
     onShareClick: (Long) -> Unit,
     onRetryClick: (Long) -> Unit,
+    onRefreshMetadataClick: (Long) -> Unit,
     pagePadding: PaddingValues,
     pageSpacing: Dp,
 ) {
@@ -350,6 +354,9 @@ private fun DownloadPager(
                         onRetryClick = {
                             onRetryClick(download.id)
                         },
+                        onRefreshMetadataClick = {
+                            onRefreshMetadataClick(download.id)
+                        },
                     )
                 } ?: LoadingState(
                     modifier = Modifier
@@ -373,6 +380,7 @@ private fun DownloadPageContent(
     onSaveClick: () -> Unit,
     onShareClick: () -> Unit,
     onRetryClick: () -> Unit,
+    onRefreshMetadataClick: () -> Unit,
 ) {
     val dimens = LocalDimens.current
     with(data) {
@@ -431,16 +439,23 @@ private fun DownloadPageContent(
                 DownloadMediaType.VIDEO -> video?.filePath
                 DownloadMediaType.AUDIO -> audio?.filePath
             }
-            val canActOnSelected = status == DownloadStatusUiData.COMPLETED &&
-                    !selectedPath.isNullOrBlank()
+            val canActOnSelected = status == DownloadStatusUiData.COMPLETED
+                    && !selectedPath.isNullOrBlank()
+
+            val isMetadataIncomplete = metadata?.thumbnailFilePath.isNullOrBlank()
+            val needsMetadataRefresh = status == DownloadStatusUiData.COMPLETED
+                    && !status.isActive
+                    && isMetadataIncomplete
 
             ThumbnailCard(
                 thumbnailFilePath = metadata?.thumbnailFilePath,
                 durationSeconds = metadata?.durationSeconds,
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
+                showMetadataRefresh = needsMetadataRefresh,
                 showPlay = canActOnSelected,
                 onPlayClick = onPlayClick,
                 onRetryClick = onRetryClick,
+                onRefreshMetadataClick = onRefreshMetadataClick,
             )
             Spacer(modifier = Modifier.height(dimens.spacingSmall))
             Row(
@@ -578,9 +593,11 @@ private fun ThumbnailCard(
     thumbnailFilePath: String?,
     durationSeconds: Int?,
     showRetry: Boolean,
+    showMetadataRefresh: Boolean,
     showPlay: Boolean,
     onPlayClick: () -> Unit,
     onRetryClick: () -> Unit,
+    onRefreshMetadataClick: () -> Unit,
 ) {
     val dimens = LocalDimens.current
     val thumbnailFile = thumbnailFilePath
@@ -669,6 +686,37 @@ private fun ThumbnailCard(
                         contentDescription = overlayContentDescription,
                         imageVector = overlayIcon,
                     )
+                }
+            }
+            if (showMetadataRefresh) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(dimens.spacingSmall)
+                        .size(dimens.overlayButtonSmall)
+                        .clip(CircleShape)
+                        .background(overlayBackgroundColor),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(dimens.overlayButtonSmall)
+                            .clip(CircleShape)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = LocalIndication.current,
+                                onClick = onRefreshMetadataClick,
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            modifier = Modifier
+                                .size(dimens.iconXXSmall),
+                            imageVector = Icons.Filled.Download,
+                            contentDescription = stringResource(R.string.content_description_refresh_metadata),
+                            tint = Color.White,
+                        )
+                    }
                 }
             }
             if (durationText != null) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -111,6 +112,7 @@ fun DownloadScreen(
     val selectedMedia by viewModel.selectedMedia.collectAsStateWithLifecycle(
         initialValue = DownloadMediaType.VIDEO,
     )
+    val refreshingMetadataIds by viewModel.refreshingMetadataIds.collectAsStateWithLifecycle()
 
     val showConfirmDeleteDialog = remember { mutableStateOf(false) }
 
@@ -225,6 +227,7 @@ fun DownloadScreen(
                         pageDataForId = viewModel::getDownloadPageUiData,
                         selectedId = selectedId,
                         selectedMedia = selectedMedia,
+                        refreshingMetadataIds = refreshingMetadataIds,
                         onEnsureDefaults = viewModel::setDefaultsForIds,
                         onDownloadPageSelected = viewModel::selectDownload,
                         onVisibleCompletedUnseenDownload = viewModel::markSeenIfCompleted,
@@ -258,6 +261,7 @@ private fun DownloadPager(
     pageDataForId: (Long) -> Flow<DownloadPageUiData?>,
     selectedId: Long,
     selectedMedia: DownloadMediaType,
+    refreshingMetadataIds: Set<Long>,
     onEnsureDefaults: (List<Long>) -> Unit,
     onDownloadPageSelected: (Long) -> Unit,
     onVisibleCompletedUnseenDownload: (Long) -> Unit,
@@ -335,6 +339,7 @@ private fun DownloadPager(
                         data = download,
                         isCurrentPage = isCurrentPage,
                         selectedMedia = selectedMedia,
+                        isRefreshingMetadata = download.id in refreshingMetadataIds,
                         onCompletedUnseenVisible = onVisibleCompletedUnseenDownload,
                         onMediaChange = { mediaType ->
                             onSelectedMedia(download.id, mediaType)
@@ -373,6 +378,7 @@ private fun DownloadPageContent(
     data: DownloadPageUiData,
     isCurrentPage: Boolean,
     selectedMedia: DownloadMediaType,
+    isRefreshingMetadata: Boolean,
     onCompletedUnseenVisible: (Long) -> Unit,
     onMediaChange: (DownloadMediaType) -> Unit,
     onEnsureValidSelection: (DownloadMediaType) -> Unit,
@@ -446,12 +452,14 @@ private fun DownloadPageContent(
             val needsMetadataRefresh = status == DownloadStatusUiData.COMPLETED
                     && !status.isActive
                     && isMetadataIncomplete
+                    && !isRefreshingMetadata
 
             ThumbnailCard(
                 thumbnailFilePath = metadata?.thumbnailFilePath,
                 durationSeconds = metadata?.durationSeconds,
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
                 showMetadataRefresh = needsMetadataRefresh,
+                showMetadataRefreshLoading = isRefreshingMetadata,
                 showPlay = canActOnSelected,
                 onPlayClick = onPlayClick,
                 onRetryClick = onRetryClick,
@@ -594,6 +602,7 @@ private fun ThumbnailCard(
     durationSeconds: Int?,
     showRetry: Boolean,
     showMetadataRefresh: Boolean,
+    showMetadataRefreshLoading: Boolean,
     showPlay: Boolean,
     onPlayClick: () -> Unit,
     onRetryClick: () -> Unit,
@@ -688,7 +697,7 @@ private fun ThumbnailCard(
                     )
                 }
             }
-            if (showMetadataRefresh) {
+            if (showMetadataRefresh || showMetadataRefreshLoading) {
                 Box(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
@@ -698,24 +707,33 @@ private fun ThumbnailCard(
                         .background(overlayBackgroundColor),
                     contentAlignment = Alignment.Center,
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .size(dimens.overlayButtonSmall)
-                            .clip(CircleShape)
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = LocalIndication.current,
-                                onClick = onRefreshMetadataClick,
-                            ),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Icon(
+                    if (showMetadataRefreshLoading) {
+                        CircularProgressIndicator(
                             modifier = Modifier
                                 .size(dimens.iconXXSmall),
-                            imageVector = Icons.Filled.Download,
-                            contentDescription = stringResource(R.string.content_description_refresh_metadata),
-                            tint = Color.White,
+                            color = Color.White,
+                            strokeWidth = dimens.spacingXXSmall,
                         )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .size(dimens.overlayButtonSmall)
+                                .clip(CircleShape)
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = LocalIndication.current,
+                                    onClick = onRefreshMetadataClick,
+                                ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                modifier = Modifier
+                                    .size(dimens.iconXXSmall),
+                                imageVector = Icons.Filled.Download,
+                                contentDescription = stringResource(R.string.content_description_refresh_metadata),
+                                tint = Color.White,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -91,6 +91,9 @@ class DownloadViewModel @Inject constructor(
         initialValue = DownloadMediaType.VIDEO,
     )
 
+    private val _refreshingMetadataIds = MutableStateFlow<Set<Long>>(emptySet())
+    val refreshingMetadataIds: StateFlow<Set<Long>> = _refreshingMetadataIds
+
     private val _events = MutableSharedFlow<DownloadEvent>(
         replay = 0,
         extraBufferCapacity = 1,
@@ -256,7 +259,12 @@ class DownloadViewModel @Inject constructor(
 
     fun refreshDownloadMetadata(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        refreshDownloadMetadataCombinedUseCase(downloadId)
+        _refreshingMetadataIds.value += downloadId
+        try {
+            refreshDownloadMetadataCombinedUseCase(downloadId)
+        } finally {
+            _refreshingMetadataIds.value -= downloadId
+        }
     }
 
     private fun getSelectedMediaFilePath(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -28,6 +28,7 @@ import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
+import org.strigate.ferrot.domain.usecase.combined.RefreshDownloadMetadataCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.Screen
@@ -49,6 +50,7 @@ class DownloadViewModel @Inject constructor(
     private val downloadMetadataUseCase: DownloadMetadataUseCase,
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
+    private val refreshDownloadMetadataCombinedUseCase: RefreshDownloadMetadataCombinedUseCase,
     downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
 ) : ViewModel() {
     private val initialId: Long = checkNotNull(savedStateHandle[Screen.Download.ARG_DOWNLOAD_ID])
@@ -250,6 +252,11 @@ class DownloadViewModel @Inject constructor(
     fun retryDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
         startDownloadUseCase(downloadId)
+    }
+
+    fun refreshDownloadMetadata(id: Long? = null) = viewModelScope.launch {
+        val downloadId = id ?: _selectedId.value
+        refreshDownloadMetadataCombinedUseCase(downloadId)
     }
 
     private fun getSelectedMediaFilePath(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="content_description_retry">Retry</string>
     <string name="content_description_retry_failed">Retry failed</string>
     <string name="content_description_play">Play</string>
+    <string name="content_description_refresh_metadata">Refresh metadata</string>
     <string name="content_description_stop_download">Stop download</string>
     <string name="content_description_resume_download">Resume download</string>
     <string name="content_description_open_download">Open download</string>

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -458,6 +458,39 @@ class DownloadViewModelTest {
     }
 
     @Test
+    fun refreshDownloadMetadata_refreshesExplicitOrSelectedDownload() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(initialId = 20L)
+            `when`(refreshDownloadMetadataCombinedUseCase.invoke(88L)).thenReturn(true)
+            `when`(refreshDownloadMetadataCombinedUseCase.invoke(20L)).thenReturn(true)
+
+            viewModel.refreshDownloadMetadata(88L)
+            advanceUntilIdle()
+
+            viewModel.refreshDownloadMetadata()
+            advanceUntilIdle()
+
+            verify(refreshDownloadMetadataCombinedUseCase).invoke(88L)
+            verify(refreshDownloadMetadataCombinedUseCase).invoke(20L)
+        }
+
+    @Test
+    fun refreshDownloadMetadata_tracksRefreshingDownloadId_whileWorkRuns() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(initialId = 20L)
+
+            `when`(refreshDownloadMetadataCombinedUseCase.invoke(20L)).thenAnswer {
+                assertEquals(setOf(20L), viewModel.refreshingMetadataIds.value)
+                true
+            }
+
+            viewModel.refreshDownloadMetadata()
+            advanceUntilIdle()
+
+            assertEquals(emptySet<Long>(), viewModel.refreshingMetadataIds.value)
+        }
+
+    @Test
     fun shareSaveAndPlay_emitEventsUsingSelectedMediaPath() = runTest(testDispatcher) {
         stubPageData(
             downloadId = 20L,

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -52,6 +52,7 @@ import org.strigate.ferrot.domain.usecase.download.RequestDeleteDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
 import org.strigate.ferrot.domain.usecase.downloadaudio.GetDownloadAudioByDownloadIdAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.combined.RefreshDownloadMetadataCombinedUseCase
 import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadMetadataByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadprogress.GetDownloadProgressByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadVideoByDownloadIdAsFlowUseCase
@@ -91,6 +92,9 @@ class DownloadViewModelTest {
 
     @Mock
     private lateinit var startDownloadUseCase: StartDownloadUseCase
+
+    @Mock
+    private lateinit var refreshDownloadMetadataCombinedUseCase: RefreshDownloadMetadataCombinedUseCase
 
     @Mock
     private lateinit var downloadWithMetadataUseCase: DownloadWithMetadataUseCase
@@ -164,6 +168,7 @@ class DownloadViewModelTest {
                 downloadMetadataUseCase = downloadMetadataUseCase,
                 clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
                 startDownloadUseCase = startDownloadUseCase,
+                refreshDownloadMetadataCombinedUseCase = refreshDownloadMetadataCombinedUseCase,
                 downloadWithMetadataUseCase = downloadWithMetadataUseCase,
             )
             fail("Expected IllegalStateException")
@@ -769,6 +774,7 @@ class DownloadViewModelTest {
             downloadMetadataUseCase = downloadMetadataUseCase,
             clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
             startDownloadUseCase = startDownloadUseCase,
+            refreshDownloadMetadataCombinedUseCase = refreshDownloadMetadataCombinedUseCase,
             downloadWithMetadataUseCase = downloadWithMetadataUseCase,
         )
     }


### PR DESCRIPTION
- Add `RefreshDownloadMetadataCombinedUseCase` to recover missing metadata and thumbnails
- Inject `RefreshDownloadMetadataCombinedUseCase` into `DownloadViewModel`
- Add `refreshDownloadMetadata` function in `DownloadViewModel`
- Expose `onRefreshMetadataClick` callback through `DownloadScreen` composables
- Add `needsMetadataRefresh` logic based on `DownloadStatusUiData` and metadata state
- Update `ThumbnailCard` to support `showMetadataRefresh`
- Add refresh metadata overlay button using `Icons.Filled.Download`
- Add `content_description_refresh_metadata` string resource
- Update tests to include `RefreshDownloadMetadataCombinedUseCase` dependency