### PR TITLE
fix: Use stable locale for hash hex output

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/util/HashUtil.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/util/HashUtil.kt
@@ -3,6 +3,7 @@ package org.strigate.ferrot.util
 import java.io.File
 import java.io.FileInputStream
 import java.security.MessageDigest
+import java.util.Locale
 
 fun sha256(filePath: String): String? {
     val file = File(filePath)
@@ -20,5 +21,5 @@ fun sha256(filePath: String): String? {
             messageDigest.update(buffer, 0, read)
         }
     }
-    return messageDigest.digest().joinToString("") { "%02x".format(it) }
+    return messageDigest.digest().joinToString("") { "%02x".format(Locale.ROOT, it) }
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/util/HashUtilTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/util/HashUtilTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import java.nio.file.Files
+import java.util.Locale
 
 class HashUtilTest {
     @Test
@@ -21,5 +22,22 @@ class HashUtilTest {
             "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
             result,
         )
+    }
+
+    @Test
+    fun sha256_usesStableAsciiHex_evenWhenDefaultLocaleChanges() {
+        val file = Files.createTempFile("hash-util-locale-test", ".txt")
+        Files.write(file, "hello world".toByteArray())
+        val originalLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("ar-EG"))
+            assertEquals(
+                "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+                sha256(file.toString()),
+            )
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
     }
 }


### PR DESCRIPTION
- Format `sha256` digest bytes with `Locale.ROOT`
- Add locale regression test for `sha256`