### PR TITLE
fix: Skip archived download completion toast

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -385,12 +385,15 @@ class DownloadWorker(
 
                 val downloadComplete = appContext.getString(R.string.download_complete)
                 Log.d(LOG_TAG, "$tag Complete")
-                appContext.toast("$downloadComplete: $videoTitle", true)
-
                 val latestDownload = downloadUseCase.getDownloadByIdUseCase(downloadId)
                 if (latestDownload?.archived == true) {
-                    Log.d(LOG_TAG, "$tag Complete notification skipped for archived download")
+                    val message = buildString {
+                        append(tag)
+                        append(" Complete toast and notification skipped for archived download")
+                    }
+                    Log.d(LOG_TAG, message)
                 } else {
+                    appContext.toast("$downloadComplete: $videoTitle", true)
                     notificationService.notifyDownloaded(
                         contentText = videoTitle,
                         contentTitle = downloadComplete,


### PR DESCRIPTION
- Move completion toast behind archived download check in `DownloadWorker`
- Skip both toast and notification when `latestDownload.archived` is true
- Replace inline archived log message with `buildString` construction