### PR TITLE
feat: Add refresh download metadata worker and atomic thumbnail handling

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -67,9 +67,14 @@ object Constants {
             private const val ONETIME = "$NAME.onetime"
             private const val PERIODIC = "$NAME.periodic"
 
-            const val ONETIME_DOWNLOAD = "$ONETIME.DOWNLOAD"
-            const val ONETIME_DOWNLOAD_AVAILABLE_UPDATE = "$ONETIME.DOWNLOAD_AVAILABLE_UPDATE"
-            const val ONETIME_UPDATE_DEPENDENCIES = "$ONETIME.UPDATE_DEPENDENCIES"
+            const val ONETIME_DOWNLOAD =
+                "$ONETIME.DOWNLOAD"
+            const val ONETIME_REFRESH_DOWNLOAD_METADATA =
+                "$ONETIME.REFRESH_DOWNLOAD_METADATA"
+            const val ONETIME_DOWNLOAD_AVAILABLE_UPDATE =
+                "$ONETIME.DOWNLOAD_AVAILABLE_UPDATE"
+            const val ONETIME_UPDATE_DEPENDENCIES =
+                "$ONETIME.UPDATE_DEPENDENCIES"
 
             const val ONETIME_DELETE_DOWNLOADS =
                 "$ONETIME.DELETE_DOWNLOADS"

--- a/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/di/WorkerFactory.kt
@@ -21,6 +21,7 @@ import org.strigate.ferrot.domain.usecase.StateUseCase
 import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
 import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
 import org.strigate.ferrot.domain.usecase.combined.GetPendingDownloadsCombinedUseCase
+import org.strigate.ferrot.domain.usecase.combined.RefreshDownloadMetadataCombinedUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.work.DeleteAllDuplicateDownloadsWorker
@@ -31,6 +32,7 @@ import org.strigate.ferrot.work.DeletePendingDownloadsDelayedWorker
 import org.strigate.ferrot.work.DeletePendingDownloadsImmediateWorker
 import org.strigate.ferrot.work.DownloadAvailableUpdateWorker
 import org.strigate.ferrot.work.DownloadWorker
+import org.strigate.ferrot.work.RefreshDownloadMetadataWorker
 import org.strigate.ferrot.work.RequeuePendingDownloadsWorker
 import org.strigate.ferrot.work.UpdateDependenciesWorker
 import javax.inject.Inject
@@ -51,6 +53,7 @@ class WorkerFactory @Inject constructor(
     private val stopDownloadUseCase: StopDownloadUseCase,
     private val getPendingDownloadsCombinedUseCase: GetPendingDownloadsCombinedUseCase,
     private val deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase,
+    private val refreshDownloadMetadataCombinedUseCase: RefreshDownloadMetadataCombinedUseCase,
     private val youtubeDlAndroidUseCase: YoutubeDlAndroidUseCase,
     private val downloadUseCase: DownloadUseCase,
     private val downloadVideoUseCase: DownloadVideoUseCase,
@@ -108,6 +111,14 @@ class WorkerFactory @Inject constructor(
                     workerParameters = workerParameters,
                     getPendingDownloadsCombinedUseCase = getPendingDownloadsCombinedUseCase,
                     startDownloadUseCase = startDownloadUseCase,
+                )
+            }
+
+            RefreshDownloadMetadataWorker::class.java.name -> {
+                RefreshDownloadMetadataWorker(
+                    appContext = appContext,
+                    workerParameters = workerParameters,
+                    refreshDownloadMetadataCombinedUseCase = refreshDownloadMetadataCombinedUseCase,
                 )
             }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestRefreshDownloadMetadataUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/RequestRefreshDownloadMetadataUseCase.kt
@@ -1,0 +1,14 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.strigate.ferrot.work.RefreshDownloadMetadataWorker
+import javax.inject.Inject
+
+class RequestRefreshDownloadMetadataUseCase @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
+) {
+    operator fun invoke(downloadId: Long) {
+        RefreshDownloadMetadataWorker.enqueueOneTimeKeep(appContext, downloadId)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadThumbnailUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadThumbnailUseCase.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.withContext
 import org.strigate.ferrot.app.YoutubeDlRuntimeInitializer
 import org.strigate.ferrot.extensions.toSafeFileName
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import javax.inject.Inject
 
 class DownloadThumbnailUseCase @Inject constructor(
@@ -21,29 +23,27 @@ class DownloadThumbnailUseCase @Inject constructor(
         return withContext(Dispatchers.IO) {
             val id = videoId ?: YoutubeDL.getInstance().getInfo(url).id ?: return@withContext null
             val thumbnailBaseName = thumbnailOutputBaseName(id)
-            outputDir
-                .listFiles()
-                ?.filter { file ->
-                    file.isFile &&
-                            file.nameWithoutExtension == thumbnailBaseName &&
-                            file.extension.isNotBlank()
-                }
-                ?.forEach { file ->
-                    if (!file.delete()) {
-                        return@withContext null
-                    }
-                }
+
+            val tempDir = File(outputDir, ".tmp_${thumbnailBaseName}")
+            if (tempDir.exists() && !tempDir.deleteRecursively()) {
+                return@withContext null
+            }
+            if (!tempDir.mkdirs()) {
+                return@withContext null
+            }
+
             val youtubeDLRequest = buildThumbnailRequestUseCase(
                 url = url,
-                outputDir = outputDir,
+                outputDir = tempDir,
                 videoId = id,
                 convertToJpg = true,
             )
             val youtubeDLResponse = YoutubeDL.getInstance().execute(youtubeDLRequest)
             if (youtubeDLResponse.exitCode != 0) {
+                tempDir.deleteRecursively()
                 return@withContext null
             }
-            outputDir
+            val downloadedFile = tempDir
                 .listFiles()
                 ?.sortedBy { it.name }
                 ?.firstOrNull { file ->
@@ -52,7 +52,35 @@ class DownloadThumbnailUseCase @Inject constructor(
                             file.nameWithoutExtension == thumbnailBaseName &&
                             file.extension.isNotBlank()
                 }
-                ?.absolutePath
+                ?: run {
+                    tempDir.deleteRecursively()
+                    return@withContext null
+                }
+
+            val finalFile = File(outputDir, downloadedFile.name)
+            runCatching {
+                Files.move(
+                    downloadedFile.toPath(),
+                    finalFile.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING,
+                )
+            }.getOrElse {
+                tempDir.deleteRecursively()
+                return@withContext null
+            }
+            outputDir
+                .listFiles()
+                ?.filter { file ->
+                    file.isFile
+                            && file.absolutePath != finalFile.absolutePath
+                            && file.nameWithoutExtension == thumbnailBaseName
+                            && file.extension.isNotBlank()
+                }
+                ?.forEach { file ->
+                    file.delete()
+                }
+            tempDir.deleteRecursively()
+            finalFile.absolutePath
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -1,5 +1,6 @@
 package org.strigate.ferrot.presentation.screen
 
+import android.view.HapticFeedbackConstants
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
@@ -26,14 +27,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.ImageNotSupported
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -59,6 +59,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
@@ -91,7 +92,6 @@ import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
-import org.strigate.ferrot.presentation.model.isActive
 import org.strigate.ferrot.presentation.state.DownloadUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
@@ -104,6 +104,7 @@ fun DownloadScreen(
     modifier: Modifier = Modifier,
     viewModel: DownloadViewModel = hiltViewModel(),
 ) {
+    val view = LocalView.current
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
@@ -112,7 +113,6 @@ fun DownloadScreen(
     val selectedMedia by viewModel.selectedMedia.collectAsStateWithLifecycle(
         initialValue = DownloadMediaType.VIDEO,
     )
-    val refreshingMetadataIds by viewModel.refreshingMetadataIds.collectAsStateWithLifecycle()
 
     val showConfirmDeleteDialog = remember { mutableStateOf(false) }
 
@@ -227,7 +227,6 @@ fun DownloadScreen(
                         pageDataForId = viewModel::getDownloadPageUiData,
                         selectedId = selectedId,
                         selectedMedia = selectedMedia,
-                        refreshingMetadataIds = refreshingMetadataIds,
                         onEnsureDefaults = viewModel::setDefaultsForIds,
                         onDownloadPageSelected = viewModel::selectDownload,
                         onVisibleCompletedUnseenDownload = viewModel::markSeenIfCompleted,
@@ -237,7 +236,10 @@ fun DownloadScreen(
                         onPlayClick = viewModel::playDownload,
                         onSaveClick = viewModel::saveDownload,
                         onShareClick = viewModel::shareDownload,
-                        onRetryClick = viewModel::retryDownload,
+                        onRetryClick = { downloadId ->
+                            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                            viewModel.retryDownload(downloadId)
+                        },
                         onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
                         pagePadding = PaddingValues(
                             horizontal = peekPadding,
@@ -261,7 +263,6 @@ private fun DownloadPager(
     pageDataForId: (Long) -> Flow<DownloadPageUiData?>,
     selectedId: Long,
     selectedMedia: DownloadMediaType,
-    refreshingMetadataIds: Set<Long>,
     onEnsureDefaults: (List<Long>) -> Unit,
     onDownloadPageSelected: (Long) -> Unit,
     onVisibleCompletedUnseenDownload: (Long) -> Unit,
@@ -339,7 +340,6 @@ private fun DownloadPager(
                         data = download,
                         isCurrentPage = isCurrentPage,
                         selectedMedia = selectedMedia,
-                        isRefreshingMetadata = download.id in refreshingMetadataIds,
                         onCompletedUnseenVisible = onVisibleCompletedUnseenDownload,
                         onMediaChange = { mediaType ->
                             onSelectedMedia(download.id, mediaType)
@@ -378,7 +378,6 @@ private fun DownloadPageContent(
     data: DownloadPageUiData,
     isCurrentPage: Boolean,
     selectedMedia: DownloadMediaType,
-    isRefreshingMetadata: Boolean,
     onCompletedUnseenVisible: (Long) -> Unit,
     onMediaChange: (DownloadMediaType) -> Unit,
     onEnsureValidSelection: (DownloadMediaType) -> Unit,
@@ -448,22 +447,29 @@ private fun DownloadPageContent(
             val canActOnSelected = status == DownloadStatusUiData.COMPLETED
                     && !selectedPath.isNullOrBlank()
 
-            val isMetadataIncomplete = metadata?.thumbnailFilePath.isNullOrBlank()
-            val needsMetadataRefresh = status == DownloadStatusUiData.COMPLETED
-                    && !status.isActive
-                    && isMetadataIncomplete
-                    && !isRefreshingMetadata
+            val hasThumbnailFile = (
+                    metadata?.thumbnailFilePath
+                        ?.let(::File)
+                        ?.let { it.exists() && it.length() > 0L }
+                    ) == true
+
+            val needsMetadataRefresh = status == DownloadStatusUiData.COMPLETED &&
+                    !hasThumbnailFile
+
+            LaunchedEffect(id, isCurrentPage, needsMetadataRefresh) {
+                if (isCurrentPage && needsMetadataRefresh) {
+                    onRefreshMetadataClick()
+                }
+            }
 
             ThumbnailCard(
                 thumbnailFilePath = metadata?.thumbnailFilePath,
                 durationSeconds = metadata?.durationSeconds,
+                isCompleted = status == DownloadStatusUiData.COMPLETED,
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
-                showMetadataRefresh = needsMetadataRefresh,
-                showMetadataRefreshLoading = isRefreshingMetadata,
                 showPlay = canActOnSelected,
                 onPlayClick = onPlayClick,
                 onRetryClick = onRetryClick,
-                onRefreshMetadataClick = onRefreshMetadataClick,
             )
             Spacer(modifier = Modifier.height(dimens.spacingSmall))
             Row(
@@ -600,13 +606,11 @@ private fun MediaSwitcherSegmentedButtonRow(
 private fun ThumbnailCard(
     thumbnailFilePath: String?,
     durationSeconds: Int?,
+    isCompleted: Boolean,
     showRetry: Boolean,
-    showMetadataRefresh: Boolean,
-    showMetadataRefreshLoading: Boolean,
     showPlay: Boolean,
     onPlayClick: () -> Unit,
     onRetryClick: () -> Unit,
-    onRefreshMetadataClick: () -> Unit,
 ) {
     val dimens = LocalDimens.current
     val thumbnailFile = thumbnailFilePath
@@ -669,7 +673,11 @@ private fun ThumbnailCard(
                     Icon(
                         modifier = Modifier
                             .size(dimens.overlayIcon),
-                        imageVector = Icons.Filled.Image,
+                        imageVector = if (isCompleted) {
+                            Icons.Filled.ImageNotSupported
+                        } else {
+                            Icons.Filled.Image
+                        },
                         contentDescription = thumbnailContentDescription,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -695,46 +703,6 @@ private fun ThumbnailCard(
                         contentDescription = overlayContentDescription,
                         imageVector = overlayIcon,
                     )
-                }
-            }
-            if (showMetadataRefresh || showMetadataRefreshLoading) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(dimens.spacingSmall)
-                        .size(dimens.overlayButtonSmall)
-                        .clip(CircleShape)
-                        .background(overlayBackgroundColor),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    if (showMetadataRefreshLoading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .size(dimens.iconXXSmall),
-                            color = Color.White,
-                            strokeWidth = dimens.spacingXXSmall,
-                        )
-                    } else {
-                        Box(
-                            modifier = Modifier
-                                .size(dimens.overlayButtonSmall)
-                                .clip(CircleShape)
-                                .clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = LocalIndication.current,
-                                    onClick = onRefreshMetadataClick,
-                                ),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Icon(
-                                modifier = Modifier
-                                    .size(dimens.iconXXSmall),
-                                imageVector = Icons.Filled.Download,
-                                contentDescription = stringResource(R.string.content_description_refresh_metadata),
-                                tint = Color.White,
-                            )
-                        }
-                    }
                 }
             }
             if (durationText != null) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -1,5 +1,6 @@
 package org.strigate.ferrot.presentation.screen
 
+import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
@@ -75,6 +76,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -120,6 +122,7 @@ fun DownloadsScreen(
     modifier: Modifier = Modifier,
     viewModel: DownloadsViewModel = hiltViewModel(),
 ) {
+    val view = LocalView.current
     val dimens = LocalDimens.current
     val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -432,6 +435,7 @@ fun DownloadsScreen(
                                         )
                                     },
                                     onClick = {
+                                        view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                                         viewModel.retryFailedDownloads()
                                         coroutineScope.launch {
                                             delay(RETRY_FAILED_SCROLL_DELAY_MILLIS)
@@ -547,10 +551,12 @@ fun DownloadsScreen(
                                         DownloadStatusUiData.WAITING_FOR_WIFI,
                                         DownloadStatusUiData.DOWNLOADING,
                                         DownloadStatusUiData.METADATA -> {
+                                            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                                             viewModel.stopDownload(item.id)
                                         }
 
                                         else -> {
+                                            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
                                             viewModel.retryDownload(item.id)
                                         }
                                     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -28,7 +28,7 @@ import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
-import org.strigate.ferrot.domain.usecase.combined.RefreshDownloadMetadataCombinedUseCase
+import org.strigate.ferrot.domain.usecase.download.RequestRefreshDownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.Screen
@@ -50,7 +50,7 @@ class DownloadViewModel @Inject constructor(
     private val downloadMetadataUseCase: DownloadMetadataUseCase,
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
-    private val refreshDownloadMetadataCombinedUseCase: RefreshDownloadMetadataCombinedUseCase,
+    private val requestRefreshDownloadMetadataUseCase: RequestRefreshDownloadMetadataUseCase,
     downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
 ) : ViewModel() {
     private val initialId: Long = checkNotNull(savedStateHandle[Screen.Download.ARG_DOWNLOAD_ID])
@@ -90,9 +90,6 @@ class DownloadViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
         initialValue = DownloadMediaType.VIDEO,
     )
-
-    private val _refreshingMetadataIds = MutableStateFlow<Set<Long>>(emptySet())
-    val refreshingMetadataIds: StateFlow<Set<Long>> = _refreshingMetadataIds
 
     private val _events = MutableSharedFlow<DownloadEvent>(
         replay = 0,
@@ -259,12 +256,7 @@ class DownloadViewModel @Inject constructor(
 
     fun refreshDownloadMetadata(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
-        _refreshingMetadataIds.value += downloadId
-        try {
-            refreshDownloadMetadataCombinedUseCase(downloadId)
-        } finally {
-            _refreshingMetadataIds.value -= downloadId
-        }
+        requestRefreshDownloadMetadataUseCase(downloadId)
     }
 
     private fun getSelectedMediaFilePath(

--- a/app/src/main/kotlin/org/strigate/ferrot/work/RefreshDownloadMetadataWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/RefreshDownloadMetadataWorker.kt
@@ -1,0 +1,72 @@
+package org.strigate.ferrot.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
+import org.strigate.ferrot.app.Constants.Work.Name.ONETIME_REFRESH_DOWNLOAD_METADATA
+import org.strigate.ferrot.domain.usecase.combined.RefreshDownloadMetadataCombinedUseCase
+
+class RefreshDownloadMetadataWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters,
+    private val refreshDownloadMetadataCombinedUseCase: RefreshDownloadMetadataCombinedUseCase,
+) : CoroutineWorker(appContext, workerParameters) {
+    override suspend fun doWork(): Result {
+        val downloadId = inputData.getLong(KEY_ID, -1L)
+        val tag = "RefreshDownloadMetadata[$downloadId]:"
+
+        if (downloadId <= 0L) {
+            Log.w(LOG_TAG, "$tag Invalid download ID")
+            return Result.failure()
+        }
+        val refreshed = runCatching {
+            refreshDownloadMetadataCombinedUseCase(downloadId)
+        }.onFailure {
+            Log.w(LOG_TAG, "$tag Worker failed", it)
+        }.getOrDefault(false)
+
+        return if (refreshed) {
+            Log.d(LOG_TAG, "$tag Complete")
+            Result.success()
+        } else {
+            Log.w(LOG_TAG, "$tag No metadata refreshed")
+            Result.failure()
+        }
+    }
+
+    companion object {
+        fun enqueueOneTimeKeep(context: Context, downloadId: Long) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val inputData = Data.Builder()
+                .putLong(KEY_ID, downloadId)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<RefreshDownloadMetadataWorker>()
+                .setConstraints(constraints)
+                .setInputData(inputData)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                uniqueWorkName(downloadId),
+                ExistingWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        fun uniqueWorkName(downloadId: Long): String {
+            return "$ONETIME_REFRESH_DOWNLOAD_METADATA-$downloadId"
+        }
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -48,11 +48,11 @@ import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
+import org.strigate.ferrot.domain.usecase.download.RequestRefreshDownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeleteDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
 import org.strigate.ferrot.domain.usecase.downloadaudio.GetDownloadAudioByDownloadIdAsFlowUseCase
-import org.strigate.ferrot.domain.usecase.combined.RefreshDownloadMetadataCombinedUseCase
 import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadMetadataByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadprogress.GetDownloadProgressByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadVideoByDownloadIdAsFlowUseCase
@@ -94,7 +94,7 @@ class DownloadViewModelTest {
     private lateinit var startDownloadUseCase: StartDownloadUseCase
 
     @Mock
-    private lateinit var refreshDownloadMetadataCombinedUseCase: RefreshDownloadMetadataCombinedUseCase
+    private lateinit var requestRefreshDownloadMetadataUseCase: RequestRefreshDownloadMetadataUseCase
 
     @Mock
     private lateinit var downloadWithMetadataUseCase: DownloadWithMetadataUseCase
@@ -168,7 +168,7 @@ class DownloadViewModelTest {
                 downloadMetadataUseCase = downloadMetadataUseCase,
                 clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
                 startDownloadUseCase = startDownloadUseCase,
-                refreshDownloadMetadataCombinedUseCase = refreshDownloadMetadataCombinedUseCase,
+                requestRefreshDownloadMetadataUseCase = requestRefreshDownloadMetadataUseCase,
                 downloadWithMetadataUseCase = downloadWithMetadataUseCase,
             )
             fail("Expected IllegalStateException")
@@ -461,8 +461,6 @@ class DownloadViewModelTest {
     fun refreshDownloadMetadata_refreshesExplicitOrSelectedDownload() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(initialId = 20L)
-            `when`(refreshDownloadMetadataCombinedUseCase.invoke(88L)).thenReturn(true)
-            `when`(refreshDownloadMetadataCombinedUseCase.invoke(20L)).thenReturn(true)
 
             viewModel.refreshDownloadMetadata(88L)
             advanceUntilIdle()
@@ -470,24 +468,19 @@ class DownloadViewModelTest {
             viewModel.refreshDownloadMetadata()
             advanceUntilIdle()
 
-            verify(refreshDownloadMetadataCombinedUseCase).invoke(88L)
-            verify(refreshDownloadMetadataCombinedUseCase).invoke(20L)
+            verify(requestRefreshDownloadMetadataUseCase).invoke(88L)
+            verify(requestRefreshDownloadMetadataUseCase).invoke(20L)
         }
 
     @Test
-    fun refreshDownloadMetadata_tracksRefreshingDownloadId_whileWorkRuns() =
+    fun refreshDownloadMetadata_enqueuesWithoutAdditionalUiTracking() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(initialId = 20L)
-
-            `when`(refreshDownloadMetadataCombinedUseCase.invoke(20L)).thenAnswer {
-                assertEquals(setOf(20L), viewModel.refreshingMetadataIds.value)
-                true
-            }
 
             viewModel.refreshDownloadMetadata()
             advanceUntilIdle()
 
-            assertEquals(emptySet<Long>(), viewModel.refreshingMetadataIds.value)
+            verify(requestRefreshDownloadMetadataUseCase).invoke(20L)
         }
 
     @Test
@@ -807,7 +800,7 @@ class DownloadViewModelTest {
             downloadMetadataUseCase = downloadMetadataUseCase,
             clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
             startDownloadUseCase = startDownloadUseCase,
-            refreshDownloadMetadataCombinedUseCase = refreshDownloadMetadataCombinedUseCase,
+            requestRefreshDownloadMetadataUseCase = requestRefreshDownloadMetadataUseCase,
             downloadWithMetadataUseCase = downloadWithMetadataUseCase,
         )
     }


### PR DESCRIPTION
- Add `RefreshDownloadMetadataWorker` for background metadata refresh
- Add `RequestRefreshDownloadMetadataUseCase` to enqueue metadata refresh work
- Inject `RefreshDownloadMetadataCombinedUseCase` into `WorkerFactory`
- Add `ONETIME_REFRESH_DOWNLOAD_METADATA` work constant
- Update `DownloadViewModel` to use `RequestRefreshDownloadMetadataUseCase`
- Remove `refreshingMetadataIds` state and related UI tracking
- Update `DownloadViewModelTest` to verify enqueue behavior
- Trigger metadata refresh automatically via `LaunchedEffect` in `DownloadScreen`
- Remove manual metadata refresh UI controls from `ThumbnailCard`
- Update thumbnail placeholder icon to `ImageNotSupported` when completed without thumbnail
- Add haptic feedback for retry and stop actions in `DownloadScreen` and `DownloadsScreen`
- Refactor `DownloadThumbnailUseCase` to use temp directory and atomic file move
- Ensure cleanup of temp files and stale thumbnails after successful download