### PR TITLE
refactor: Extract release artifact rename task

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,7 @@ object BuildInfo {
     const val VERSION_CODE = 28
     const val VERSION_NAME = "$BASE_VERSION-$VERSION_CODE"
     const val RELEASE_APK_NAME = "ferrot"
+    const val RELEASE_VARIANT_SUFFIX = "release"
 }
 
 android {
@@ -118,26 +119,14 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
-tasks.register<Copy>("renameReleaseApk") {
-    val releaseDir = layout.buildDirectory.dir("outputs/apk/release")
-    from(releaseDir)
-    include("app-release.apk")
-    into(releaseDir)
-    rename {
-        "${BuildInfo.RELEASE_APK_NAME}-release.apk"
-    }
-    doFirst {
-        println("Renaming APK")
-    }
-}
-
-tasks.named("renameReleaseApk") {
-    mustRunAfter("createReleaseApkListingFileRedirect")
-}
-
-tasks.matching { it.name == "assembleRelease" }.configureEach {
-    finalizedBy("renameReleaseApk")
-}
+registerReleaseArtifactRenameTask(
+    taskName = "renameReleaseApk",
+    outputDirectory = "outputs/apk/release",
+    sourceFileName = "app-release.apk",
+    extension = "apk",
+    listingTaskName = "createReleaseApkListingFileRedirect",
+    buildTaskName = "assembleRelease",
+)
 
 private fun ApplicationDefaultConfig.applyFirebaseProperties(
     includeResString: Boolean = true,
@@ -172,6 +161,33 @@ private fun Properties.getString(key: String): String {
 
 private fun String.escapeForBuildConfig(): String {
     return "\"" + this.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+}
+
+private fun registerReleaseArtifactRenameTask(
+    taskName: String,
+    outputDirectory: String,
+    sourceFileName: String,
+    extension: String,
+    listingTaskName: String,
+    buildTaskName: String,
+) {
+    tasks.register<Copy>(taskName) {
+        val releaseDir = layout.buildDirectory.dir(outputDirectory)
+        from(releaseDir)
+        include(sourceFileName)
+        into(releaseDir)
+        rename(sourceFileName, releaseArtifactFileName(extension))
+    }
+    tasks.named(taskName) {
+        mustRunAfter(listingTaskName)
+    }
+    tasks.matching { it.name == buildTaskName }.configureEach {
+        finalizedBy(taskName)
+    }
+}
+
+private fun releaseArtifactFileName(extension: String): String {
+    return "${BuildInfo.RELEASE_APK_NAME}-${BuildInfo.RELEASE_VARIANT_SUFFIX}.$extension"
 }
 
 dependencies {


### PR DESCRIPTION
- Add `RELEASE_VARIANT_SUFFIX` to `BuildInfo`
- Replace inline `renameReleaseApk` task setup with `registerReleaseArtifactRenameTask`
- Add `releaseArtifactFileName` for release artifact naming