### PR TITLE
refactor: Replace `popUpToDownloads` with generic `popUpToRoute`

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
@@ -134,9 +134,9 @@ class MainActivity : ComponentActivity() {
                     try {
                         navController.currentBackStackEntryFlow.first()
                         navController.navigate(targetRoute) {
-                            event.popUpToRoute?.let { popUpToRoute ->
-                                popUpTo(popUpToRoute) {
-                                    inclusive = targetRoute == popUpToRoute
+                            event.popUpToRoute?.let { route ->
+                                popUpTo(route) {
+                                    inclusive = targetRoute == route
                                     saveState = false
                                 }
                             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
@@ -54,7 +54,7 @@ class MainActivity : ComponentActivity() {
         if (Intent.ACTION_APPLICATION_PREFERENCES == intent.action) {
             viewModel.navigateTo(
                 route = Screen.Settings.route,
-                popUpToDownloads = true,
+                popUpToRoute = Screen.Downloads.route,
             )
             return
         }
@@ -71,7 +71,7 @@ class MainActivity : ComponentActivity() {
                         viewModel.startDownload(sharedUrl)
                         viewModel.navigateTo(
                             route = Screen.Downloads.route,
-                            popUpToDownloads = true,
+                            popUpToRoute = Screen.Downloads.route,
                         )
                     }
                 }
@@ -90,7 +90,7 @@ class MainActivity : ComponentActivity() {
             ACTION_NAVIGATE_DOWNLOADS -> {
                 viewModel.navigateTo(
                     route = Screen.Downloads.route,
-                    popUpToDownloads = true,
+                    popUpToRoute = Screen.Downloads.route,
                 )
                 return
             }
@@ -100,7 +100,7 @@ class MainActivity : ComponentActivity() {
                 InstallHelper.requestInstallApkIfExists(this, apkFilePath)
                 viewModel.navigateTo(
                     route = Screen.Downloads.route,
-                    popUpToDownloads = true,
+                    popUpToRoute = Screen.Downloads.route,
                 )
                 return
             }
@@ -134,9 +134,9 @@ class MainActivity : ComponentActivity() {
                     try {
                         navController.currentBackStackEntryFlow.first()
                         navController.navigate(targetRoute) {
-                            if (event.popUpToDownloads) {
-                                popUpTo(Screen.Downloads.route) {
-                                    inclusive = targetRoute == Screen.Downloads.route
+                            event.popUpToRoute?.let { popUpToRoute ->
+                                popUpTo(popUpToRoute) {
+                                    inclusive = targetRoute == popUpToRoute
                                     saveState = false
                                 }
                             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
@@ -54,7 +54,9 @@ fun MainNavHost(
                 },
             ),
         ) {
-            DownloadScreen()
+            DownloadScreen(
+                navController = navController,
+            )
         }
         composable(Screen.Settings.route) {
             SettingsScreen(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainViewModel.kt
@@ -24,9 +24,9 @@ class MainViewModel @Inject constructor(
     private val _navigateRoute = MutableStateFlow<NavigationEvent?>(null)
     val navigateRoute: StateFlow<NavigationEvent?> = _navigateRoute.asStateFlow()
 
-    fun navigateTo(route: String, popUpToDownloads: Boolean = false) {
+    fun navigateTo(route: String, popUpToRoute: String? = null) {
         _navigateRoute.value = NavigationEvent.Route(
-            popUpToDownloads = popUpToDownloads,
+            popUpToRoute = popUpToRoute,
             route = route,
         )
     }
@@ -41,8 +41,15 @@ class MainViewModel @Inject constructor(
                     )
                 }
                 navigateTo(
-                    route = Screen.Download.route(download.id),
-                    popUpToDownloads = true,
+                    route = Screen.Download.route(
+                        id = download.id,
+                        archived = download.archived,
+                    ),
+                    popUpToRoute = if (download.archived) {
+                        Screen.Archived.route
+                    } else {
+                        Screen.Downloads.route
+                    },
                 )
             }
         }
@@ -75,6 +82,6 @@ class MainViewModel @Inject constructor(
 sealed class NavigationEvent {
     data class Route(
         val route: String,
-        val popUpToDownloads: Boolean = false,
+        val popUpToRoute: String? = null,
     ) : NavigationEvent()
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -1,7 +1,7 @@
 package org.strigate.ferrot.presentation.screen
 
 import android.view.HapticFeedbackConstants
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
@@ -72,6 +72,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
@@ -86,6 +87,7 @@ import org.strigate.ferrot.extensions.copyToClipboard
 import org.strigate.ferrot.helper.PlayHelper
 import org.strigate.ferrot.helper.SaveHelper
 import org.strigate.ferrot.helper.ShareHelper
+import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.component.ActionIconButton
 import org.strigate.ferrot.presentation.component.ConfirmDialog
 import org.strigate.ferrot.presentation.component.DownloadProgressSection
@@ -104,12 +106,12 @@ import java.io.File
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadScreen(
+    navController: NavController,
     modifier: Modifier = Modifier,
     viewModel: DownloadViewModel = hiltViewModel(),
 ) {
     val view = LocalView.current
     val context = LocalContext.current
-    val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val selectedId by viewModel.selectedId.collectAsStateWithLifecycle()
@@ -119,6 +121,16 @@ fun DownloadScreen(
     val selectedPageData by viewModel.selectedPageData.collectAsStateWithLifecycle()
 
     val showConfirmDeleteDialog = remember { mutableStateOf(false) }
+    val onNavigateBack = {
+        navigateBackToParent(
+            navController = navController,
+            archived = selectedPageData?.archived == true,
+        )
+    }
+
+    BackHandler {
+        onNavigateBack()
+    }
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -127,7 +139,7 @@ fun DownloadScreen(
         viewModel.events.collect { event ->
             when (event) {
                 DownloadEvent.NavigateBack -> {
-                    backDispatcher?.onBackPressed()
+                    onNavigateBack()
                 }
 
                 is DownloadEvent.Play -> {
@@ -170,7 +182,7 @@ fun DownloadScreen(
                 navigationIcon = {
                     IconButton(
                         onClick = {
-                            backDispatcher?.onBackPressed()
+                            onNavigateBack()
                         },
                     ) {
                         Icon(
@@ -277,6 +289,34 @@ fun DownloadScreen(
             }
         },
     )
+}
+
+private fun navigateBackToParent(
+    navController: NavController,
+    archived: Boolean,
+) {
+    val parentRoute = if (archived) {
+        Screen.Archived.route
+    } else {
+        Screen.Downloads.route
+    }
+    val previousRoute = navController.previousBackStackEntry?.destination?.route
+    if (previousRoute == parentRoute) {
+        navController.popBackStack()
+        return
+    }
+    val parentAlreadyInBackStack = navController.popBackStack(parentRoute, false)
+    if (parentAlreadyInBackStack) {
+        return
+    }
+    navController.navigate(parentRoute) {
+        popUpTo(Screen.Downloads.route) {
+            inclusive = false
+            saveState = false
+        }
+        launchSingleTop = true
+        restoreState = false
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -128,7 +128,7 @@ fun DownloadScreen(
         )
     }
 
-    BackHandler {
+    BackHandler(enabled = !showConfirmDeleteDialog.value) {
         onNavigateBack()
     }
 
@@ -305,8 +305,7 @@ private fun navigateBackToParent(
         navController.popBackStack()
         return
     }
-    val parentAlreadyInBackStack = navController.popBackStack(parentRoute, false)
-    if (parentAlreadyInBackStack) {
+    if (navController.popBackStack(parentRoute, false)) {
         return
     }
     navController.navigate(parentRoute) {

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
@@ -68,12 +68,12 @@ class MainViewModelTest {
     fun navigateTo_updatesNavigationEvent() {
         val viewModel = createViewModel()
 
-        viewModel.navigateTo(route = Screen.Settings.route, popUpToDownloads = true)
+        viewModel.navigateTo(route = Screen.Settings.route, popUpToRoute = Screen.Downloads.route)
 
         assertEquals(
             NavigationEvent.Route(
                 route = Screen.Settings.route,
-                popUpToDownloads = true,
+                popUpToRoute = Screen.Downloads.route,
             ),
             viewModel.navigateRoute.value,
         )
@@ -110,11 +110,38 @@ class MainViewModelTest {
         assertEquals(
             NavigationEvent.Route(
                 route = Screen.Download.route(42L),
-                popUpToDownloads = true,
+                popUpToRoute = Screen.Downloads.route,
             ),
             viewModel.navigateRoute.value,
         )
     }
+
+    @Test
+    fun navigateToDownload_routesToArchivedDownload_whenDownloadIsArchived() =
+        runTest(testDispatcher) {
+            val download = Download(
+                id = 42L,
+                uid = "uid-42",
+                url = "https://example.com",
+                status = DownloadStatus.COMPLETED,
+                seen = false,
+                archived = true,
+            )
+            val viewModel = createViewModel()
+            `when`(downloadRepository.getById(42L))
+                .thenReturn(download)
+
+            viewModel.navigateToDownload(42L)
+            advanceUntilIdle()
+
+            assertEquals(
+                NavigationEvent.Route(
+                    route = Screen.Download.route(42L, archived = true),
+                    popUpToRoute = Screen.Archived.route,
+                ),
+                viewModel.navigateRoute.value,
+            )
+        }
 
     @Test
     fun navigateToDownload_clearsPendingDeleteBeforeNavigation_whenDownloadIsPendingDelete() =
@@ -138,7 +165,7 @@ class MainViewModelTest {
             assertEquals(
                 NavigationEvent.Route(
                     route = Screen.Download.route(42L),
-                    popUpToDownloads = true,
+                    popUpToRoute = Screen.Downloads.route,
                 ),
                 viewModel.navigateRoute.value,
             )


### PR DESCRIPTION
- Replace `popUpToDownloads` with `popUpToRoute` in `MainViewModel`
- Update `NavigationEvent.Route` to use nullable `popUpToRoute`
- Update navigation handling in `MainActivity` to use dynamic `popUpToRoute`
- Adjust navigation calls to pass `Screen.Downloads.route` explicitly
- Add conditional `popUpToRoute` for archived downloads in `navigateToDownload`
- Update tests to reflect new `popUpToRoute` behavior
- Add test for archived download navigation using `Screen.Archived.route`