### PR TITLE
chore: Update AGP and Gradle wrapper

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ espressoCore = "3.7.0"
 coroutinesTest = "1.10.2"
 mockito = "5.23.0"
 byteBuddy = "1.18.8"
-agp = "9.1.0"
+agp = "9.1.1"
 kotlin = "2.3.20"
 ksp = "2.3.4"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update `agp` from `9.1.0` to `9.1.1` in `libs.versions.toml`
- Update Gradle wrapper distribution from `gradle-9.3.1-bin.zip` to `gradle-9.4.1-bin.zip`