### PR TITLE
fix: Scroll to top when restored item returns to first position

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -787,6 +787,17 @@ private fun DownloadsList(
         previousItemIds = itemIds
         previousPendingDeleteIds = pendingDeleteIds
     }
+    LaunchedEffect(restoringItemIds, itemIds) {
+        if (shouldScrollToTopOnRestore(
+                restoredItemIds = restoringItemIds,
+                currentItemIds = itemIds,
+                firstVisibleItemIndex = lazyListState.firstVisibleItemIndex,
+                firstVisibleItemScrollOffset = lazyListState.firstVisibleItemScrollOffset,
+            )
+        ) {
+            lazyListState.scrollToItem(0)
+        }
+    }
     LaunchedEffect(items.map { it.id to it.status }, trackedAutoScrollDownloadId) {
         val trackedId = trackedAutoScrollDownloadId ?: return@LaunchedEffect
         val trackedIndex = items.indexOfFirst { it.id == trackedId }
@@ -1272,6 +1283,19 @@ internal fun getRestoredItemIds(
     return previousPendingDeleteIds
         .intersect(currentItemIds.toSet())
         .minus(currentPendingDeleteIds)
+}
+
+internal fun shouldScrollToTopOnRestore(
+    restoredItemIds: Set<Long>,
+    currentItemIds: List<Long>,
+    firstVisibleItemIndex: Int,
+    firstVisibleItemScrollOffset: Int,
+): Boolean {
+    if (restoredItemIds.isEmpty() || currentItemIds.isEmpty()) {
+        return false
+    }
+    val userWasNearTop = firstVisibleItemIndex <= 1 || firstVisibleItemScrollOffset == 0
+    return userWasNearTop && currentItemIds.first() in restoredItemIds
 }
 
 private fun getPendingDeleteSnackbarMessage(

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
@@ -108,4 +108,52 @@ class DownloadsScreenScrollBehaviorTest {
 
         assertEquals(setOf(2L), restoredIds)
     }
+
+    @Test
+    fun shouldScrollToTopOnRestore_returnsTrue_whenTopItemWasRestoredAndListIsAtTop() {
+        val shouldScroll = shouldScrollToTopOnRestore(
+            restoredItemIds = setOf(1L),
+            currentItemIds = listOf(1L, 2L, 3L),
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+        )
+
+        assertTrue(shouldScroll)
+    }
+
+    @Test
+    fun shouldScrollToTopOnRestore_returnsTrue_whenTopItemWasRestoredAndAnchorShiftedToIndexOne() {
+        val shouldScroll = shouldScrollToTopOnRestore(
+            restoredItemIds = setOf(1L),
+            currentItemIds = listOf(1L, 2L, 3L),
+            firstVisibleItemIndex = 1,
+            firstVisibleItemScrollOffset = 24,
+        )
+
+        assertTrue(shouldScroll)
+    }
+
+    @Test
+    fun shouldScrollToTopOnRestore_returnsFalse_whenTopItemWasNotRestored() {
+        val shouldScroll = shouldScrollToTopOnRestore(
+            restoredItemIds = setOf(3L),
+            currentItemIds = listOf(1L, 2L, 3L),
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0,
+        )
+
+        assertFalse(shouldScroll)
+    }
+
+    @Test
+    fun shouldScrollToTopOnRestore_returnsFalse_whenListIsNotAtTop() {
+        val shouldScroll = shouldScrollToTopOnRestore(
+            restoredItemIds = setOf(1L),
+            currentItemIds = listOf(1L, 2L, 3L),
+            firstVisibleItemIndex = 2,
+            firstVisibleItemScrollOffset = 64,
+        )
+
+        assertFalse(shouldScroll)
+    }
 }


### PR DESCRIPTION
- Add `shouldScrollToTopOnRestore` to detect when a restored item reappears at the top of the list
- Trigger `lazyListState.scrollToItem(0)` from `LaunchedEffect` when the restored item becomes the first visible entry and the user was near the top
- Add test coverage for restored top-item handling and non-scroll cases in `DownloadsScreenScrollBehaviorTest`