### PR TITLE
refactor: Extract YoutubeDL client and download work scheduler

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/integration/DownloadWorkScheduler.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/integration/DownloadWorkScheduler.kt
@@ -1,0 +1,18 @@
+package org.strigate.ferrot.app.integration
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.strigate.ferrot.work.DownloadWorker
+import javax.inject.Inject
+
+class DownloadWorkScheduler @Inject constructor(
+    @param:ApplicationContext private val appContext: Context,
+) {
+    fun enqueueOneTimeReplace(downloadId: Long, wifiOnly: Boolean) {
+        DownloadWorker.enqueueOneTimeReplace(
+            context = appContext,
+            id = downloadId,
+            wifiOnly = wifiOnly,
+        )
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/app/integration/YoutubeDlClient.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/integration/YoutubeDlClient.kt
@@ -1,0 +1,26 @@
+package org.strigate.ferrot.app.integration
+
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import com.yausername.youtubedl_android.YoutubeDLResponse
+import javax.inject.Inject
+
+open class YoutubeDlClient @Inject constructor() {
+    open fun execute(
+        request: YoutubeDLRequest,
+        processId: String,
+        redirectErrorStream: Boolean = false,
+        callback: ((Float, Long, String) -> Unit)? = null,
+    ): YoutubeDLResponse {
+        return YoutubeDL.getInstance().execute(
+            request = request,
+            processId = processId,
+            redirectErrorStream = redirectErrorStream,
+            callback = callback,
+        )
+    }
+
+    open fun destroyProcessById(processId: String): Boolean {
+        return YoutubeDL.getInstance().destroyProcessById(processId)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCase.kt
@@ -2,15 +2,13 @@ package org.strigate.ferrot.domain.usecase.apply
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import org.strigate.ferrot.app.integration.DownloadWorkScheduler
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.download.DeleteDownloadFilesUseCase
 import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadErrorMessageUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
 import org.strigate.ferrot.util.NetworkOps
-import org.strigate.ferrot.work.DownloadWorker
 import javax.inject.Inject
 
 class ApplyWifiOnlyPolicyUseCase @Inject constructor(
@@ -19,8 +17,9 @@ class ApplyWifiOnlyPolicyUseCase @Inject constructor(
     private val updateDownloadErrorMessageUseCase: UpdateDownloadErrorMessageUseCase,
     private val updateDownloadStatusUseCase: UpdateDownloadStatusUseCase,
     private val deleteDownloadFilesUseCase: DeleteDownloadFilesUseCase,
+    private val downloadWorkScheduler: DownloadWorkScheduler,
 ) {
-    suspend operator fun invoke(isWifiOnly: Boolean) = withContext(Dispatchers.IO) {
+    suspend operator fun invoke(isWifiOnly: Boolean) {
         val (_, isOnWifi) = NetworkOps.quickNetworkProbe(appContext)
         val downloads = getAllDownloadsUseCase()
 
@@ -50,11 +49,7 @@ class ApplyWifiOnlyPolicyUseCase @Inject constructor(
                         runCatching {
                             deleteDownloadFilesUseCase(download.id)
                         }
-                        DownloadWorker.enqueueOneTimeReplace(
-                            context = appContext,
-                            id = download.id,
-                            wifiOnly = true,
-                        )
+                        downloadWorkScheduler.enqueueOneTimeReplace(download.id, true)
                     }
             }
         } else {
@@ -72,11 +67,7 @@ class ApplyWifiOnlyPolicyUseCase @Inject constructor(
                             downloadId = download.id,
                         )
                     }
-                    DownloadWorker.enqueueOneTimeReplace(
-                        context = appContext,
-                        id = download.id,
-                        wifiOnly = false,
-                    )
+                    downloadWorkScheduler.enqueueOneTimeReplace(download.id, false)
                 }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCase.kt
@@ -3,16 +3,14 @@ package org.strigate.ferrot.domain.usecase.download
 import android.content.Context
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
 import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.integration.DownloadWorkScheduler
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.util.NetworkOps
-import org.strigate.ferrot.work.DownloadWorker
 import javax.inject.Inject
 
 class StartDownloadUseCase @Inject constructor(
@@ -20,8 +18,9 @@ class StartDownloadUseCase @Inject constructor(
     private val settingsUseCase: SettingsUseCase,
     private val downloadUseCase: DownloadUseCase,
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
+    private val downloadWorkScheduler: DownloadWorkScheduler,
 ) {
-    suspend operator fun invoke(downloadId: Long) = withContext(Dispatchers.IO) {
+    suspend operator fun invoke(downloadId: Long) {
         val wifiOnly = settingsUseCase
             .getDownloadWifiOnlySettingAsFlowUseCase()
             .first()
@@ -39,10 +38,6 @@ class StartDownloadUseCase @Inject constructor(
             downloadId = downloadId,
         )
         Log.d(LOG_TAG, "Enqueuing download: $downloadId ($downloadStatus)")
-        DownloadWorker.enqueueOneTimeReplace(
-            context = appContext,
-            id = downloadId,
-            wifiOnly = wifiOnly,
-        )
+        downloadWorkScheduler.enqueueOneTimeReplace(downloadId, wifiOnly)
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCase.kt
@@ -1,12 +1,12 @@
 package org.strigate.ferrot.domain.usecase.youtubedl_android
 
 import android.os.SystemClock
-import com.yausername.youtubedl_android.YoutubeDL
 import com.yausername.youtubedl_android.YoutubeDLRequest
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import org.strigate.ferrot.app.YoutubeDlRuntimeInitializer
+import org.strigate.ferrot.app.integration.YoutubeDlClient
 import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.domain.model.QualityProfile
 import java.io.File
@@ -18,6 +18,7 @@ class DownloadWithProgressUseCase @Inject constructor(
     private val buildVideoDownloadRequestUseCase: BuildVideoDownloadRequestUseCase,
     private val buildAudioDownloadRequestUseCase: BuildAudioDownloadRequestUseCase,
     private val youtubeDlRuntimeInitializer: YoutubeDlRuntimeInitializer,
+    private val youtubeDlClient: YoutubeDlClient,
 ) {
     operator fun invoke(
         url: String,
@@ -54,7 +55,7 @@ class DownloadWithProgressUseCase @Inject constructor(
                 }
             }
 
-            val youtubeDlResponse = YoutubeDL.getInstance().execute(
+            val youtubeDlResponse = youtubeDlClient.execute(
                 request = youtubeDlRequest,
                 processId = processId,
                 redirectErrorStream = false,
@@ -79,7 +80,7 @@ class DownloadWithProgressUseCase @Inject constructor(
         awaitClose {
             outputPathFile?.delete()
             runCatching {
-                YoutubeDL.getInstance().destroyProcessById(processId)
+                youtubeDlClient.destroyProcessById(processId)
             }
             job.cancel()
         }

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImplTest.kt
@@ -36,25 +36,20 @@ class AvailableUpdateRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
-
     @Test
     fun getAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
-        `when`(availableUpdateDao.get()).thenReturn(
-            flowOf(
-                AvailableUpdateEntity(
-                    id = 0,
-                    tag = "v1.2.3",
-                    localFilePath = "/tmp/update.apk",
+        `when`(availableUpdateDao.get())
+            .thenReturn(
+                flowOf(
+                    AvailableUpdateEntity(
+                        id = 0,
+                        tag = "v1.2.3",
+                        localFilePath = "/tmp/update.apk",
+                    ),
                 ),
-            ),
-        )
-        val repository = AvailableUpdateRepositoryImpl(availableUpdateDao)
+            )
 
+        val repository = AvailableUpdateRepositoryImpl(availableUpdateDao)
         val result = repository.getAsFlow().value()
 
         assertEquals(
@@ -68,7 +63,9 @@ class AvailableUpdateRepositoryImplTest {
 
     @Test
     fun getAsFlow_returnsNull_whenDaoEmitsNull() = runTest(testDispatcher) {
-        `when`(availableUpdateDao.get()).thenReturn(flowOf(null))
+        `when`(availableUpdateDao.get())
+            .thenReturn(flowOf(null))
+
         val repository = AvailableUpdateRepositoryImpl(availableUpdateDao)
 
         assertNull(repository.getAsFlow().value())
@@ -84,24 +81,33 @@ class AvailableUpdateRepositoryImplTest {
 
         repository.save(update)
 
-        verify(availableUpdateDao).insertReplace(
-            AvailableUpdateEntity(
-                id = 0,
-                tag = "v2.0.0",
-                localFilePath = "/updates/update.apk",
-            ),
-        )
+        verify(availableUpdateDao)
+            .insertReplace(
+                AvailableUpdateEntity(
+                    id = 0,
+                    tag = "v2.0.0",
+                    localFilePath = "/updates/update.apk",
+                ),
+            )
     }
 
     @Test
     fun delete_returnsDaoDeleteCount() = runTest(testDispatcher) {
-        `when`(availableUpdateDao.delete()).thenReturn(1)
-        val repository = AvailableUpdateRepositoryImpl(availableUpdateDao)
+        `when`(availableUpdateDao.delete())
+            .thenReturn(1)
 
+        val repository = AvailableUpdateRepositoryImpl(availableUpdateDao)
         val result = repository.delete()
 
         assertEquals(1, result)
-        verify(availableUpdateDao).delete()
+        verify(availableUpdateDao)
+            .delete()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private suspend fun <T> kotlinx.coroutines.flow.Flow<T>.value(): T = first()

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
@@ -36,11 +36,6 @@ class DownloadAudioRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -51,7 +46,8 @@ class DownloadAudioRepositoryImplTest {
 
         val result = repository.save(sampleAudio())
         assertEquals(4L, result)
-        verify(downloadAudioDao).insertReplace(sampleEntity())
+        verify(downloadAudioDao)
+            .insertReplace(sampleEntity())
     }
 
     @Test
@@ -84,8 +80,16 @@ class DownloadAudioRepositoryImplTest {
         assertEquals(listOf("/tmp/audio.m4a"), repository.getAllFilePaths())
         assertEquals(1, repository.deleteByDownloadId(3L))
 
-        verify(downloadAudioDao).getAllFilePaths()
-        verify(downloadAudioDao).deleteByDownloadId(3L)
+        verify(downloadAudioDao)
+            .getAllFilePaths()
+        verify(downloadAudioDao)
+            .deleteByDownloadId(3L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun sampleAudio(downloadId: Long = 1L) = DownloadAudio(

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
@@ -36,11 +36,6 @@ class DownloadMetadataRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -51,7 +46,8 @@ class DownloadMetadataRepositoryImplTest {
         val result = repository.save(sampleMetadata())
 
         assertEquals(6L, result)
-        verify(downloadMetadataDao).insertReplace(sampleEntity())
+        verify(downloadMetadataDao)
+            .insertReplace(sampleEntity())
     }
 
     @Test
@@ -91,9 +87,18 @@ class DownloadMetadataRepositoryImplTest {
         assertEquals(listOf("/tmp/one.jpg", "/tmp/two.jpg"), repository.getAllThumbnailFilePaths())
         assertEquals(1, repository.deleteByDownloadId(2L))
 
-        verify(downloadMetadataDao).getDownloadIdsBySourceAndVideoId("youtube", "abc123")
-        verify(downloadMetadataDao).getAllThumbnailFilePaths()
-        verify(downloadMetadataDao).deleteByDownloadId(2L)
+        verify(downloadMetadataDao)
+            .getDownloadIdsBySourceAndVideoId("youtube", "abc123")
+        verify(downloadMetadataDao)
+            .getAllThumbnailFilePaths()
+        verify(downloadMetadataDao)
+            .deleteByDownloadId(2L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun sampleMetadata(downloadId: Long = 1L) = DownloadMetadata(

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
@@ -39,11 +39,6 @@ class DownloadProgressRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -56,7 +51,8 @@ class DownloadProgressRepositoryImplTest {
         val result = repository.save(progress)
 
         assertEquals(5L, result)
-        verify(downloadProgressDao).insertReplace(sampleEntity())
+        verify(downloadProgressDao)
+            .insertReplace(sampleEntity())
     }
 
     @Test
@@ -101,7 +97,14 @@ class DownloadProgressRepositoryImplTest {
         val result = repository.deleteByDownloadId(7L)
 
         assertEquals(1, result)
-        verify(downloadProgressDao).deleteByDownloadId(7L)
+        verify(downloadProgressDao)
+            .deleteByDownloadId(7L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun sampleDownloadProgress(downloadId: Long = 4L) = DownloadProgress(

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
@@ -40,11 +40,6 @@ class DownloadRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -69,17 +64,23 @@ class DownloadRepositoryImplTest {
         assertEquals(download.completedAtMillis, insertedEntity?.completedAtMillis)
         assertNull(insertedEntity?.startedAtMillis)
 
-        verify(downloadDao).insert(insertedEntity ?: error("Entity not captured"))
+        verify(downloadDao)
+            .insert(insertedEntity ?: error("Entity not captured"))
     }
 
     @Test
     fun getAll_mapsEntitiesToDomain() = runTest(testDispatcher) {
-        `when`(downloadDao.getAll()).thenReturn(
-            listOf(
-                sampleEntity(id = 1L, status = EntityStatus.DOWNLOADING),
-                sampleEntity(id = 2L, status = EntityStatus.COMPLETED, completedAtMillis = 300L),
-            ),
-        )
+        `when`(downloadDao.getAll())
+            .thenReturn(
+                listOf(
+                    sampleEntity(id = 1L, status = EntityStatus.DOWNLOADING),
+                    sampleEntity(
+                        id = 2L,
+                        status = EntityStatus.COMPLETED,
+                        completedAtMillis = 300L
+                    ),
+                ),
+            )
 
         val repository = DownloadRepositoryImpl(downloadDao)
         val result = repository.getAll()
@@ -138,14 +139,22 @@ class DownloadRepositoryImplTest {
 
     @Test
     fun updateMethods_delegateToDao() = runTest(testDispatcher) {
-        `when`(downloadDao.updateStatusById(3L, EntityStatus.STOPPED)).thenReturn(1)
-        `when`(downloadDao.updateErrorMessageById(3L, "boom")).thenReturn(1)
-        `when`(downloadDao.updateSeenByIds(setOf(3L, 4L), false)).thenReturn(2)
-        `when`(downloadDao.updatePendingDeleteByIds(setOf(3L, 4L), true)).thenReturn(2)
-        `when`(downloadDao.updateArchivedByIds(setOf(3L, 4L), true)).thenReturn(2)
-        `when`(downloadDao.updateStartedAtById(3L, 100L)).thenReturn(1)
-        `when`(downloadDao.updateCompletedAtById(3L, 200L)).thenReturn(1)
-        `when`(downloadDao.deleteById(3L)).thenReturn(1)
+        `when`(downloadDao.updateStatusById(3L, EntityStatus.STOPPED))
+            .thenReturn(1)
+        `when`(downloadDao.updateErrorMessageById(3L, "boom"))
+            .thenReturn(1)
+        `when`(downloadDao.updateSeenByIds(setOf(3L, 4L), false))
+            .thenReturn(2)
+        `when`(downloadDao.updatePendingDeleteByIds(setOf(3L, 4L), true))
+            .thenReturn(2)
+        `when`(downloadDao.updateArchivedByIds(setOf(3L, 4L), true))
+            .thenReturn(2)
+        `when`(downloadDao.updateStartedAtById(3L, 100L))
+            .thenReturn(1)
+        `when`(downloadDao.updateCompletedAtById(3L, 200L))
+            .thenReturn(1)
+        `when`(downloadDao.deleteById(3L))
+            .thenReturn(1)
 
         val repository = DownloadRepositoryImpl(downloadDao)
 
@@ -158,14 +167,28 @@ class DownloadRepositoryImplTest {
         assertEquals(1, repository.updateCompletedAtById(3L, 200L))
         assertEquals(1, repository.deleteById(3L))
 
-        verify(downloadDao).updateStatusById(3L, EntityStatus.STOPPED)
-        verify(downloadDao).updateErrorMessageById(3L, "boom")
-        verify(downloadDao).updateSeenByIds(setOf(3L, 4L), false)
-        verify(downloadDao).updatePendingDeleteByIds(setOf(3L, 4L), true)
-        verify(downloadDao).updateArchivedByIds(setOf(3L, 4L), true)
-        verify(downloadDao).updateStartedAtById(3L, 100L)
-        verify(downloadDao).updateCompletedAtById(3L, 200L)
-        verify(downloadDao).deleteById(3L)
+        verify(downloadDao)
+            .updateStatusById(3L, EntityStatus.STOPPED)
+        verify(downloadDao)
+            .updateErrorMessageById(3L, "boom")
+        verify(downloadDao)
+            .updateSeenByIds(setOf(3L, 4L), false)
+        verify(downloadDao)
+            .updatePendingDeleteByIds(setOf(3L, 4L), true)
+        verify(downloadDao)
+            .updateArchivedByIds(setOf(3L, 4L), true)
+        verify(downloadDao)
+            .updateStartedAtById(3L, 100L)
+        verify(downloadDao)
+            .updateCompletedAtById(3L, 200L)
+        verify(downloadDao)
+            .deleteById(3L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun sampleDownload(

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
@@ -36,11 +36,6 @@ class DownloadVideoRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -51,7 +46,8 @@ class DownloadVideoRepositoryImplTest {
         val result = repository.save(sampleVideo())
         assertEquals(5L, result)
 
-        verify(downloadVideoDao).insertReplace(sampleEntity())
+        verify(downloadVideoDao)
+            .insertReplace(sampleEntity())
     }
 
     @Test
@@ -76,18 +72,30 @@ class DownloadVideoRepositoryImplTest {
 
     @Test
     fun queryMethods_delegateToDao() = runTest(testDispatcher) {
-        `when`(downloadVideoDao.getDownloadIdsBySha256("sha")).thenReturn(listOf(2L, 8L))
-        `when`(downloadVideoDao.getAllFilePaths()).thenReturn(listOf("/tmp/video.mp4"))
-        `when`(downloadVideoDao.deleteByDownloadId(3L)).thenReturn(1)
+        `when`(downloadVideoDao.getDownloadIdsBySha256("sha"))
+            .thenReturn(listOf(2L, 8L))
+        `when`(downloadVideoDao.getAllFilePaths())
+            .thenReturn(listOf("/tmp/video.mp4"))
+        `when`(downloadVideoDao.deleteByDownloadId(3L))
+            .thenReturn(1)
         val repository = DownloadVideoRepositoryImpl(downloadVideoDao)
 
         assertEquals(listOf(2L, 8L), repository.getDownloadIdsBySha256("sha"))
         assertEquals(listOf("/tmp/video.mp4"), repository.getAllFilePaths())
         assertEquals(1, repository.deleteByDownloadId(3L))
 
-        verify(downloadVideoDao).getDownloadIdsBySha256("sha")
-        verify(downloadVideoDao).getAllFilePaths()
-        verify(downloadVideoDao).deleteByDownloadId(3L)
+        verify(downloadVideoDao)
+            .getDownloadIdsBySha256("sha")
+        verify(downloadVideoDao)
+            .getAllFilePaths()
+        verify(downloadVideoDao)
+            .deleteByDownloadId(3L)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun sampleVideo(downloadId: Long = 1L) = DownloadVideo(

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
@@ -36,27 +36,23 @@ class DownloadWithMetadataRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun getDownloadsWithMetadataAsFlow_mapsViewsToDomain() = runTest(testDispatcher) {
-        `when`(downloadWithMetadataViewDao.getDownloadsAsFlow()).thenReturn(
-            flowOf(
-                listOf(
-                    sampleView(id = 1L, status = EntityStatus.DOWNLOADING),
-                    sampleView(
-                        id = 2L,
-                        status = EntityStatus.COMPLETED,
-                        completedAtMillis = 88L,
-                        pendingDelete = true,
+        `when`(downloadWithMetadataViewDao.getDownloadsAsFlow())
+            .thenReturn(
+                flowOf(
+                    listOf(
+                        sampleView(id = 1L, status = EntityStatus.DOWNLOADING),
+                        sampleView(
+                            id = 2L,
+                            status = EntityStatus.COMPLETED,
+                            completedAtMillis = 88L,
+                            pendingDelete = true,
+                        ),
                     ),
                 ),
-            ),
-        )
+            )
 
         val repository = DownloadWithMetadataRepositoryImpl(downloadWithMetadataViewDao)
         val result = repository.getDownloadsWithMetadataAsFlow().first()
@@ -72,6 +68,12 @@ class DownloadWithMetadataRepositoryImplTest {
             ),
             result,
         )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun sampleView(

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
@@ -29,10 +29,6 @@ class SettingsRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
 
     @Test
     fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {
@@ -69,6 +65,11 @@ class SettingsRepositoryImplTest {
         assertEquals(false, repository.getAutomaticUpdatesAsFlow().first())
         assertEquals(false, repository.getAutomaticDependencyUpdatesAsFlow().first())
         assertEquals(false, repository.getAutomaticDuplicateDownloadDeletionAsFlow().first())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     private fun createRepository(scope: CoroutineScope): SettingsRepositoryImpl {

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
@@ -28,10 +28,6 @@ class StateRepositoryImplTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
 
     @Test
     fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {
@@ -62,6 +58,11 @@ class StateRepositoryImplTest {
         assertEquals(123L, repository.getBootTimeMillisAsFlow().first())
         assertEquals(456L, repository.getLastAvailableUpdateCheckMillisAsFlow().first())
         assertEquals(789L, repository.getLastDependencyUpdateCheckMillisAsFlow().first())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     private fun createRepository(scope: CoroutineScope): StateRepositoryImpl {

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCaseTest.kt
@@ -1,0 +1,173 @@
+package org.strigate.ferrot.domain.usecase.apply
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.integration.DownloadWorkScheduler
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.download.DeleteDownloadFilesUseCase
+import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
+import org.strigate.ferrot.domain.usecase.download.UpdateDownloadErrorMessageUseCase
+import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ApplyWifiOnlyPolicyUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var connectivityManager: ConnectivityManager
+
+    @Mock
+    private lateinit var network: Network
+
+    @Mock
+    private lateinit var networkCapabilities: NetworkCapabilities
+
+    @Mock
+    private lateinit var downloadWorkScheduler: DownloadWorkScheduler
+
+    @Mock
+    private lateinit var getAllDownloadsUseCase: GetAllDownloadsUseCase
+
+    @Mock
+    private lateinit var updateDownloadErrorMessageUseCase: UpdateDownloadErrorMessageUseCase
+
+    @Mock
+    private lateinit var updateDownloadStatusUseCase: UpdateDownloadStatusUseCase
+
+    @Mock
+    private lateinit var deleteDownloadFilesUseCase: DeleteDownloadFilesUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+
+        `when`(appContext.getSystemService(Context.CONNECTIVITY_SERVICE))
+            .thenReturn(connectivityManager)
+    }
+
+    @Test
+    fun invoke_movesActiveToWaitingForWifi_whenOffWifi() = runTest(testDispatcher) {
+        val queued = sampleDownload(41L, DownloadStatus.QUEUED)
+        val downloading = sampleDownload(42L, DownloadStatus.DOWNLOADING)
+        val completed = sampleDownload(43L, DownloadStatus.COMPLETED)
+
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(listOf(queued, downloading, completed))
+
+        stubQuickNetworkProbe(isOnline = true, onWifi = false)
+        createUseCase().invoke(true)
+
+        verify(updateDownloadStatusUseCase)
+            .invoke(41L, DownloadStatus.WAITING_FOR_WIFI)
+        verify(updateDownloadStatusUseCase)
+            .invoke(42L, DownloadStatus.WAITING_FOR_WIFI)
+        verify(updateDownloadErrorMessageUseCase)
+            .invoke(41L, null)
+        verify(updateDownloadErrorMessageUseCase)
+            .invoke(42L, null)
+        verify(deleteDownloadFilesUseCase)
+            .invoke(41L)
+        verify(deleteDownloadFilesUseCase)
+            .invoke(42L)
+        verify(updateDownloadStatusUseCase, never())
+            .invoke(43L, DownloadStatus.WAITING_FOR_WIFI)
+        verify(downloadWorkScheduler)
+            .enqueueOneTimeReplace(41L, true)
+        verify(downloadWorkScheduler)
+            .enqueueOneTimeReplace(42L, true)
+    }
+
+    @Test
+    fun invoke_doesNothing_whenWifiOnlyEnabledOnWifi() = runTest(testDispatcher) {
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(listOf(sampleDownload(44L, DownloadStatus.QUEUED)))
+
+        stubQuickNetworkProbe(isOnline = true, onWifi = true)
+        createUseCase().invoke(true)
+
+        verify(updateDownloadStatusUseCase, never())
+            .invoke(44L, DownloadStatus.WAITING_FOR_WIFI)
+        verify(downloadWorkScheduler, never())
+            .enqueueOneTimeReplace(44L, true)
+    }
+
+    @Test
+    fun invoke_movesWaitingForWifiToNetwork_whenWifiOnlyOff() = runTest(testDispatcher) {
+        val waiting = sampleDownload(45L, DownloadStatus.WAITING_FOR_WIFI)
+        val queued = sampleDownload(46L, DownloadStatus.QUEUED)
+
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(listOf(waiting, queued))
+
+        stubQuickNetworkProbe(isOnline = true, onWifi = false)
+        createUseCase().invoke(false)
+
+        verify(updateDownloadErrorMessageUseCase)
+            .invoke(45L, null)
+        verify(updateDownloadStatusUseCase)
+            .invoke(45L, DownloadStatus.WAITING_FOR_NETWORK)
+        verify(updateDownloadStatusUseCase, never())
+            .invoke(46L, DownloadStatus.WAITING_FOR_NETWORK)
+        verify(downloadWorkScheduler)
+            .enqueueOneTimeReplace(45L, false)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    private fun stubQuickNetworkProbe(isOnline: Boolean, onWifi: Boolean) {
+        `when`(connectivityManager.activeNetwork)
+            .thenReturn(network)
+        `when`(connectivityManager.getNetworkCapabilities(network))
+            .thenReturn(networkCapabilities)
+        `when`(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED))
+            .thenReturn(isOnline)
+        `when`(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET))
+            .thenReturn(isOnline)
+        `when`(networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI))
+            .thenReturn(onWifi)
+    }
+
+    private fun createUseCase() = ApplyWifiOnlyPolicyUseCase(
+        appContext = appContext,
+        getAllDownloadsUseCase = getAllDownloadsUseCase,
+        updateDownloadErrorMessageUseCase = updateDownloadErrorMessageUseCase,
+        updateDownloadStatusUseCase = updateDownloadStatusUseCase,
+        deleteDownloadFilesUseCase = deleteDownloadFilesUseCase,
+        downloadWorkScheduler = downloadWorkScheduler,
+    )
+
+    private fun sampleDownload(id: Long, status: DownloadStatus) = Download(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/$id",
+        status = status,
+        seen = false,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/availableupdate/ClearAvailableUpdateFilesAndDataUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/availableupdate/ClearAvailableUpdateFilesAndDataUseCaseTest.kt
@@ -1,0 +1,103 @@
+package org.strigate.ferrot.domain.usecase.availableupdate
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.provider.UpdatePathProvider
+import org.strigate.ferrot.domain.repository.AvailableUpdateRepository
+import java.io.File
+import java.nio.file.Files
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClearAvailableUpdateFilesAndDataUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var availableUpdateRepository: AvailableUpdateRepository
+
+    @Mock
+    private lateinit var updatePathProvider: UpdatePathProvider
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @Test
+    fun invoke_returnsTrue_whenDatabaseDeleteSucceeds() = runTest(testDispatcher) {
+        val updatesDir = File(
+            Files.createTempDirectory("clear-update-db-success").toFile(), "missing",
+        )
+        `when`(availableUpdateRepository.delete())
+            .thenReturn(1)
+        `when`(updatePathProvider.updatesDir())
+            .thenReturn(updatesDir)
+
+        val result = createUseCase().invoke()
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun invoke_returnsTrue_whenFilesDeleteSucceeds() = runTest(testDispatcher) {
+        val updatesDir = Files.createTempDirectory("clear-update-files-success").toFile()
+            .apply {
+                resolve("update.apk").writeText("apk")
+            }
+
+        `when`(availableUpdateRepository.delete())
+            .thenReturn(0)
+        `when`(updatePathProvider.updatesDir())
+            .thenReturn(updatesDir)
+
+        val result = createUseCase().invoke()
+
+        assertTrue(result)
+        assertFalse(updatesDir.exists())
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenDatabaseAndFileDeleteFail() = runTest(testDispatcher) {
+        val parentDir = Files.createTempDirectory("clear-update-fail").toFile()
+        val updatesDir = object : File(parentDir, "updates") {
+            override fun exists(): Boolean = true
+            override fun isDirectory(): Boolean = true
+            override fun listFiles(): Array<File> = emptyArray()
+            override fun delete(): Boolean = false
+        }
+
+        `when`(availableUpdateRepository.delete())
+            .thenReturn(0)
+        `when`(updatePathProvider.updatesDir())
+            .thenReturn(updatesDir)
+
+        val result = createUseCase().invoke()
+
+        assertFalse(result)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    private fun createUseCase() = ClearAvailableUpdateFilesAndDataUseCase(
+        availableUpdateRepository = availableUpdateRepository,
+        updatePathProvider = updatePathProvider,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
@@ -1,0 +1,196 @@
+package org.strigate.ferrot.domain.usecase.combined
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.InOrder
+import org.mockito.Mock
+import org.mockito.Mockito.inOrder
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.domain.usecase.DownloadAudioUseCase
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.download.DeleteDownloadByIdUseCase
+import org.strigate.ferrot.domain.usecase.download.DeleteDownloadFilesUseCase
+import org.strigate.ferrot.domain.usecase.downloadaudio.DeleteDownloadAudioUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.DeleteDownloadMetadataByDownloadIdUseCase
+import org.strigate.ferrot.domain.usecase.downloadprogress.DeleteDownloadProgressByDownloadIdUseCase
+import org.strigate.ferrot.domain.usecase.downloadvideo.DeleteDownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeleteDownloadAndRelatedCombinedUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var downloadAudioUseCase: DownloadAudioUseCase
+
+    @Mock
+    private lateinit var downloadVideoUseCase: DownloadVideoUseCase
+
+    @Mock
+    private lateinit var downloadProgressUseCase: DownloadProgressUseCase
+
+    @Mock
+    private lateinit var downloadMetadataUseCase: DownloadMetadataUseCase
+
+    @Mock
+    private lateinit var clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase
+
+    @Mock
+    private lateinit var deleteDownloadFilesUseCase: DeleteDownloadFilesUseCase
+
+    @Mock
+    private lateinit var deleteDownloadMetadataByDownloadIdUseCase: DeleteDownloadMetadataByDownloadIdUseCase
+
+    @Mock
+    private lateinit var deleteDownloadProgressByDownloadIdUseCase: DeleteDownloadProgressByDownloadIdUseCase
+
+    @Mock
+    private lateinit var deleteDownloadAudioUseCase: DeleteDownloadAudioUseCase
+
+    @Mock
+    private lateinit var deleteDownloadVideoUseCase: DeleteDownloadVideoUseCase
+
+    @Mock
+    private lateinit var deleteDownloadByIdUseCase: DeleteDownloadByIdUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+
+        `when`(downloadUseCase.deleteDownloadFilesUseCase)
+            .thenReturn(deleteDownloadFilesUseCase)
+        `when`(downloadUseCase.deleteDownloadByIdUseCase)
+            .thenReturn(deleteDownloadByIdUseCase)
+        `when`(downloadMetadataUseCase.deleteDownloadMetadataByDownloadIdUseCase)
+            .thenReturn(deleteDownloadMetadataByDownloadIdUseCase)
+        `when`(downloadProgressUseCase.deleteDownloadProgressByDownloadIdUseCase)
+            .thenReturn(deleteDownloadProgressByDownloadIdUseCase)
+        `when`(downloadAudioUseCase.deleteDownloadAudioUseCase)
+            .thenReturn(deleteDownloadAudioUseCase)
+        `when`(downloadVideoUseCase.deleteDownloadVideoUseCase)
+            .thenReturn(deleteDownloadVideoUseCase)
+    }
+
+    @Test
+    fun invoke_returnsTrue_whenAllDeletesSucceed() = runTest(testDispatcher) {
+        stubDeletes(
+            files = true,
+            metadata = true,
+            progress = true,
+            audio = true,
+            video = true,
+            download = true,
+        )
+
+        val result = createUseCase().invoke(31L)
+
+        assertTrue(result)
+        verifyDeleteSequence(31L)
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenAnyDeleteFails() = runTest(testDispatcher) {
+        stubDeletes(
+            files = true,
+            metadata = false,
+            progress = true,
+            audio = true,
+            video = true,
+            download = true
+        )
+
+        val result = createUseCase().invoke(32L)
+
+        assertFalse(result)
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(32L)
+        verify(deleteDownloadByIdUseCase)
+            .invoke(32L)
+    }
+
+    private suspend fun stubDeletes(
+        files: Boolean,
+        metadata: Boolean,
+        progress: Boolean,
+        audio: Boolean,
+        video: Boolean,
+        download: Boolean,
+    ) {
+        `when`(deleteDownloadFilesUseCase.invoke(anyLong()))
+            .thenReturn(files)
+        `when`(deleteDownloadMetadataByDownloadIdUseCase.invoke(anyLong()))
+            .thenReturn(metadata)
+        `when`(deleteDownloadProgressByDownloadIdUseCase.invoke(anyLong()))
+            .thenReturn(progress)
+        `when`(deleteDownloadAudioUseCase.invoke(anyLong()))
+            .thenReturn(audio)
+        `when`(deleteDownloadVideoUseCase.invoke(anyLong()))
+            .thenReturn(video)
+        `when`(deleteDownloadByIdUseCase.invoke(anyLong()))
+            .thenReturn(download)
+    }
+
+    private suspend fun verifyDeleteSequence(downloadId: Long) {
+        val inOrder: InOrder = inOrder(
+            clearNotificationsByDownloadIdUseCase,
+            deleteDownloadFilesUseCase,
+            deleteDownloadMetadataByDownloadIdUseCase,
+            deleteDownloadProgressByDownloadIdUseCase,
+            deleteDownloadAudioUseCase,
+            deleteDownloadVideoUseCase,
+            deleteDownloadByIdUseCase,
+        )
+
+        inOrder.verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(downloadId)
+        inOrder.verify(deleteDownloadFilesUseCase)
+            .invoke(downloadId)
+        inOrder.verify(deleteDownloadMetadataByDownloadIdUseCase)
+            .invoke(downloadId)
+        inOrder.verify(deleteDownloadProgressByDownloadIdUseCase)
+            .invoke(downloadId)
+        inOrder.verify(deleteDownloadAudioUseCase)
+            .invoke(downloadId)
+        inOrder.verify(deleteDownloadVideoUseCase)
+            .invoke(downloadId)
+        inOrder.verify(deleteDownloadByIdUseCase)
+            .invoke(downloadId)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    private fun createUseCase() = DeleteDownloadAndRelatedCombinedUseCase(
+        downloadUseCase = downloadUseCase,
+        downloadAudioUseCase = downloadAudioUseCase,
+        downloadVideoUseCase = downloadVideoUseCase,
+        downloadProgressUseCase = downloadProgressUseCase,
+        downloadMetadataUseCase = downloadMetadataUseCase,
+        clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
+    )
+
+    private fun anyLong(): Long = org.mockito.Mockito.anyLong()
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetPendingDownloadsCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetPendingDownloadsCombinedUseCaseTest.kt
@@ -1,0 +1,87 @@
+package org.strigate.ferrot.domain.usecase.combined
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetPendingDownloadsCombinedUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var getAllDownloadsUseCase: GetAllDownloadsUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+        `when`(downloadUseCase.getAllDownloadsUseCase)
+            .thenReturn(getAllDownloadsUseCase)
+    }
+
+    @Test
+    fun invoke_returnsOnlyRequeueableDownloads() = runTest(testDispatcher) {
+        val downloads = listOf(
+            sampleDownload(1L, DownloadStatus.QUEUED),
+            sampleDownload(2L, DownloadStatus.WAITING_FOR_NETWORK),
+            sampleDownload(3L, DownloadStatus.WAITING_FOR_WIFI),
+            sampleDownload(4L, DownloadStatus.PAUSED),
+            sampleDownload(5L, DownloadStatus.METADATA),
+            sampleDownload(6L, DownloadStatus.DOWNLOADING),
+            sampleDownload(7L, DownloadStatus.COMPLETED),
+            sampleDownload(8L, DownloadStatus.FAILED),
+            sampleDownload(9L, DownloadStatus.STOPPED),
+        )
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(downloads)
+
+        val result = createUseCase().invoke()
+
+        assertEquals(
+            listOf(
+                sampleDownload(1L, DownloadStatus.QUEUED),
+                sampleDownload(2L, DownloadStatus.WAITING_FOR_NETWORK),
+                sampleDownload(3L, DownloadStatus.WAITING_FOR_WIFI),
+                sampleDownload(4L, DownloadStatus.PAUSED),
+            ),
+            result,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    private fun createUseCase() = GetPendingDownloadsCombinedUseCase(
+        downloadUseCase = downloadUseCase,
+    )
+
+    private fun sampleDownload(id: Long, status: DownloadStatus) = Download(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/$id",
+        status = status,
+        seen = false,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCaseTest.kt
@@ -1,0 +1,333 @@
+package org.strigate.ferrot.domain.usecase.combined
+
+import android.util.Log
+import com.yausername.youtubedl_android.mapper.VideoInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.provider.DownloadPathProvider
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadMetadata
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
+import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadMetadataByIdAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.SaveDownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.youtubedl_android.DownloadThumbnailUseCase
+import org.strigate.ferrot.domain.usecase.youtubedl_android.GetVideoInfoUseCase
+import java.io.File
+import java.nio.file.Files
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RefreshDownloadMetadataCombinedUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    private var logMock: MockedStatic<Log>? = null
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var downloadMetadataUseCase: DownloadMetadataUseCase
+
+    @Mock
+    private lateinit var youtubeDlAndroidUseCase: YoutubeDlAndroidUseCase
+
+    @Mock
+    private lateinit var downloadPathProvider: DownloadPathProvider
+
+    @Mock
+    private lateinit var getDownloadByIdUseCase: GetDownloadByIdUseCase
+
+    @Mock
+    private lateinit var getDownloadMetadataByIdAsFlowUseCase: GetDownloadMetadataByIdAsFlowUseCase
+
+    @Mock
+    private lateinit var saveDownloadMetadataUseCase: SaveDownloadMetadataUseCase
+
+    @Mock
+    private lateinit var getVideoInfoUseCase: GetVideoInfoUseCase
+
+    @Mock
+    private lateinit var downloadThumbnailUseCase: DownloadThumbnailUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        logMock = mockStatic(Log::class.java)
+        Dispatchers.setMain(testDispatcher)
+
+        `when`(downloadUseCase.getDownloadByIdUseCase)
+            .thenReturn(getDownloadByIdUseCase)
+        `when`(downloadMetadataUseCase.getDownloadMetadataByIdAsFlowUseCase)
+            .thenReturn(getDownloadMetadataByIdAsFlowUseCase)
+        `when`(downloadMetadataUseCase.saveDownloadMetadataUseCase)
+            .thenReturn(saveDownloadMetadataUseCase)
+        `when`(youtubeDlAndroidUseCase.getVideoInfoUseCase)
+            .thenReturn(getVideoInfoUseCase)
+        `when`(youtubeDlAndroidUseCase.downloadThumbnailUseCase)
+            .thenReturn(downloadThumbnailUseCase)
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenDownloadMissing() = runTest(testDispatcher) {
+        `when`(getDownloadByIdUseCase.invoke(42L))
+            .thenReturn(null)
+
+        val useCase = createUseCase()
+        val result = useCase(42L)
+
+        assertFalse(result)
+        verify(saveDownloadMetadataUseCase, never())
+            .invoke(anyObject())
+    }
+
+    @Test
+    fun invoke_savesMergedMetadata_whenRefreshSucceeds() = runTest(testDispatcher) {
+        val download = sampleDownload()
+        val outputDir = Files.createTempDirectory("refresh-meta-success").toFile()
+        val videoInfo = videoInfo(
+            id = "video-1",
+            title = "Fresh title",
+            extractorKey = "YouTube",
+            duration = 321,
+        )
+        var savedMetadata: DownloadMetadata? = null
+
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(download.id))
+            .thenReturn(flowOf(sampleMetadata()))
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(outputDir)
+        `when`(getVideoInfoUseCase.invoke(download.url))
+            .thenReturn(videoInfo)
+        `when`(
+            downloadThumbnailUseCase.invoke(
+                url = download.url,
+                outputDir = outputDir,
+                videoId = "video-1",
+            ),
+        )
+            .thenReturn("/tmp/new-thumb.jpg")
+
+        doAnswer { invocation ->
+            savedMetadata = invocation.getArgument(0)
+            Unit
+        }.`when`(saveDownloadMetadataUseCase).invoke(anyObject())
+
+        val result = createUseCase()(download.id)
+
+        assertTrue(result)
+        assertEquals(
+            DownloadMetadata(
+                downloadId = download.id,
+                videoId = "video-1",
+                source = "youtube",
+                title = "Fresh title",
+                thumbnailFilePath = "/tmp/new-thumb.jpg",
+                durationSeconds = 321,
+            ),
+            savedMetadata,
+        )
+    }
+
+    @Test
+    fun invoke_usesExistingThumbnail_whenRefreshFails() = runTest(testDispatcher) {
+        val download = sampleDownload(id = 8L)
+        val outputDir = Files.createTempDirectory("refresh-meta-thumb-fallback").toFile()
+        val existingThumbnail = File(outputDir, "existing-thumb.jpg").apply {
+            writeText("thumb")
+        }
+        val existingMetadata = sampleMetadata(
+            downloadId = download.id,
+            videoId = "old-id",
+            source = "vimeo",
+            title = "Old title",
+            thumbnailFilePath = existingThumbnail.absolutePath,
+            durationSeconds = 90,
+        )
+        var savedMetadata: DownloadMetadata? = null
+
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(download.id))
+            .thenReturn(flowOf(existingMetadata))
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(outputDir)
+        `when`(getVideoInfoUseCase.invoke(download.url))
+            .thenThrow(RuntimeException("metadata unavailable"))
+
+        `when`(
+            downloadThumbnailUseCase.invoke(
+                url = download.url,
+                outputDir = outputDir,
+                videoId = "old-id",
+            ),
+        ).thenThrow(RuntimeException("thumbnail unavailable"))
+
+        doAnswer { invocation ->
+            savedMetadata = invocation.getArgument(0)
+            Unit
+        }.`when`(saveDownloadMetadataUseCase).invoke(anyObject())
+
+        val result = createUseCase()(download.id)
+        assertTrue(result)
+        assertEquals(existingMetadata, savedMetadata)
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenNothingRecovered() = runTest(testDispatcher) {
+        val download = sampleDownload(id = 12L)
+        val outputDir = Files.createTempDirectory("refresh-meta-empty").toFile()
+
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(download.id))
+            .thenReturn(flowOf(null))
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(outputDir)
+        `when`(getVideoInfoUseCase.invoke(download.url))
+            .thenThrow(RuntimeException("metadata unavailable"))
+
+        `when`(
+            downloadThumbnailUseCase.invoke(
+                url = download.url,
+                outputDir = outputDir,
+                videoId = null,
+            ),
+        ).thenThrow(RuntimeException("thumbnail unavailable"))
+
+        val result = createUseCase()(download.id)
+        assertFalse(result)
+        verify(saveDownloadMetadataUseCase, never())
+            .invoke(anyObject())
+    }
+
+    @Test
+    fun invoke_keepsExistingDuration_whenFetchedDurationInvalid() = runTest(testDispatcher) {
+        val download = sampleDownload(id = 15L)
+        val outputDir = Files.createTempDirectory("refresh-meta-duration").toFile()
+        val existingMetadata = sampleMetadata(
+            downloadId = download.id,
+            durationSeconds = 444,
+        )
+        val videoInfo = videoInfo(
+            id = "video-15",
+            title = "New title",
+            extractorKey = "YouTube",
+            duration = 0,
+        )
+        var savedMetadata: DownloadMetadata? = null
+
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(download.id))
+            .thenReturn(flowOf(existingMetadata))
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(outputDir)
+        `when`(getVideoInfoUseCase.invoke(download.url))
+            .thenReturn(videoInfo)
+
+        `when`(
+            downloadThumbnailUseCase.invoke(
+                url = download.url,
+                outputDir = outputDir,
+                videoId = "video-15",
+            ),
+        )
+            .thenReturn("/tmp/thumb-15.jpg")
+
+        doAnswer { invocation ->
+            savedMetadata = invocation.getArgument(0)
+            Unit
+        }.`when`(saveDownloadMetadataUseCase).invoke(anyObject())
+
+        val result = createUseCase()(download.id)
+        assertTrue(result)
+        assertEquals(444, savedMetadata?.durationSeconds)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        logMock?.close()
+        logMock = null
+        autoCloseable.close()
+    }
+
+    private fun createUseCase() = RefreshDownloadMetadataCombinedUseCase(
+        downloadUseCase = downloadUseCase,
+        downloadMetadataUseCase = downloadMetadataUseCase,
+        youtubeDlAndroidUseCase = youtubeDlAndroidUseCase,
+        downloadPathProvider = downloadPathProvider,
+    )
+
+    private fun sampleDownload(id: Long = 7L) = Download(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/watch/$id",
+        status = DownloadStatus.QUEUED,
+        seen = false,
+    )
+
+    private fun sampleMetadata(
+        downloadId: Long = 7L,
+        videoId: String? = "existing-id",
+        source: String? = "youtube",
+        title: String? = "Existing title",
+        thumbnailFilePath: String? = "/tmp/existing.jpg",
+        durationSeconds: Int? = 111,
+    ) = DownloadMetadata(
+        downloadId = downloadId,
+        videoId = videoId,
+        source = source,
+        title = title,
+        thumbnailFilePath = thumbnailFilePath,
+        durationSeconds = durationSeconds,
+    )
+
+    private fun videoInfo(
+        id: String?,
+        title: String?,
+        extractorKey: String?,
+        duration: Int,
+    ): VideoInfo {
+        return VideoInfo().apply {
+            setField("id", id)
+            setField("title", title)
+            setField("extractorKey", extractorKey)
+            setField("duration", duration)
+        }
+    }
+
+    private fun VideoInfo.setField(name: String, value: Any?) {
+        val field = VideoInfo::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(this, value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> anyObject(): T = org.mockito.Mockito.any<T>() ?: null as T
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/DeleteDownloadFilesUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/DeleteDownloadFilesUseCaseTest.kt
@@ -1,0 +1,127 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.provider.DownloadPathProvider
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadStatus
+import java.io.File
+import java.nio.file.Files
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeleteDownloadFilesUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    private var logMock: MockedStatic<Log>? = null
+
+    @Mock
+    private lateinit var downloadPathProvider: DownloadPathProvider
+
+    @Mock
+    private lateinit var getDownloadByIdUseCase: GetDownloadByIdUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        logMock = mockStatic(Log::class.java)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenDownloadMissing() = runTest(testDispatcher) {
+        `when`(getDownloadByIdUseCase.invoke(21L))
+            .thenReturn(null)
+
+        val result = createUseCase().invoke(21L)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun invoke_returnsTrue_whenUidDirMissing() = runTest(testDispatcher) {
+        val download = sampleDownload(22L)
+        val missingDir = File(Files.createTempDirectory("delete-files-missing").toFile(), "nope")
+
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(missingDir)
+
+        val result = createUseCase().invoke(download.id)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun invoke_returnsTrue_whenUidDirDeleted() = runTest(testDispatcher) {
+        val download = sampleDownload(23L)
+        val uidDir = Files.createTempDirectory("delete-files-success").toFile().apply {
+            resolve("file.txt").writeText("content")
+        }
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(uidDir)
+
+        val result = createUseCase().invoke(download.id)
+
+        assertTrue(result)
+        assertFalse(uidDir.exists())
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenDeletionFails() = runTest(testDispatcher) {
+        val download = sampleDownload(24L)
+        val parentDir = Files.createTempDirectory("delete-files-failure").toFile()
+        val uidDir = object : File(parentDir, "uid-${download.id}") {
+            override fun exists(): Boolean = true
+            override fun isDirectory(): Boolean = true
+            override fun listFiles(): Array<File> = emptyArray()
+            override fun delete(): Boolean = false
+        }
+        `when`(getDownloadByIdUseCase.invoke(download.id))
+            .thenReturn(download)
+        `when`(downloadPathProvider.uidDir(download.uid))
+            .thenReturn(uidDir)
+
+        val result = createUseCase().invoke(download.id)
+
+        assertFalse(result)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        logMock?.close()
+        autoCloseable.close()
+    }
+
+    private fun createUseCase() = DeleteDownloadFilesUseCase(
+        downloadPathProvider = downloadPathProvider,
+        getDownloadByIdUseCase = getDownloadByIdUseCase,
+    )
+
+    private fun sampleDownload(id: Long) = Download(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/$id",
+        status = DownloadStatus.QUEUED,
+        seen = false,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCaseTest.kt
@@ -1,0 +1,169 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.integration.DownloadWorkScheduler
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsFlowUseCase
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StartDownloadUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    private var logMock: MockedStatic<Log>? = null
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var connectivityManager: ConnectivityManager
+
+    @Mock
+    private lateinit var network: Network
+
+    @Mock
+    private lateinit var networkCapabilities: NetworkCapabilities
+
+    @Mock
+    private lateinit var downloadWorkScheduler: DownloadWorkScheduler
+
+    @Mock
+    private lateinit var settingsUseCase: SettingsUseCase
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase
+
+    @Mock
+    private lateinit var getDownloadWifiOnlySettingAsFlowUseCase: GetDownloadWifiOnlySettingAsFlowUseCase
+
+    @Mock
+    private lateinit var updateDownloadStatusUseCase: UpdateDownloadStatusUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        logMock = mockStatic(Log::class.java)
+        Dispatchers.setMain(testDispatcher)
+
+        `when`(settingsUseCase.getDownloadWifiOnlySettingAsFlowUseCase)
+            .thenReturn(getDownloadWifiOnlySettingAsFlowUseCase)
+        `when`(downloadUseCase.updateDownloadStatusUseCase)
+            .thenReturn(updateDownloadStatusUseCase)
+        `when`(appContext.getSystemService(Context.CONNECTIVITY_SERVICE))
+            .thenReturn(connectivityManager)
+    }
+
+    @Test
+    fun invoke_setsWaitingForNetwork_whenOffline() = runTest(testDispatcher) {
+        stubWifiOnly(enabled = false)
+        stubNetwork(hasInternet = false, onWifi = false)
+
+        createUseCase().invoke(11L)
+
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(11L)
+        verify(updateDownloadStatusUseCase)
+            .invoke(
+                downloadId = 11L,
+                status = DownloadStatus.WAITING_FOR_NETWORK,
+            )
+        verify(downloadWorkScheduler)
+            .enqueueOneTimeReplace(11L, false)
+    }
+
+    @Test
+    fun invoke_setsWaitingForWifi_whenWifiOnlyAndNotOnWifi() = runTest(testDispatcher) {
+        stubWifiOnly(enabled = true)
+        stubNetwork(hasInternet = true, onWifi = false)
+
+        createUseCase().invoke(12L)
+
+        verify(updateDownloadStatusUseCase)
+            .invoke(
+                downloadId = 12L,
+                status = DownloadStatus.WAITING_FOR_WIFI,
+            )
+        verify(downloadWorkScheduler)
+            .enqueueOneTimeReplace(12L, true)
+    }
+
+    @Test
+    fun invoke_setsQueued_whenDownloadCanStart() = runTest(testDispatcher) {
+        stubWifiOnly(enabled = true)
+        stubNetwork(hasInternet = true, onWifi = true)
+
+        createUseCase().invoke(13L)
+
+        verify(updateDownloadStatusUseCase)
+            .invoke(
+                downloadId = 13L,
+                status = DownloadStatus.QUEUED,
+            )
+        verify(downloadWorkScheduler)
+            .enqueueOneTimeReplace(13L, true)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        logMock?.close()
+        autoCloseable.close()
+    }
+
+    private fun stubWifiOnly(enabled: Boolean) {
+        `when`(getDownloadWifiOnlySettingAsFlowUseCase.invoke())
+            .thenReturn(flowOf(enabled))
+    }
+
+    private fun stubNetwork(hasInternet: Boolean, onWifi: Boolean) {
+        `when`(connectivityManager.activeNetwork)
+            .thenReturn(network)
+        `when`(connectivityManager.getNetworkCapabilities(network))
+            .thenReturn(networkCapabilities)
+        `when`(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED))
+            .thenReturn(hasInternet)
+        `when`(networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET))
+            .thenReturn(hasInternet)
+        `when`(networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI))
+            .thenReturn(onWifi)
+        if (!hasInternet) {
+            @Suppress("DEPRECATION")
+            `when`(connectivityManager.allNetworks)
+                .thenReturn(emptyArray())
+        }
+    }
+
+    private fun createUseCase() = StartDownloadUseCase(
+        appContext = appContext,
+        settingsUseCase = settingsUseCase,
+        downloadUseCase = downloadUseCase,
+        clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
+        downloadWorkScheduler = downloadWorkScheduler,
+    )
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCaseTest.kt
@@ -1,0 +1,85 @@
+package org.strigate.ferrot.domain.usecase.notifications
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Bundle
+import android.service.notification.StatusBarNotification
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
+import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
+import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_DOWNLOADED
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ClearNotificationsByDownloadIdUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var notificationManager: NotificationManager
+
+    @Mock
+    private lateinit var statusBarNotification: StatusBarNotification
+
+    @Mock
+    private lateinit var extras: Bundle
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+
+        `when`(appContext.getSystemService(NotificationManager::class.java))
+            .thenReturn(notificationManager)
+        `when`(notificationManager.activeNotifications)
+            .thenReturn(arrayOf(statusBarNotification))
+        `when`(statusBarNotification.id)
+            .thenReturn(55)
+        `when`(statusBarNotification.tag)
+            .thenReturn("download-tag")
+
+        doReturn(ACTION_NAVIGATE_DOWNLOAD)
+            .`when`(extras).getString(EXTRA_ACTION)
+        doReturn("77")
+            .`when`(extras).getString(EXTRA_DOWNLOAD_ID)
+
+        val notification = object : Notification() {
+            override fun getChannelId(): String = CHANNEL_ID_DOWNLOADED
+        }.apply {
+            this.extras = this@ClearNotificationsByDownloadIdUseCaseTest.extras
+        }
+        doReturn(notification)
+            .`when`(statusBarNotification).notification
+    }
+
+    @Test
+    fun invoke_clearsDownloadedNotifications_matchingDownloadId() {
+        ClearNotificationsByDownloadIdUseCase(appContext).invoke(77L)
+
+        verify(notificationManager)
+            .cancel("download-tag", 55)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildAudioDownloadRequestUseCaseTest.kt
@@ -1,0 +1,63 @@
+package org.strigate.ferrot.domain.usecase.youtubedl_android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BuildAudioDownloadRequestUseCaseTest {
+    private val useCase = BuildAudioDownloadRequestUseCase()
+
+    @Test
+    fun invoke_buildsProgressRequest() {
+        val request = useCase(
+            url = "https://example.com/audio",
+            template = "/tmp/%(title)s.%(ext)s",
+            noProgress = false,
+        )
+
+        assertEquals("ba/b", request.getOption("-f"))
+        assertEquals("/tmp/%(title)s.%(ext)s", request.getOption("-o"))
+        assertTrue(request.hasOption("--extract-audio"))
+        assertEquals("mp3", request.getOption("--audio-format"))
+        assertEquals("0", request.getOption("--audio-quality"))
+        assertTrue(request.hasOption("--no-overwrites"))
+        assertTrue(request.hasOption("--no-post-overwrites"))
+        assertTrue(request.hasOption("--newline"))
+        assertFalse(request.hasOption("--no-progress"))
+    }
+
+    @Test
+    fun invoke_addsPrintToFile_andGetFilename_whenRequested() {
+        val request = useCase(
+            url = "https://example.com/audio",
+            template = "/tmp/%(title)s.%(ext)s",
+            noProgress = true,
+            outputPathFilePath = "/tmp/audio.txt",
+        )
+
+        val command = request.buildCommand()
+
+        assertTrue(request.hasOption("--no-progress"))
+        assertTrue(request.hasOption("--get-filename"))
+        assertFalse(request.hasOption("--print"))
+        assertTrue(
+            command.containsAll(
+                listOf("--print-to-file", "after_move:%(filepath)s", "/tmp/audio.txt"),
+            ),
+        )
+    }
+
+    @Test
+    fun invoke_printsFilename_whenRequested() {
+        val request = useCase(
+            url = "https://example.com/audio",
+            template = "/tmp/%(title)s.%(ext)s",
+            noProgress = true,
+            printFilename = true,
+        )
+
+        assertEquals("filename", request.getOption("--print"))
+        assertFalse(request.hasOption("--get-filename"))
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildThumbnailRequestUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildThumbnailRequestUseCaseTest.kt
@@ -1,0 +1,45 @@
+package org.strigate.ferrot.domain.usecase.youtubedl_android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class BuildThumbnailRequestUseCaseTest {
+    private val useCase = BuildThumbnailRequestUseCase()
+
+    @Test
+    fun invoke_buildsRequest_withJpgConversionByDefault() {
+        val outputDir = Files.createTempDirectory("thumb-request").toFile()
+        val request = useCase(
+            url = "https://example.com/video",
+            outputDir = outputDir,
+            videoId = "abc:123 test",
+        )
+
+        assertEquals(
+            File(outputDir, "thumb_abc123 test.%(ext)s").absolutePath,
+            request.getOption("-o"),
+        )
+        assertTrue(request.hasOption("--restrict-filenames"))
+        assertTrue(request.hasOption("--skip-download"))
+        assertTrue(request.hasOption("--write-thumbnail"))
+        assertEquals("jpg", request.getOption("--convert-thumbnails"))
+        assertTrue(request.hasOption("--no-progress"))
+    }
+
+    @Test
+    fun invoke_skipsConversion_whenDisabled() {
+        val outputDir = Files.createTempDirectory("thumb-request-no-convert").toFile()
+        val request = useCase(
+            url = "https://example.com/video",
+            outputDir = outputDir,
+            videoId = "plain-id",
+            convertToJpg = false,
+        )
+
+        assertFalse(request.hasOption("--convert-thumbnails"))
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/BuildVideoDownloadRequestUseCaseTest.kt
@@ -1,0 +1,75 @@
+package org.strigate.ferrot.domain.usecase.youtubedl_android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.strigate.ferrot.domain.model.QualityProfile
+
+class BuildVideoDownloadRequestUseCaseTest {
+    private val useCase = BuildVideoDownloadRequestUseCase()
+
+    @Test
+    fun invoke_buildsProgressRequest_forMaxQuality() {
+        val request = useCase(
+            url = "https://example.com/video",
+            template = "/tmp/%(title)s.%(ext)s",
+            qualityProfile = QualityProfile.MAX,
+            noProgress = false,
+        )
+
+        val command = request.buildCommand()
+
+        assertEquals("bv*+ba/b", request.getOption("-f"))
+        assertEquals("/tmp/%(title)s.%(ext)s", request.getOption("-o"))
+        assertTrue(request.hasOption("--windows-filenames"))
+        assertTrue(request.hasOption("--add-metadata"))
+        assertTrue(request.hasOption("--newline"))
+        assertFalse(request.hasOption("--no-progress"))
+        assertFalse(request.hasOption("--merge-output-format"))
+        assertEquals("aria2c", request.getOption("--external-downloader"))
+        assertEquals("aria2c:-x16 -k1M", request.getOption("--external-downloader-args"))
+        assertEquals("https://example.com/video", command.last())
+    }
+
+    @Test
+    fun invoke_addsPrintToFile_andFilenamePrinting_whenRequested() {
+        val request = useCase(
+            url = "https://example.com/video",
+            template = "/tmp/%(title)s.%(ext)s",
+            qualityProfile = QualityProfile.CAP_2160,
+            noProgress = true,
+            outputPathFilePath = "/tmp/out.txt",
+            printFilename = true,
+        )
+
+        val command = request.buildCommand()
+
+        assertEquals("bv*[height<=2160]+ba/b", request.getOption("-f"))
+        assertTrue(request.hasOption("--no-progress"))
+        assertEquals("filename", request.getOption("--print"))
+        assertFalse(request.hasOption("--get-filename"))
+        assertTrue(
+            command.containsAll(
+                listOf("--print-to-file", "after_move:%(filepath)s", "/tmp/out.txt"),
+            ),
+        )
+    }
+
+    @Test
+    fun invoke_forCompat2160_addsMergeFormat_andGetFilename() {
+        val request = useCase(
+            url = "https://example.com/video",
+            template = "/tmp/%(title)s.%(ext)s",
+            qualityProfile = QualityProfile.COMPAT_2160,
+            noProgress = true,
+        )
+
+        assertEquals(
+            "bv*[vcodec^=avc1][height<=2160]+ba[acodec^=mp4a]/b[ext=mp4]",
+            request.getOption("-f"),
+        )
+        assertEquals("mp4", request.getOption("--merge-output-format"))
+        assertTrue(request.hasOption("--get-filename"))
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCaseTest.kt
@@ -1,0 +1,178 @@
+package org.strigate.ferrot.domain.usecase.youtubedl_android
+
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import com.yausername.youtubedl_android.YoutubeDLResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.YoutubeDlRuntimeInitializer
+import org.strigate.ferrot.app.integration.YoutubeDlClient
+import org.strigate.ferrot.domain.model.DownloadMediaType
+import org.strigate.ferrot.domain.model.QualityProfile
+import java.nio.file.Files
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadWithProgressUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    private lateinit var fakeClient: FakeYoutubeDlClient
+
+    @Mock
+    private lateinit var youtubeDlRuntimeInitializer: YoutubeDlRuntimeInitializer
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+        fakeClient = FakeYoutubeDlClient()
+    }
+
+    @Test
+    fun invoke_buildsVideoRequest_andReportsOutputPath() = runTest(testDispatcher) {
+        val outputPathFile = Files.createTempFile("download-with-progress", ".txt").toFile()
+        var reportedOutputPath: String? = null
+        fakeClient.onExecute = { request, _, _, _ ->
+            outputPathFile.writeText("/storage/emulated/0/Movies/video.mp4\n")
+            fakeClient.capturedRequest = request
+            YoutubeDLResponse(
+                command = listOf("yt-dlp"),
+                exitCode = 0,
+                elapsedTime = 100L,
+                out = "",
+                err = "",
+            )
+        }
+
+        val result = createUseCase().invoke(
+            url = "https://example.com/video",
+            template = "/tmp/%(title)s.%(ext)s",
+            profile = QualityProfile.MAX,
+            processId = "process-1",
+            bytesProvider = { 123L },
+            outputPathFile = outputPathFile,
+            onOutputFilePath = { reportedOutputPath = it },
+        ).toList()
+
+        assertTrue(result.isEmpty())
+        assertEquals("/storage/emulated/0/Movies/video.mp4", reportedOutputPath)
+        assertEquals("bv*+ba/b", fakeClient.capturedRequest?.getOption("-f"))
+        assertEquals("/tmp/%(title)s.%(ext)s", fakeClient.capturedRequest?.getOption("-o"))
+        assertEquals("aria2c", fakeClient.capturedRequest?.getOption("--external-downloader"))
+        verify(youtubeDlRuntimeInitializer)
+            .initializeIfNeeded()
+        assertEquals(listOf("process-1"), fakeClient.destroyedProcessIds)
+    }
+
+    @Test
+    fun invoke_buildsAudioRequest_forAudioDownloads() = runTest(testDispatcher) {
+        fakeClient.onExecute = { request, _, _, _ ->
+            fakeClient.capturedRequest = request
+            YoutubeDLResponse(
+                command = listOf("yt-dlp"),
+                exitCode = 0,
+                elapsedTime = 50L,
+                out = "",
+                err = "",
+            )
+        }
+
+        val result = createUseCase().invoke(
+            url = "https://example.com/audio",
+            template = "/tmp/%(title)s.%(ext)s",
+            profile = QualityProfile.CAP_2160,
+            processId = "process-2",
+            bytesProvider = { 456L },
+            downloadMediaType = DownloadMediaType.AUDIO,
+        ).toList()
+
+        assertTrue(result.isEmpty())
+        assertEquals("ba/b", fakeClient.capturedRequest?.getOption("-f"))
+        assertEquals("/tmp/%(title)s.%(ext)s", fakeClient.capturedRequest?.getOption("-o"))
+        assertTrue(fakeClient.capturedRequest?.hasOption("--extract-audio") == true)
+    }
+
+    @Test
+    fun invoke_throwsWhenYoutubeDlReturnsNonZeroExitCode() = runTest(testDispatcher) {
+        fakeClient.onExecute = { _, _, _, _ ->
+            YoutubeDLResponse(
+                command = listOf("yt-dlp"),
+                exitCode = 1,
+                elapsedTime = 10L,
+                out = "",
+                err = "boom",
+            )
+        }
+
+        val failure = runCatching {
+            createUseCase().invoke(
+                url = "https://example.com/video",
+                template = "/tmp/%(title)s.%(ext)s",
+                profile = QualityProfile.MAX,
+                processId = "process-3",
+                bytesProvider = { 0L },
+            ).toList()
+        }.exceptionOrNull()
+
+        assertNotNull(failure)
+        assertTrue(failure is IllegalStateException)
+        assertEquals("Exit code 1", failure?.message)
+        assertEquals(listOf("process-3"), fakeClient.destroyedProcessIds)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
+
+    private fun createUseCase() = DownloadWithProgressUseCase(
+        buildVideoDownloadRequestUseCase = BuildVideoDownloadRequestUseCase(),
+        buildAudioDownloadRequestUseCase = BuildAudioDownloadRequestUseCase(),
+        youtubeDlRuntimeInitializer = youtubeDlRuntimeInitializer,
+        youtubeDlClient = fakeClient,
+    )
+
+    private class FakeYoutubeDlClient : YoutubeDlClient() {
+        var capturedRequest: YoutubeDLRequest? = null
+        var destroyedProcessIds: MutableList<String> = mutableListOf()
+        var onExecute: (YoutubeDLRequest, String, Boolean, ((Float, Long, String) -> Unit)?) -> YoutubeDLResponse =
+            { _, _, _, _ ->
+                YoutubeDLResponse(
+                    command = emptyList(),
+                    exitCode = 0,
+                    elapsedTime = 0L,
+                    out = "",
+                    err = "",
+                )
+            }
+
+        override fun execute(
+            request: YoutubeDLRequest,
+            processId: String,
+            redirectErrorStream: Boolean,
+            callback: ((Float, Long, String) -> Unit)?,
+        ): YoutubeDLResponse {
+            capturedRequest = request
+            return onExecute(request, processId, redirectErrorStream, callback)
+        }
+
+        override fun destroyProcessById(processId: String): Boolean {
+            destroyedProcessIds += processId
+            return true
+        }
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
@@ -56,13 +56,6 @@ class MainViewModelTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        logMock?.close()
-        logMock = null
-        autoCloseable.close()
-    }
 
     @Test
     fun navigateTo_updatesNavigationEvent() {
@@ -117,95 +110,93 @@ class MainViewModelTest {
     }
 
     @Test
-    fun navigateToDownload_routesToArchivedDownload_whenDownloadIsArchived() =
-        runTest(testDispatcher) {
-            val download = Download(
-                id = 42L,
-                uid = "uid-42",
-                url = "https://example.com",
-                status = DownloadStatus.COMPLETED,
-                seen = false,
-                archived = true,
-            )
-            val viewModel = createViewModel()
-            `when`(downloadRepository.getById(42L))
-                .thenReturn(download)
+    fun navigateToDownload_routesArchivedDownload_whenArchived() = runTest(testDispatcher) {
+        val download = Download(
+            id = 42L,
+            uid = "uid-42",
+            url = "https://example.com",
+            status = DownloadStatus.COMPLETED,
+            seen = false,
+            archived = true,
+        )
+        val viewModel = createViewModel()
+        `when`(downloadRepository.getById(42L))
+            .thenReturn(download)
 
-            viewModel.navigateToDownload(42L)
-            advanceUntilIdle()
+        viewModel.navigateToDownload(42L)
+        advanceUntilIdle()
 
-            assertEquals(
-                NavigationEvent.Route(
-                    route = Screen.Download.route(42L, archived = true),
-                    popUpToRoute = Screen.Archived.route,
-                ),
-                viewModel.navigateRoute.value,
-            )
-        }
-
-    @Test
-    fun navigateToDownload_clearsPendingDeleteBeforeNavigation_whenDownloadIsPendingDelete() =
-        runTest(testDispatcher) {
-            val download = Download(
-                id = 42L,
-                uid = "uid-42",
-                url = "https://example.com",
-                status = DownloadStatus.COMPLETED,
-                seen = false,
-                pendingDelete = true,
-            )
-            val viewModel = createViewModel()
-            `when`(downloadRepository.getById(42L))
-                .thenReturn(download)
-
-            viewModel.navigateToDownload(42L)
-            advanceUntilIdle()
-
-            verify(downloadRepository).updatePendingDeleteByIds(setOf(42L), false)
-            assertEquals(
-                NavigationEvent.Route(
-                    route = Screen.Download.route(42L),
-                    popUpToRoute = Screen.Downloads.route,
-                ),
-                viewModel.navigateRoute.value,
-            )
-        }
+        assertEquals(
+            NavigationEvent.Route(
+                route = Screen.Download.route(42L, archived = true),
+                popUpToRoute = Screen.Archived.route,
+            ),
+            viewModel.navigateRoute.value,
+        )
+    }
 
     @Test
-    fun navigateToDownload_keepsNavigationEmpty_whenDownloadDoesNotExist() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel()
-            `when`(downloadRepository.getById(99L))
-                .thenReturn(null)
+    fun navigateToDownload_clearsPendingDelete_whenPendingDelete() = runTest(testDispatcher) {
+        val download = Download(
+            id = 42L,
+            uid = "uid-42",
+            url = "https://example.com",
+            status = DownloadStatus.COMPLETED,
+            seen = false,
+            pendingDelete = true,
+        )
+        val viewModel = createViewModel()
+        `when`(downloadRepository.getById(42L))
+            .thenReturn(download)
 
-            viewModel.navigateToDownload(99L)
-            advanceUntilIdle()
+        viewModel.navigateToDownload(42L)
+        advanceUntilIdle()
 
-            assertNull(viewModel.navigateRoute.value)
-        }
+        verify(downloadRepository)
+            .updatePendingDeleteByIds(setOf(42L), false)
+        assertEquals(
+            NavigationEvent.Route(
+                route = Screen.Download.route(42L),
+                popUpToRoute = Screen.Downloads.route,
+            ),
+            viewModel.navigateRoute.value,
+        )
+    }
 
     @Test
-    fun startDownload_savesQueuedUnseenDownloadAndStartsIt_whenSaveSucceeds() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel()
-            val savedDownloads = mutableListOf<Download>()
-            doAnswer { invocation ->
-                savedDownloads += invocation.getArgument<Download>(0)
-                12L
-            }.`when`(downloadRepository).save(anyObject())
+    fun navigateToDownload_keepsNavigationEmpty_whenMissing() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        `when`(downloadRepository.getById(99L))
+            .thenReturn(null)
 
-            viewModel.startDownload("https://example.com/video")
-            advanceUntilIdle()
+        viewModel.navigateToDownload(99L)
+        advanceUntilIdle()
 
-            val savedDownload = savedDownloads.single()
-            assertEquals("https://example.com/video", savedDownload.url)
-            assertEquals(DownloadStatus.QUEUED, savedDownload.status)
-            assertFalse(savedDownload.seen)
-            assertNotNull(savedDownload.uid)
-            assertFalse(savedDownload.uid.isBlank())
+        assertNull(viewModel.navigateRoute.value)
+    }
 
-            verify(startDownloadUseCase).invoke(12L)
-        }
+    @Test
+    fun startDownload_savesQueuedUnseenAndStarts_whenSaveSucceeds() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        val savedDownloads = mutableListOf<Download>()
+        doAnswer { invocation ->
+            savedDownloads += invocation.getArgument<Download>(0)
+            12L
+        }.`when`(downloadRepository).save(anyObject())
+
+        viewModel.startDownload("https://example.com/video")
+        advanceUntilIdle()
+
+        val savedDownload = savedDownloads.single()
+        assertEquals("https://example.com/video", savedDownload.url)
+        assertEquals(DownloadStatus.QUEUED, savedDownload.status)
+        assertFalse(savedDownload.seen)
+        assertNotNull(savedDownload.uid)
+        assertFalse(savedDownload.uid.isBlank())
+
+        verify(startDownloadUseCase)
+            .invoke(12L)
+    }
 
     @Test
     fun startDownload_doesNotStartIt_whenSaveFails() = runTest(testDispatcher) {
@@ -231,6 +222,14 @@ class MainViewModelTest {
         viewModel.resetNavigate()
 
         assertNull(viewModel.navigateRoute.value)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        logMock?.close()
+        logMock = null
+        autoCloseable.close()
     }
 
     private fun createViewModel(): MainViewModel {

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/util/UiFormatterTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/util/UiFormatterTest.kt
@@ -31,11 +31,6 @@ class UiFormatterTest {
         Locale.setDefault(Locale.US)
     }
 
-    @After
-    fun tearDown() {
-        Locale.setDefault(originalLocale)
-        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(originalZoneId))
-    }
 
     @Test
     fun formatBytes_handlesZeroAndScaledValues() {
@@ -66,7 +61,8 @@ class UiFormatterTest {
     @Test
     fun formatLastCheckedTime_returnsNever_whenMillisIsNotPositive() {
         val context = mock(Context::class.java)
-        `when`(context.getString(R.string.never)).thenReturn("Never")
+        `when`(context.getString(R.string.never))
+            .thenReturn("Never")
 
         assertEquals("Never", UiFormatter.formatLastCheckedTime(context, 0L))
     }
@@ -82,7 +78,8 @@ class UiFormatterTest {
             mockStatic(DateFormat::class.java).use { dateFormatMock ->
                 dateUtilsMock.`when`<CharSequence> {
                     DateUtils.getRelativeTimeSpanString(anyLong(), anyLong(), anyLong(), anyInt())
-                }.thenReturn("moments ago")
+                }
+                    .thenReturn("moments ago")
                 dateFormatMock.`when`<java.text.DateFormat> { DateFormat.getMediumDateFormat(context) }
                     .thenReturn(dateFormat)
                 dateFormatMock.`when`<java.text.DateFormat> { DateFormat.getTimeFormat(context) }
@@ -111,7 +108,8 @@ class UiFormatterTest {
             .toEpochMilli()
 
         mockStatic(DateFormat::class.java).use { dateFormatMock ->
-            dateFormatMock.`when`<Boolean> { DateFormat.is24HourFormat(context) }.thenReturn(true)
+            dateFormatMock.`when`<Boolean> { DateFormat.is24HourFormat(context) }
+                .thenReturn(true)
             dateFormatMock.`when`<String> {
                 DateFormat.getBestDateTimePattern(
                     Locale.US,
@@ -193,4 +191,11 @@ class UiFormatterTest {
             assertEquals("2024-01-02 09:45 PM", result)
         }
     }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(originalZoneId))
+    }
+
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
@@ -35,19 +35,14 @@ class AboutViewModelTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
-
     @Test
     fun logShown_logsAboutScreen() {
         val viewModel = AboutViewModel(analyticsLogger)
 
         viewModel.logShown()
 
-        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.ABOUT)
+        verify(analyticsLogger)
+            .logScreen(AnalyticsEvents.Screens.ABOUT)
     }
 
     @Test
@@ -70,5 +65,11 @@ class AboutViewModelTest {
         advanceUntilIdle()
 
         assertEquals(AboutEvent.OpenAppInfo, event.await())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -48,8 +48,8 @@ import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
-import org.strigate.ferrot.domain.usecase.download.RequestRefreshDownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeleteDownloadsUseCase
+import org.strigate.ferrot.domain.usecase.download.RequestRefreshDownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
 import org.strigate.ferrot.domain.usecase.downloadaudio.GetDownloadAudioByDownloadIdAsFlowUseCase
@@ -132,18 +132,14 @@ class DownloadViewModelTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun init_clearsNotificationsForInitialDownload() = runTest(testDispatcher) {
         createViewModel(initialId = 20L)
         advanceUntilIdle()
 
-        verify(clearNotificationsByDownloadIdUseCase).invoke(20L)
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(20L)
     }
 
     @Test
@@ -152,7 +148,8 @@ class DownloadViewModelTest {
 
         viewModel.logShown()
 
-        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.DOWNLOAD)
+        verify(analyticsLogger)
+            .logScreen(AnalyticsEvents.Screens.DOWNLOAD)
     }
 
     @Test
@@ -219,55 +216,53 @@ class DownloadViewModelTest {
     }
 
     @Test
-    fun selectedId_movesToNextAdjacentDownload_whenCurrentDownloadIsDeleted() =
-        runTest(testDispatcher) {
-            val downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L))
-            val viewModel = createViewModel(
-                initialId = 20L,
-                downloadIdsFlow = downloadIdsFlow,
-            )
-            val collector = collectUiState(backgroundScope, viewModel)
+    fun selectedId_movesToNextDownload_whenCurrentIsDeleted() = runTest(testDispatcher) {
+        val downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L))
+        val viewModel = createViewModel(
+            initialId = 20L,
+            downloadIdsFlow = downloadIdsFlow,
+        )
+        val collector = collectUiState(backgroundScope, viewModel)
 
-            advanceUntilIdle()
-            downloadIdsFlow.value = listOf(10L, 30L)
-            advanceUntilIdle()
-            waitForUiState(viewModel) { state ->
-                val data = state as? DownloadUiState.Data ?: return@waitForUiState false
-                data.data.id == 30L
-            }
-
-            assertEquals(30L, viewModel.selectedId.value)
-            assertEquals(30L, (viewModel.uiState.value as DownloadUiState.Data).data.id)
-
-            collector.cancel()
+        advanceUntilIdle()
+        downloadIdsFlow.value = listOf(10L, 30L)
+        advanceUntilIdle()
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadUiState.Data ?: return@waitForUiState false
+            data.data.id == 30L
         }
+
+        assertEquals(30L, viewModel.selectedId.value)
+        assertEquals(30L, (viewModel.uiState.value as DownloadUiState.Data).data.id)
+
+        collector.cancel()
+    }
 
     @Test
-    fun selectedId_movesToPreviousAdjacentDownload_whenLastDownloadIsDeleted() =
-        runTest(testDispatcher) {
-            val downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L))
-            val viewModel = createViewModel(
-                initialId = 30L,
-                downloadIdsFlow = downloadIdsFlow,
-            )
-            val collector = collectUiState(backgroundScope, viewModel)
+    fun selectedId_movesToPreviousDownload_whenLastIsDeleted() = runTest(testDispatcher) {
+        val downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L))
+        val viewModel = createViewModel(
+            initialId = 30L,
+            downloadIdsFlow = downloadIdsFlow,
+        )
+        val collector = collectUiState(backgroundScope, viewModel)
 
-            advanceUntilIdle()
-            downloadIdsFlow.value = listOf(10L, 20L)
-            advanceUntilIdle()
-            waitForUiState(viewModel) { state ->
-                val data = state as? DownloadUiState.Data ?: return@waitForUiState false
-                data.data.id == 20L
-            }
-
-            assertEquals(20L, viewModel.selectedId.value)
-            assertEquals(
-                20L,
-                (viewModel.uiState.value as DownloadUiState.Data).data.id,
-            )
-
-            collector.cancel()
+        advanceUntilIdle()
+        downloadIdsFlow.value = listOf(10L, 20L)
+        advanceUntilIdle()
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadUiState.Data ?: return@waitForUiState false
+            data.data.id == 20L
         }
+
+        assertEquals(20L, viewModel.selectedId.value)
+        assertEquals(
+            20L,
+            (viewModel.uiState.value as DownloadUiState.Data).data.id,
+        )
+
+        collector.cancel()
+    }
 
     @Test
     fun uiState_filtersOutPendingDeleteDownloadIds() = runTest(testDispatcher) {
@@ -348,29 +343,28 @@ class DownloadViewModelTest {
     }
 
     @Test
-    fun setDefaultsForIds_addsMissingDefaults_withoutOverwritingExistingSelection() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel()
-            val collector = collectSelectedMedia(backgroundScope, viewModel)
+    fun setDefaultsForIds_addsMissingDefaults_withoutOverwriting() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+        val collector = collectSelectedMedia(backgroundScope, viewModel)
 
-            viewModel.selectDownload(20L)
-            advanceUntilIdle()
-            viewModel.setSelectedMedia(DownloadMediaType.AUDIO)
-            advanceUntilIdle()
+        viewModel.selectDownload(20L)
+        advanceUntilIdle()
+        viewModel.setSelectedMedia(DownloadMediaType.AUDIO)
+        advanceUntilIdle()
 
-            viewModel.setDefaultsForIds(listOf(20L, 30L))
-            advanceUntilIdle()
-            viewModel.setDefaultsForIds(listOf(20L, 30L))
-            advanceUntilIdle()
+        viewModel.setDefaultsForIds(listOf(20L, 30L))
+        advanceUntilIdle()
+        viewModel.setDefaultsForIds(listOf(20L, 30L))
+        advanceUntilIdle()
 
-            assertEquals(DownloadMediaType.AUDIO, viewModel.selectedMedia.value)
+        assertEquals(DownloadMediaType.AUDIO, viewModel.selectedMedia.value)
 
-            viewModel.selectDownload(30L)
-            advanceUntilIdle()
-            assertEquals(DownloadMediaType.VIDEO, viewModel.selectedMedia.value)
+        viewModel.selectDownload(30L)
+        advanceUntilIdle()
+        assertEquals(DownloadMediaType.VIDEO, viewModel.selectedMedia.value)
 
-            collector.cancel()
-        }
+        collector.cancel()
+    }
 
     @Test
     fun markSeenIfCompleted_updatesSeenForCompletedUnseenDownload() = runTest(testDispatcher) {
@@ -381,52 +375,57 @@ class DownloadViewModelTest {
         viewModel.markSeenIfCompleted(7L)
         advanceUntilIdle()
 
-        verify(updateDownloadsSeenUseCase).invoke(setOf(7L))
-        verify(clearNotificationsByDownloadIdUseCase).invoke(7L)
+        verify(updateDownloadsSeenUseCase)
+            .invoke(setOf(7L))
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(7L)
     }
 
     @Test
-    fun markSeenIfCompleted_doesNothingForMissingSeenOrIncompleteDownload() =
-        runTest(testDispatcher) {
-            `when`(getDownloadByIdUseCase.invoke(7L)).thenReturn(null)
-            `when`(getDownloadByIdUseCase.invoke(8L))
-                .thenReturn(createDownload(id = 8L, status = DownloadStatus.COMPLETED, seen = true))
-            `when`(getDownloadByIdUseCase.invoke(9L))
-                .thenReturn(createDownload(id = 9L, status = DownloadStatus.FAILED, seen = false))
-            val viewModel = createViewModel()
+    fun markSeenIfCompleted_doesNothingForMissingSeenOrIncomplete() = runTest(testDispatcher) {
+        `when`(getDownloadByIdUseCase.invoke(7L))
+            .thenReturn(null)
+        `when`(getDownloadByIdUseCase.invoke(8L))
+            .thenReturn(createDownload(id = 8L, status = DownloadStatus.COMPLETED, seen = true))
+        `when`(getDownloadByIdUseCase.invoke(9L))
+            .thenReturn(createDownload(id = 9L, status = DownloadStatus.FAILED, seen = false))
+        val viewModel = createViewModel()
 
-            viewModel.markSeenIfCompleted(7L)
-            viewModel.markSeenIfCompleted(8L)
-            viewModel.markSeenIfCompleted(9L)
-            advanceUntilIdle()
+        viewModel.markSeenIfCompleted(7L)
+        viewModel.markSeenIfCompleted(8L)
+        viewModel.markSeenIfCompleted(9L)
+        advanceUntilIdle()
 
-            verify(updateDownloadsSeenUseCase, never()).invoke(setOf(7L))
-            verify(updateDownloadsSeenUseCase, never()).invoke(setOf(8L))
-            verify(updateDownloadsSeenUseCase, never()).invoke(setOf(9L))
-        }
+        verify(updateDownloadsSeenUseCase, never())
+            .invoke(setOf(7L))
+        verify(updateDownloadsSeenUseCase, never())
+            .invoke(setOf(8L))
+        verify(updateDownloadsSeenUseCase, never())
+            .invoke(setOf(9L))
+    }
 
     @Test
-    fun deleteDownload_requestsDeletion_withoutNavigation_whenOtherDownloadsRemain() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(
-                initialId = 20L,
-                downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L)),
-            )
-            val eventDeferred = backgroundScope.async {
-                runCatching {
-                    withTimeout(250L) {
-                        viewModel.events.first()
-                    }
+    fun deleteDownload_requestsDeletion_withoutNav_whenOthersRemain() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            initialId = 20L,
+            downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L)),
+        )
+        val eventDeferred = backgroundScope.async {
+            runCatching {
+                withTimeout(250L) {
+                    viewModel.events.first()
                 }
             }
-
-            advanceUntilIdle()
-            viewModel.deleteDownload(20L)
-            advanceUntilIdle()
-
-            verify(requestDeleteDownloadsUseCase).invoke(listOf(20L))
-            assertNull(eventDeferred.await().getOrNull())
         }
+
+        advanceUntilIdle()
+        viewModel.deleteDownload(20L)
+        advanceUntilIdle()
+
+        verify(requestDeleteDownloadsUseCase)
+            .invoke(listOf(20L))
+        assertNull(eventDeferred.await().getOrNull())
+    }
 
     @Test
     fun deleteDownload_emitsNavigateBack_whenDeletingLastDownload() = runTest(testDispatcher) {
@@ -441,7 +440,8 @@ class DownloadViewModelTest {
         viewModel.deleteDownload()
         advanceUntilIdle()
 
-        verify(requestDeleteDownloadsUseCase).invoke(listOf(20L))
+        verify(requestDeleteDownloadsUseCase)
+            .invoke(listOf(20L))
         assertEquals(DownloadEvent.NavigateBack, eventDeferred.await())
     }
 
@@ -453,35 +453,38 @@ class DownloadViewModelTest {
         viewModel.retryDownload()
         advanceUntilIdle()
 
-        verify(startDownloadUseCase).invoke(88L)
-        verify(startDownloadUseCase).invoke(20L)
+        verify(startDownloadUseCase)
+            .invoke(88L)
+        verify(startDownloadUseCase)
+            .invoke(20L)
     }
 
     @Test
-    fun refreshDownloadMetadata_refreshesExplicitOrSelectedDownload() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(initialId = 20L)
+    fun refreshDownloadMetadata_refreshesExplicitOrSelected() = runTest(testDispatcher) {
+        val viewModel = createViewModel(initialId = 20L)
 
-            viewModel.refreshDownloadMetadata(88L)
-            advanceUntilIdle()
+        viewModel.refreshDownloadMetadata(88L)
+        advanceUntilIdle()
 
-            viewModel.refreshDownloadMetadata()
-            advanceUntilIdle()
+        viewModel.refreshDownloadMetadata()
+        advanceUntilIdle()
 
-            verify(requestRefreshDownloadMetadataUseCase).invoke(88L)
-            verify(requestRefreshDownloadMetadataUseCase).invoke(20L)
-        }
+        verify(requestRefreshDownloadMetadataUseCase)
+            .invoke(88L)
+        verify(requestRefreshDownloadMetadataUseCase)
+            .invoke(20L)
+    }
 
     @Test
-    fun refreshDownloadMetadata_enqueuesWithoutAdditionalUiTracking() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(initialId = 20L)
+    fun refreshDownloadMetadata_enqueuesWithoutExtraUiTracking() = runTest(testDispatcher) {
+        val viewModel = createViewModel(initialId = 20L)
 
-            viewModel.refreshDownloadMetadata()
-            advanceUntilIdle()
+        viewModel.refreshDownloadMetadata()
+        advanceUntilIdle()
 
-            verify(requestRefreshDownloadMetadataUseCase).invoke(20L)
-        }
+        verify(requestRefreshDownloadMetadataUseCase)
+            .invoke(20L)
+    }
 
     @Test
     fun shareSaveAndPlay_emitEventsUsingSelectedMediaPath() = runTest(testDispatcher) {
@@ -566,54 +569,58 @@ class DownloadViewModelTest {
     }
 
     @Test
-    fun shareDownload_usesExplicitStoredVideoSelection_forExplicitDownloadId() =
-        runTest(testDispatcher) {
-            stubPageData(
+    fun shareDownload_usesStoredVideoSelection_forExplicitId() = runTest(testDispatcher) {
+        stubPageData(
+            downloadId = 88L,
+            download = createDownload(id = 88L, status = DownloadStatus.COMPLETED),
+            video = DownloadVideo(
                 downloadId = 88L,
-                download = createDownload(id = 88L, status = DownloadStatus.COMPLETED),
-                video = DownloadVideo(
-                    downloadId = 88L,
-                    filePath = "/tmp/stored-video.mp4",
-                    fileExtension = "mp4",
-                    sha256 = null,
-                ),
-            )
-            val viewModel = createViewModel(initialId = 20L)
+                filePath = "/tmp/stored-video.mp4",
+                fileExtension = "mp4",
+                sha256 = null,
+            ),
+        )
+        val viewModel = createViewModel(initialId = 20L)
 
-            viewModel.setSelectedMedia(DownloadMediaType.VIDEO, forDownloadId = 88L)
-            advanceUntilIdle()
+        viewModel.setSelectedMedia(DownloadMediaType.VIDEO, forDownloadId = 88L)
+        advanceUntilIdle()
 
-            val shareDeferred = backgroundScope.async { viewModel.events.first() }
-            viewModel.shareDownload(88L)
-            advanceUntilIdle()
+        val shareDeferred = backgroundScope.async { viewModel.events.first() }
+        viewModel.shareDownload(88L)
+        advanceUntilIdle()
 
-            assertEquals(DownloadEvent.Share("/tmp/stored-video.mp4"), shareDeferred.await())
-        }
+        assertEquals(DownloadEvent.Share("/tmp/stored-video.mp4"), shareDeferred.await())
+    }
 
     @Test
     fun shareDownload_handlesSuspendingPageDataFlow() = runTest(testDispatcher) {
-        `when`(getDownloadByIdAsFlowUseCase.invoke(66L)).thenReturn(
-            flow {
-                kotlinx.coroutines.yield()
-                emit(createDownload(id = 66L, status = DownloadStatus.COMPLETED))
-            }
-        )
-        `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(66L)).thenReturn(
-            flow {
-                kotlinx.coroutines.yield()
-                emit(
-                    DownloadVideo(
-                        downloadId = 66L,
-                        filePath = "/tmp/suspending-video.mp4",
-                        fileExtension = "mp4",
-                        sha256 = null,
+        `when`(getDownloadByIdAsFlowUseCase.invoke(66L))
+            .thenReturn(
+                flow {
+                    kotlinx.coroutines.yield()
+                    emit(createDownload(id = 66L, status = DownloadStatus.COMPLETED))
+                }
+            )
+        `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(66L))
+            .thenReturn(
+                flow {
+                    kotlinx.coroutines.yield()
+                    emit(
+                        DownloadVideo(
+                            downloadId = 66L,
+                            filePath = "/tmp/suspending-video.mp4",
+                            fileExtension = "mp4",
+                            sha256 = null,
+                        )
                     )
-                )
-            }
-        )
-        `when`(getDownloadAudioByDownloadIdAsFlowUseCase.invoke(66L)).thenReturn(flowOf(null))
-        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(66L)).thenReturn(flowOf(null))
-        `when`(getDownloadProgressByDownloadIdAsFlowUseCase.invoke(66L)).thenReturn(flowOf(null))
+                }
+            )
+        `when`(getDownloadAudioByDownloadIdAsFlowUseCase.invoke(66L))
+            .thenReturn(flowOf(null))
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(66L))
+            .thenReturn(flowOf(null))
+        `when`(getDownloadProgressByDownloadIdAsFlowUseCase.invoke(66L))
+            .thenReturn(flowOf(null))
 
         val viewModel = createViewModel(initialId = 20L)
         val shareDeferred = backgroundScope.async { viewModel.events.first() }
@@ -755,6 +762,12 @@ class DownloadViewModelTest {
             ),
             pageData,
         )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun createViewModel(

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -111,11 +111,6 @@ class DownloadsViewModelTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun uiState_exposesMappedDownloadsAndAvailableUpdate() = runTest(testDispatcher) {
@@ -155,34 +150,33 @@ class DownloadsViewModelTest {
     }
 
     @Test
-    fun uiState_hidesPendingDeleteDownloads_andExposesPendingDeleteFlag() =
-        runTest(testDispatcher) {
-            val downloadsFlow = MutableStateFlow(
-                listOf(
-                    createDownload(id = 1L, title = "Visible Download"),
-                    createDownload(id = 2L, title = "Pending Delete", pendingDelete = true),
-                )
+    fun uiState_hidesPendingDelete_andExposesFlag() = runTest(testDispatcher) {
+        val downloadsFlow = MutableStateFlow(
+            listOf(
+                createDownload(id = 1L, title = "Visible Download"),
+                createDownload(id = 2L, title = "Pending Delete", pendingDelete = true),
             )
-            val updateFlow = MutableStateFlow<AvailableUpdate?>(null)
-            val viewModel = createViewModel(
-                downloadsFlow = downloadsFlow,
-                updateFlow = updateFlow,
-            )
+        )
+        val updateFlow = MutableStateFlow<AvailableUpdate?>(null)
+        val viewModel = createViewModel(
+            downloadsFlow = downloadsFlow,
+            updateFlow = updateFlow,
+        )
 
-            val collector = backgroundScope.launch {
-                viewModel.uiState.collect()
-            }
-            waitForUiState(viewModel) { state ->
-                val data = state as? DownloadsUiState.Data ?: return@waitForUiState false
-                data.data.downloads.size == 1 && data.data.pendingDeleteIds.isNotEmpty()
-            }
-
-            val state = viewModel.uiState.value as DownloadsUiState.Data
-            assertEquals(listOf(1L), state.data.downloads.map { it.id })
-            assertEquals(setOf(2L), state.data.pendingDeleteIds)
-
-            collector.cancel()
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
         }
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadsUiState.Data ?: return@waitForUiState false
+            data.data.downloads.size == 1 && data.data.pendingDeleteIds.isNotEmpty()
+        }
+
+        val state = viewModel.uiState.value as DownloadsUiState.Data
+        assertEquals(listOf(1L), state.data.downloads.map { it.id })
+        assertEquals(setOf(2L), state.data.pendingDeleteIds)
+
+        collector.cancel()
+    }
 
     @Test
     fun updateSearchQuery_trimsInputAndFiltersDownloadsByTitle() = runTest(testDispatcher) {
@@ -232,7 +226,8 @@ class DownloadsViewModelTest {
 
         viewModel.logShown()
 
-        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.DOWNLOADS)
+        verify(analyticsLogger)
+            .logScreen(AnalyticsEvents.Screens.DOWNLOADS)
     }
 
     @Test
@@ -245,14 +240,17 @@ class DownloadsViewModelTest {
         viewModel.stopDownload(42L)
         advanceUntilIdle()
 
-        verify(updateDownloadStatusUseCase).invoke(42L, DownloadStatus.STOPPED)
-        verify(updateDownloadProgressUseCase).invoke(
-            id = 42L,
-            progressPercent = 0F,
-            bytesDownloaded = 0L,
-            etaSeconds = null,
-        )
-        verify(stopDownloadUseCase).invoke(42L)
+        verify(updateDownloadStatusUseCase)
+            .invoke(42L, DownloadStatus.STOPPED)
+        verify(updateDownloadProgressUseCase)
+            .invoke(
+                id = 42L,
+                progressPercent = 0F,
+                bytesDownloaded = 0L,
+                etaSeconds = null,
+            )
+        verify(stopDownloadUseCase)
+            .invoke(42L)
     }
 
     @Test
@@ -268,14 +266,17 @@ class DownloadsViewModelTest {
         viewModel.stopDownload(7L)
         advanceUntilIdle()
 
-        verify(updateDownloadStatusUseCase).invoke(7L, DownloadStatus.STOPPED)
-        verify(updateDownloadProgressUseCase, never()).invoke(
-            id = 7L,
-            progressPercent = 0F,
-            bytesDownloaded = 0L,
-            etaSeconds = null,
-        )
-        verify(stopDownloadUseCase).invoke(7L)
+        verify(updateDownloadStatusUseCase)
+            .invoke(7L, DownloadStatus.STOPPED)
+        verify(updateDownloadProgressUseCase, never())
+            .invoke(
+                id = 7L,
+                progressPercent = 0F,
+                bytesDownloaded = 0L,
+                etaSeconds = null,
+            )
+        verify(stopDownloadUseCase)
+            .invoke(7L)
     }
 
     @Test
@@ -304,14 +305,22 @@ class DownloadsViewModelTest {
         viewModel.stopAllDownloads()
         advanceUntilIdle()
 
-        verify(updateDownloadStatusUseCase).invoke(1L, DownloadStatus.STOPPED)
-        verify(updateDownloadStatusUseCase).invoke(2L, DownloadStatus.STOPPED)
-        verify(updateDownloadStatusUseCase, never()).invoke(3L, DownloadStatus.STOPPED)
-        verify(updateDownloadStatusUseCase, never()).invoke(4L, DownloadStatus.STOPPED)
-        verify(stopDownloadUseCase).invoke(1L)
-        verify(stopDownloadUseCase).invoke(2L)
-        verify(stopDownloadUseCase, never()).invoke(3L)
-        verify(stopDownloadUseCase, never()).invoke(4L)
+        verify(updateDownloadStatusUseCase)
+            .invoke(1L, DownloadStatus.STOPPED)
+        verify(updateDownloadStatusUseCase)
+            .invoke(2L, DownloadStatus.STOPPED)
+        verify(updateDownloadStatusUseCase, never())
+            .invoke(3L, DownloadStatus.STOPPED)
+        verify(updateDownloadStatusUseCase, never())
+            .invoke(4L, DownloadStatus.STOPPED)
+        verify(stopDownloadUseCase)
+            .invoke(1L)
+        verify(stopDownloadUseCase)
+            .invoke(2L)
+        verify(stopDownloadUseCase, never())
+            .invoke(3L)
+        verify(stopDownloadUseCase, never())
+            .invoke(4L)
 
         collector.cancel()
     }
@@ -326,7 +335,8 @@ class DownloadsViewModelTest {
         viewModel.retryDownload(11L)
         advanceUntilIdle()
 
-        verify(startDownloadUseCase).invoke(11L)
+        verify(startDownloadUseCase)
+            .invoke(11L)
     }
 
     @Test
@@ -351,100 +361,111 @@ class DownloadsViewModelTest {
         viewModel.retryFailedDownloads()
         advanceUntilIdle()
 
-        verify(startDownloadUseCase).invoke(1L)
-        verify(startDownloadUseCase).invoke(4L)
-        verify(startDownloadUseCase, never()).invoke(2L)
-        verify(startDownloadUseCase, never()).invoke(3L)
+        verify(startDownloadUseCase)
+            .invoke(1L)
+        verify(startDownloadUseCase)
+            .invoke(4L)
+        verify(startDownloadUseCase, never())
+            .invoke(2L)
+        verify(startDownloadUseCase, never())
+            .invoke(3L)
         collector.cancel()
     }
 
     @Test
-    fun toggleDownloadsSeen_marksAllSeen_whenAnySelectedDownloadIsUnseen() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(
-                downloadsFlow = MutableStateFlow(
-                    listOf(
-                        createDownload(id = 1L, title = "Seen", seen = true),
-                        createDownload(id = 2L, title = "Unseen", seen = false),
-                        createDownload(id = 3L, title = "Seen 2", seen = true),
-                    )
-                ),
-                updateFlow = MutableStateFlow(null),
-            )
+    fun toggleDownloadsSeen_marksAllSeen_whenAnySelectedIsUnseen() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(
+                listOf(
+                    createDownload(id = 1L, title = "Seen", seen = true),
+                    createDownload(id = 2L, title = "Unseen", seen = false),
+                    createDownload(id = 3L, title = "Seen 2", seen = true),
+                )
+            ),
+            updateFlow = MutableStateFlow(null),
+        )
 
-            val collector = backgroundScope.launch {
-                viewModel.uiState.collect()
-            }
-            waitForUiState(viewModel) { it is DownloadsUiState.Data }
-
-            viewModel.toggleDownloadsSeen(setOf(1L, 2L, 3L))
-            advanceUntilIdle()
-
-            verify(updateDownloadsSeenUseCase).invoke(setOf(1L, 2L, 3L), true)
-            verify(clearNotificationsByDownloadIdUseCase).invoke(1L)
-            verify(clearNotificationsByDownloadIdUseCase).invoke(2L)
-            verify(clearNotificationsByDownloadIdUseCase).invoke(3L)
-            collector.cancel()
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
         }
+        waitForUiState(viewModel) { it is DownloadsUiState.Data }
+
+        viewModel.toggleDownloadsSeen(setOf(1L, 2L, 3L))
+        advanceUntilIdle()
+
+        verify(updateDownloadsSeenUseCase)
+            .invoke(setOf(1L, 2L, 3L), true)
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(1L)
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(2L)
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(3L)
+        collector.cancel()
+    }
 
     @Test
-    fun toggleDownloadsSeen_marksAllUnseen_whenAllSelectedDownloadsAreSeen() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(
-                downloadsFlow = MutableStateFlow(
-                    listOf(
-                        createDownload(id = 1L, title = "Seen", seen = true),
-                        createDownload(id = 2L, title = "Seen 2", seen = true),
-                    )
-                ),
-                updateFlow = MutableStateFlow(null),
-            )
+    fun toggleDownloadsSeen_marksAllUnseen_whenAllSelectedAreSeen() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(
+                listOf(
+                    createDownload(id = 1L, title = "Seen", seen = true),
+                    createDownload(id = 2L, title = "Seen 2", seen = true),
+                )
+            ),
+            updateFlow = MutableStateFlow(null),
+        )
 
-            val collector = backgroundScope.launch {
-                viewModel.uiState.collect()
-            }
-            waitForUiState(viewModel) { it is DownloadsUiState.Data }
-
-            viewModel.toggleDownloadsSeen(setOf(1L, 2L))
-            advanceUntilIdle()
-
-            verify(updateDownloadsSeenUseCase).invoke(setOf(1L, 2L), false)
-            verify(clearNotificationsByDownloadIdUseCase, never()).invoke(1L)
-            verify(clearNotificationsByDownloadIdUseCase, never()).invoke(2L)
-            collector.cancel()
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
         }
+        waitForUiState(viewModel) { it is DownloadsUiState.Data }
+
+        viewModel.toggleDownloadsSeen(setOf(1L, 2L))
+        advanceUntilIdle()
+
+        verify(updateDownloadsSeenUseCase)
+            .invoke(setOf(1L, 2L), false)
+        verify(clearNotificationsByDownloadIdUseCase, never())
+            .invoke(1L)
+        verify(clearNotificationsByDownloadIdUseCase, never())
+            .invoke(2L)
+        collector.cancel()
+    }
 
     @Test
-    fun markDownloadsPendingDelete_marksIds_andRequestsDelayedDeleteWorker() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(
-                downloadsFlow = MutableStateFlow(emptyList()),
-                updateFlow = MutableStateFlow(null),
-            )
-            val ids = setOf(7L)
+    fun markDownloadsPendingDelete_marksIds_andRequestsDelayedWorker() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(emptyList()),
+            updateFlow = MutableStateFlow(null),
+        )
+        val ids = setOf(7L)
 
-            viewModel.markDownloadsPendingDelete(ids)
-            advanceUntilIdle()
+        viewModel.markDownloadsPendingDelete(ids)
+        advanceUntilIdle()
 
-            verify(updateDownloadsPendingDeleteUseCase).invoke(ids, true)
-            verify(requestDeletePendingDownloadsDelayedUseCase).invoke()
-        }
+        verify(updateDownloadsPendingDeleteUseCase)
+            .invoke(ids, true)
+        verify(requestDeletePendingDownloadsDelayedUseCase)
+            .invoke()
+    }
 
     @Test
-    fun markDownloadsPendingDelete_false_doesNotRequestDelayedDeleteWorker() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(
-                downloadsFlow = MutableStateFlow(emptyList()),
-                updateFlow = MutableStateFlow(null),
-            )
-            val ids = setOf(7L)
+    fun markDownloadsPendingDelete_false_skipsDelayedWorker() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(emptyList()),
+            updateFlow = MutableStateFlow(null),
+        )
+        val ids = setOf(7L)
 
-            viewModel.markDownloadsPendingDelete(ids, pendingDelete = false)
-            advanceUntilIdle()
+        viewModel.markDownloadsPendingDelete(ids, pendingDelete = false)
+        advanceUntilIdle()
 
-            verify(updateDownloadsPendingDeleteUseCase).invoke(ids, false)
-            verify(requestDeletePendingDownloadsDelayedUseCase, never()).invoke()
-        }
+        verify(updateDownloadsPendingDeleteUseCase)
+            .invoke(ids, false)
+        verify(requestDeletePendingDownloadsDelayedUseCase, never())
+            .invoke()
+    }
 
     @Test
     fun requestDeletePendingDownloadsImmediate_requestsImmediateWorker() = runTest(testDispatcher) {
@@ -456,7 +477,8 @@ class DownloadsViewModelTest {
         viewModel.requestDeletePendingDownloadsImmediate()
         advanceUntilIdle()
 
-        verify(requestDeletePendingDownloadsImmediateUseCase).invoke()
+        verify(requestDeletePendingDownloadsImmediateUseCase)
+            .invoke()
     }
 
     @Test
@@ -521,6 +543,12 @@ class DownloadsViewModelTest {
         assertNull(emittedEvent)
         eventCollector.cancel()
         collector.cancel()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun createViewModel(

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
@@ -71,11 +71,6 @@ class SettingsViewModelTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun uiState_exposesMappedSettings() = runTest(testDispatcher) {
@@ -107,7 +102,8 @@ class SettingsViewModelTest {
 
         viewModel.logShown()
 
-        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.SETTINGS)
+        verify(analyticsLogger)
+            .logScreen(AnalyticsEvents.Screens.SETTINGS)
     }
 
     @Test
@@ -120,26 +116,35 @@ class SettingsViewModelTest {
         viewModel.setDownloadWifiOnly(true)
         advanceUntilIdle()
 
-        verify(saveDownloadWifiOnlySettingUseCase).invoke(true)
-        verify(applyWifiOnlyPolicyUseCase).invoke(true)
+        verify(saveDownloadWifiOnlySettingUseCase)
+            .invoke(true)
+        verify(applyWifiOnlyPolicyUseCase)
+            .invoke(true)
     }
 
     @Test
-    fun setAutomaticDuplicateDownloadDeletion_savesSetting_andAppliesPolicy() =
-        runTest(testDispatcher) {
-            val viewModel = createViewModel(
-                downloadWifiOnlyFlow = MutableStateFlow(false),
-                automaticDeletionFlow = MutableStateFlow(false),
-            )
+    fun setAutomaticDuplicateDownloadDeletion_savesAndApplies() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadWifiOnlyFlow = MutableStateFlow(false),
+            automaticDeletionFlow = MutableStateFlow(false),
+        )
 
-            viewModel.setAutomaticDuplicateDownloadDeletion(true)
-            advanceUntilIdle()
+        viewModel.setAutomaticDuplicateDownloadDeletion(true)
+        advanceUntilIdle()
 
-            verify(saveAutomaticDuplicateDownloadDeletionSettingUseCase).invoke(true)
-            verify(applyAutomaticDuplicateDownloadDeletionSettingUseCase).invoke(
+        verify(saveAutomaticDuplicateDownloadDeletionSettingUseCase)
+            .invoke(true)
+        verify(applyAutomaticDuplicateDownloadDeletionSettingUseCase)
+            .invoke(
                 automaticDuplicateDownloadDeletion = true,
             )
-        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
+    }
 
     private fun createViewModel(
         downloadWifiOnlyFlow: MutableStateFlow<Boolean>,

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
@@ -66,11 +66,6 @@ class UpdatesViewModelTest {
         Dispatchers.setMain(testDispatcher)
     }
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        autoCloseable.close()
-    }
 
     @Test
     fun uiState_exposesMappedSettingsAndInfo() = runTest(testDispatcher) {
@@ -110,7 +105,14 @@ class UpdatesViewModelTest {
 
         viewModel.logShown()
 
-        verify(analyticsLogger).logScreen(AnalyticsEvents.Screens.UPDATES)
+        verify(analyticsLogger)
+            .logScreen(AnalyticsEvents.Screens.UPDATES)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        autoCloseable.close()
     }
 
     private fun createViewModel(


### PR DESCRIPTION
- Replace direct `YoutubeDL` usage with `YoutubeDlClient` in `DownloadWithProgressUseCase`
- Add `YoutubeDlClient` abstraction for `execute` and `destroyProcessById`
- Replace direct `DownloadWorker` calls with `DownloadWorkScheduler`
- Inject `DownloadWorkScheduler` into `StartDownloadUseCase` and `ApplyWifiOnlyPolicyUseCase`
- Remove `withContext(Dispatchers.IO)` usage from use cases
- Update tests to use new abstractions and improve formatting
- Add tests for `StartDownloadUseCase`, `ApplyWifiOnlyPolicyUseCase`, and delete-related use cases
- Add tests for `DownloadWithProgressUseCase` using fake `YoutubeDlClient`