### PR TITLE
feat: Handle archived downloads and improve navigation routing

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
@@ -122,10 +122,11 @@ class MainActivity : ComponentActivity() {
                     .collectAsStateWithLifecycle(initialValue = null)
 
                 LaunchedEffect(navigateRoute) {
-                    val event = navigateRoute ?: return@LaunchedEffect
-                    val targetRoute = when (event) {
-                        is NavigationEvent.Route -> event.route
-                    }
+                    val routeEvent =
+                        navigateRoute as? NavigationEvent.Route ?: return@LaunchedEffect
+
+                    val targetRoute = routeEvent.route
+                    val popUpToRoute = routeEvent.popUpToRoute
                     val currentRoute = navController.currentDestination?.route
                     if (targetRoute == currentRoute) {
                         viewModel.resetNavigate()
@@ -133,8 +134,18 @@ class MainActivity : ComponentActivity() {
                     }
                     try {
                         navController.currentBackStackEntryFlow.first()
+                        val resolvedPopUpToRoute = when {
+                            popUpToRoute == null -> null
+                            runCatching { navController.getBackStackEntry(popUpToRoute) }
+                                .isSuccess -> popUpToRoute
+
+                            runCatching { navController.getBackStackEntry(Screen.Downloads.route) }
+                                .isSuccess -> Screen.Downloads.route
+
+                            else -> null
+                        }
                         navController.navigate(targetRoute) {
-                            event.popUpToRoute?.let { route ->
+                            resolvedPopUpToRoute?.let { route ->
                                 popUpTo(route) {
                                     inclusive = targetRoute == route
                                     saveState = false

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -53,7 +53,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -259,7 +258,6 @@ fun DownloadScreen(
                             .padding(contentPadding)
                             .fillMaxSize(),
                         data = state.data,
-                        selectedPageData = selectedPageData,
                         pageDataForId = viewModel::getDownloadPageUiData,
                         selectedId = selectedId,
                         selectedMedia = selectedMedia,
@@ -323,7 +321,6 @@ private fun navigateBackToParent(
 private fun DownloadPager(
     modifier: Modifier = Modifier,
     data: DownloadUiData,
-    selectedPageData: DownloadPageUiData?,
     pageDataForId: (Long) -> Flow<DownloadPageUiData?>,
     selectedId: Long,
     selectedMedia: DownloadMediaType,
@@ -387,15 +384,9 @@ private fun DownloadPager(
         ) { page ->
             val downloadId = downloadIds[page]
             val isCurrentPage = pagerState.currentPage == page
-            val pageData by if (isCurrentPage) {
-                rememberUpdatedState(
-                    newValue = selectedPageData?.takeIf { it.id == downloadId },
-                )
-            } else {
-                remember(downloadId) {
-                    pageDataForId(downloadId)
-                }.collectAsStateWithLifecycle(initialValue = null)
-            }
+            val pageData by remember(downloadId) {
+                pageDataForId(downloadId)
+            }.collectAsStateWithLifecycle(initialValue = null)
 
             Surface(
                 modifier = Modifier

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -387,18 +387,23 @@ class DownloadWorker(
                 Log.d(LOG_TAG, "$tag Complete")
                 appContext.toast("$downloadComplete: $videoTitle", true)
 
-                notificationService.notifyDownloaded(
-                    contentText = videoTitle,
-                    contentTitle = downloadComplete,
-                    extras = notificationExtras,
-                    tag = downloadNotificationTag(downloadId),
-                    actions = buildCompletedNotificationActions(
-                        downloadId = downloadId,
-                        shareFilePath = videoOutputFilePath,
-                    ),
-                    thumbnailFilePath = thumbnailFilePath,
-                    autoCancel = false,
-                )
+                val latestDownload = downloadUseCase.getDownloadByIdUseCase(downloadId)
+                if (latestDownload?.archived == true) {
+                    Log.d(LOG_TAG, "$tag Complete notification skipped for archived download")
+                } else {
+                    notificationService.notifyDownloaded(
+                        contentText = videoTitle,
+                        contentTitle = downloadComplete,
+                        extras = notificationExtras,
+                        tag = downloadNotificationTag(downloadId),
+                        actions = buildCompletedNotificationActions(
+                            downloadId = downloadId,
+                            shareFilePath = videoOutputFilePath,
+                        ),
+                        thumbnailFilePath = thumbnailFilePath,
+                        autoCancel = false,
+                    )
+                }
                 Result.success()
 
             } catch (throwable: Throwable) {


### PR DESCRIPTION
- Skip completed notification when `download.archived` is true in `DownloadWorker`
- Fetch latest download via `getDownloadByIdUseCase` before showing notification
- Replace unsafe cast with safe cast for `NavigationEvent.Route` in `MainActivity`
- Introduce `resolvedPopUpToRoute` with fallback handling for navigation
- Ensure `popUpTo` only uses valid back stack entries
- Remove `selectedPageData` parameter from `DownloadPager`
- Simplify page data loading using `pageDataForId` with `collectAsStateWithLifecycle`
- Remove unnecessary `rememberUpdatedState` usage