### PR TITLE
chore: Update compile and target SDK to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,12 +33,12 @@ object BuildInfo {
 
 android {
     namespace = BuildInfo.PACKAGE_NAME
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "org.strigate.ferrot"
         minSdk = 30
-        targetSdk = 36
+        targetSdk = 37
         versionCode = BuildInfo.VERSION_CODE
         versionName = BuildInfo.VERSION_NAME
         stringField("VERSION", BuildInfo.BASE_VERSION)


### PR DESCRIPTION
- Update `compileSdk` from `36` to `37`
- Update `targetSdk` from `36` to `37`