### PR TITLE
chore: Update AGP and archived download title

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,6 @@ android {
         debug {
             isDebuggable = true
             isMinifyEnabled = false
-            isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro",
             )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -192,7 +192,11 @@ fun DownloadScreen(
                 },
                 title = {
                     Text(
-                        text = stringResource(R.string.screen_title_download),
+                        text = if (selectedPageData?.archived == true) {
+                            stringResource(R.string.screen_title_archived_download)
+                        } else {
+                            stringResource(R.string.screen_title_download)
+                        },
                     )
                 },
                 actions = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     </plurals>
 
     <string name="screen_title_download">Download</string>
+    <string name="screen_title_archived_download">Archived download</string>
     <string name="screen_title_archived">Archived</string>
     <string name="screen_title_settings">Settings</string>
     <string name="screen_title_updates">Updates</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ espressoCore = "3.7.0"
 coroutinesTest = "1.10.2"
 mockito = "5.23.0"
 byteBuddy = "1.18.8"
-agp = "9.1.1"
+agp = "9.2.0"
 kotlin = "2.3.20"
 ksp = "2.3.4"
 


### PR DESCRIPTION
- Add `screen_title_archived_download` to `strings.xml`
- Show `screen_title_archived_download` in `DownloadScreen` when `selectedPageData?.archived == true`
- Bump `agp` from `9.1.1` to `9.2.0`
- Remove explicit `isShrinkResources = false` from the `debug` build type