### PR TITLE
refactor: Centralize update toast handling via events

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/event/UpdatesEvent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/event/UpdatesEvent.kt
@@ -1,0 +1,7 @@
+package org.strigate.ferrot.presentation.event
+
+import androidx.annotation.StringRes
+
+sealed interface UpdatesEvent {
+    data class ShowToast(@param:StringRes val textRes: Int) : UpdatesEvent
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -28,11 +28,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.strigate.ferrot.R
+import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
 import org.strigate.ferrot.presentation.component.settings.SwitchSetting
 import org.strigate.ferrot.presentation.component.settings.TextSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
+import org.strigate.ferrot.presentation.event.UpdatesEvent
 import org.strigate.ferrot.presentation.state.UpdatesUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
@@ -51,6 +53,15 @@ fun UpdatesScreen(
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
+    }
+    LaunchedEffect(Unit) {
+        viewModel.event.collect { event ->
+            when (event) {
+                is UpdatesEvent.ShowToast -> {
+                    context.toast(event.textRes)
+                }
+            }
+        }
     }
 
     Scaffold(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -62,10 +62,7 @@ class DownloadsViewModel @Inject constructor(
     )
     val searchQuery: StateFlow<TextFieldValue> = _searchQuery
 
-    private val _events = MutableSharedFlow<DownloadsEvent>(
-        replay = 0,
-        extraBufferCapacity = 1,
-    )
+    private val _events = MutableSharedFlow<DownloadsEvent>()
     val events = _events.asSharedFlow()
 
     val uiState: StateFlow<DownloadsUiState> = getUiState().stateIn(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -16,7 +18,7 @@ import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.StateUseCase
-import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.presentation.event.UpdatesEvent
 import org.strigate.ferrot.presentation.model.UpdatesInfoUiData
 import org.strigate.ferrot.presentation.model.UpdatesSettingsUiData
 import org.strigate.ferrot.presentation.model.UpdatesUiData
@@ -32,6 +34,9 @@ class UpdatesViewModel @Inject constructor(
     private val settingsUseCase: SettingsUseCase,
     private val stateUseCase: StateUseCase,
 ) : ViewModel() {
+    private val _event = MutableSharedFlow<UpdatesEvent>()
+    val event = _event.asSharedFlow()
+
     val uiState: StateFlow<UpdatesUiState> = getUiState().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
@@ -75,7 +80,7 @@ class UpdatesViewModel @Inject constructor(
 
     fun checkForAvailableUpdate() {
         viewModelScope.launch {
-            appContext.toast(appContext.getString(R.string.toast_checking_for_available_update))
+            _event.emit(UpdatesEvent.ShowToast(R.string.toast_checking_for_updates))
             DownloadAvailableUpdateWorker.enqueueOneTimeReplace(appContext)
         }
     }
@@ -93,7 +98,7 @@ class UpdatesViewModel @Inject constructor(
 
     fun checkForDependencyUpdates() {
         viewModelScope.launch {
-            appContext.toast(appContext.getString(R.string.toast_checking_for_dependency_updates))
+            _event.emit(UpdatesEvent.ShowToast(R.string.toast_checking_for_dependency_updates))
             UpdateDependenciesWorker.enqueueOneTimeReplace(appContext)
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorker.kt
@@ -83,7 +83,7 @@ class DownloadAvailableUpdateWorker(
             }
             if (!isNewerVersion(latestTag, currentTag)) {
                 if (isAppInForeground()) {
-                    appContext.toast(R.string.toast_already_up_to_date, true)
+                    appContext.toast(R.string.toast_no_updates_available, true)
                 }
                 Log.d(LOG_TAG, "$tag Already up to date: latest=$latestTag current=$currentTag")
                 clearAvailableUpdate()
@@ -168,7 +168,7 @@ class DownloadAvailableUpdateWorker(
                 notificationText = appContext.getString(R.string.notification_text_downloading_app_update),
             )
             if (isAppInForeground()) {
-                appContext.toast(R.string.toast_downloading_app_update, true)
+                appContext.toast(R.string.toast_downloading_update, true)
             }
 
             try {

--- a/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/UpdateDependenciesWorker.kt
@@ -48,11 +48,11 @@ class UpdateDependenciesWorker(
             if (isAppInForeground()) {
                 when (updateStatus) {
                     YoutubeDL.UpdateStatus.ALREADY_UP_TO_DATE -> {
-                        appContext.toast(appContext.getString(R.string.toast_dependencies_already_up_to_date))
+                        appContext.toast(appContext.getString(R.string.toast_no_dependency_updates_available))
                     }
 
                     YoutubeDL.UpdateStatus.DONE -> {
-                        appContext.toast(appContext.getString(R.string.toast_dependencies_update_complete))
+                        appContext.toast(appContext.getString(R.string.toast_dependencies_updated))
                     }
 
                     else -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,15 +84,15 @@
     <string name="snackbar_delete_undo">Undo</string>
     <string name="bulk_selected">selected</string>
 
-    <string name="toast_checking_for_available_update">Checking for available update</string>
-    <string name="toast_checking_for_dependency_updates">Checking for dependency updates</string>
     <string name="toast_saved_to">Saved to %1$s</string>
     <string name="toast_already_saved">Already saved in %1$s</string>
     <string name="toast_copied_to_clipboard">Copied to clipboard</string>
-    <string name="toast_dependencies_update_complete">Dependencies update complete</string>
-    <string name="toast_dependencies_already_up_to_date">Dependencies already up to date</string>
-    <string name="toast_downloading_app_update">Downloading app update</string>
-    <string name="toast_already_up_to_date">Already up to date</string>
+    <string name="toast_checking_for_updates">Checking for updates</string>
+    <string name="toast_checking_for_dependency_updates">Checking for dependency updates</string>
+    <string name="toast_downloading_update">Downloading update</string>
+    <string name="toast_dependencies_updated">Dependencies updated</string>
+    <string name="toast_no_updates_available">No updates available</string>
+    <string name="toast_no_dependency_updates_available">No dependency updates available</string>
 
     <string name="settings_section_general">General</string>
     <string name="settings_section_app_info">App info</string>


### PR DESCRIPTION
- Add `UpdatesEvent` sealed interface with `ShowToast`
- Introduce `MutableSharedFlow` in `UpdatesViewModel` for event emission
- Replace direct `toast` calls in `UpdatesViewModel` with event emission
- Collect `event` flow in `UpdatesScreen` and trigger `toast` from UI layer
- Simplify `DownloadsViewModel` `_events` initialization
- Update toast string resources
- Replace outdated toast usages in `DownloadAvailableUpdateWorker`
- Replace outdated toast usages in `UpdateDependenciesWorker`