### PR TITLE
feat: Add configurable swipe actions for downloads

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -21,12 +21,16 @@ object Constants {
     object Settings {
         const val KEY_DOWNLOAD_WIFI_ONLY = "download_wifi_only"
         const val DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY = true
+        const val KEY_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION = "auto_duplicate_download_deletion"
+        const val DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION = true
+        const val KEY_LEFT_SWIPE_ACTION = "left_swipe_action"
+        const val DEFAULT_VALUE_LEFT_SWIPE_ACTION = "archive"
+        const val KEY_RIGHT_SWIPE_ACTION = "right_swipe_action"
+        const val DEFAULT_VALUE_RIGHT_SWIPE_ACTION = "delete"
         const val KEY_AUTOMATIC_UPDATES = "auto_updates"
         const val DEFAULT_VALUE_AUTOMATIC_UPDATES = true
         const val KEY_AUTOMATIC_DEPENDENCY_UPDATES = "auto_dependency_updates"
         const val DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES = true
-        const val KEY_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION = "auto_duplicate_download_deletion"
-        const val DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION = true
     }
 
     object Notifications {

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImpl.kt
@@ -4,16 +4,22 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_LEFT_SWIPE_ACTION
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_RIGHT_SWIPE_ACTION
 import org.strigate.ferrot.app.Constants.Settings.KEY_AUTOMATIC_DEPENDENCY_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.KEY_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
 import org.strigate.ferrot.app.Constants.Settings.KEY_AUTOMATIC_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.KEY_DOWNLOAD_WIFI_ONLY
+import org.strigate.ferrot.app.Constants.Settings.KEY_LEFT_SWIPE_ACTION
+import org.strigate.ferrot.app.Constants.Settings.KEY_RIGHT_SWIPE_ACTION
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 import org.strigate.ferrot.domain.repository.SettingsRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,12 +30,16 @@ class SettingsRepositoryImpl @Inject constructor(
 ) : SettingsRepository {
     private val downloadWifiOnlyKey =
         booleanPreferencesKey(KEY_DOWNLOAD_WIFI_ONLY)
+    private val automaticDuplicateDownloadDeletionKey =
+        booleanPreferencesKey(KEY_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION)
+    private val leftSwipeActionKey =
+        stringPreferencesKey(KEY_LEFT_SWIPE_ACTION)
+    private val rightSwipeActionKey =
+        stringPreferencesKey(KEY_RIGHT_SWIPE_ACTION)
     private val automaticUpdatesKey =
         booleanPreferencesKey(KEY_AUTOMATIC_UPDATES)
     private val automaticDependencyUpdatesKey =
         booleanPreferencesKey(KEY_AUTOMATIC_DEPENDENCY_UPDATES)
-    private val automaticDuplicateDownloadDeletionKey =
-        booleanPreferencesKey(KEY_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION)
 
     override suspend fun saveDownloadWifiOnly(enabled: Boolean) {
         preferencesDataStore.edit {
@@ -40,6 +50,49 @@ class SettingsRepositoryImpl @Inject constructor(
     override fun getDownloadWifiOnlyAsFlow(): Flow<Boolean> {
         return preferencesDataStore.data.map {
             it[downloadWifiOnlyKey] ?: DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY
+        }
+    }
+
+    override suspend fun saveAutomaticDuplicateDownloadDeletion(enabled: Boolean) {
+        preferencesDataStore.edit {
+            it[automaticDuplicateDownloadDeletionKey] = enabled
+        }
+    }
+
+    override fun getAutomaticDuplicateDownloadDeletionAsFlow(): Flow<Boolean> {
+        return preferencesDataStore.data.map {
+            it[automaticDuplicateDownloadDeletionKey]
+                ?: DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
+        }
+    }
+
+    override suspend fun saveLeftSwipeAction(action: DownloadSwipeAction) {
+        preferencesDataStore.edit {
+            it[leftSwipeActionKey] = action.storageValue
+        }
+    }
+
+    override fun getLeftSwipeActionAsFlow(): Flow<DownloadSwipeAction> {
+        return preferencesDataStore.data.map {
+            DownloadSwipeAction.fromStorageValue(
+                value = it[leftSwipeActionKey] ?: DEFAULT_VALUE_LEFT_SWIPE_ACTION,
+                defaultAction = DownloadSwipeAction.ARCHIVE,
+            )
+        }
+    }
+
+    override suspend fun saveRightSwipeAction(action: DownloadSwipeAction) {
+        preferencesDataStore.edit {
+            it[rightSwipeActionKey] = action.storageValue
+        }
+    }
+
+    override fun getRightSwipeActionAsFlow(): Flow<DownloadSwipeAction> {
+        return preferencesDataStore.data.map {
+            DownloadSwipeAction.fromStorageValue(
+                value = it[rightSwipeActionKey] ?: DEFAULT_VALUE_RIGHT_SWIPE_ACTION,
+                defaultAction = DownloadSwipeAction.DELETE,
+            )
         }
     }
 
@@ -64,19 +117,6 @@ class SettingsRepositoryImpl @Inject constructor(
     override fun getAutomaticDependencyUpdatesAsFlow(): Flow<Boolean> {
         return preferencesDataStore.data.map {
             it[automaticDependencyUpdatesKey] ?: DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES
-        }
-    }
-
-    override suspend fun saveAutomaticDuplicateDownloadDeletion(enabled: Boolean) {
-        preferencesDataStore.edit {
-            it[automaticDuplicateDownloadDeletionKey] = enabled
-        }
-    }
-
-    override fun getAutomaticDuplicateDownloadDeletionAsFlow(): Flow<Boolean> {
-        return preferencesDataStore.data.map {
-            it[automaticDuplicateDownloadDeletionKey]
-                ?: DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
         }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadSwipeAction.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadSwipeAction.kt
@@ -1,0 +1,21 @@
+package org.strigate.ferrot.domain.model
+
+enum class DownloadSwipeAction(
+    val storageValue: String,
+) {
+    NONE("none"),
+    ARCHIVE("archive"),
+    SEEN("seen"),
+    DELETE("delete");
+
+    companion object {
+        fun fromStorageValue(
+            value: String?,
+            defaultAction: DownloadSwipeAction = DEFAULT,
+        ): DownloadSwipeAction {
+            return entries.firstOrNull { it.storageValue == value } ?: defaultAction
+        }
+
+        val DEFAULT = ARCHIVE
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/repository/SettingsRepository.kt
@@ -1,14 +1,19 @@
 package org.strigate.ferrot.domain.repository
 
 import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 
 interface SettingsRepository {
     suspend fun saveDownloadWifiOnly(enabled: Boolean)
     fun getDownloadWifiOnlyAsFlow(): Flow<Boolean>
+    suspend fun saveAutomaticDuplicateDownloadDeletion(enabled: Boolean)
+    fun getAutomaticDuplicateDownloadDeletionAsFlow(): Flow<Boolean>
+    suspend fun saveLeftSwipeAction(action: DownloadSwipeAction)
+    fun getLeftSwipeActionAsFlow(): Flow<DownloadSwipeAction>
+    suspend fun saveRightSwipeAction(action: DownloadSwipeAction)
+    fun getRightSwipeActionAsFlow(): Flow<DownloadSwipeAction>
     suspend fun saveAutomaticUpdates(enabled: Boolean)
     fun getAutomaticUpdatesAsFlow(): Flow<Boolean>
     suspend fun saveAutomaticDependencyUpdates(enabled: Boolean)
     fun getAutomaticDependencyUpdatesAsFlow(): Flow<Boolean>
-    suspend fun saveAutomaticDuplicateDownloadDeletion(enabled: Boolean)
-    fun getAutomaticDuplicateDownloadDeletionAsFlow(): Flow<Boolean>
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/SettingsUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/SettingsUseCase.kt
@@ -4,19 +4,27 @@ import org.strigate.ferrot.domain.usecase.settings.GetAutomaticDependencyUpdates
 import org.strigate.ferrot.domain.usecase.settings.GetAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetAutomaticUpdatesSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetLeftSwipeActionSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetRightSwipeActionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticDependencyUpdatesSettingUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticDuplicateDownloadDeletionSettingUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticUpdatesSettingUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveDownloadWifiOnlySettingUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveLeftSwipeActionSettingUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveRightSwipeActionSettingUseCase
 import javax.inject.Inject
 
 class SettingsUseCase @Inject constructor(
     val saveDownloadWifiOnlySettingUseCase: SaveDownloadWifiOnlySettingUseCase,
     val getDownloadWifiOnlySettingAsFlowUseCase: GetDownloadWifiOnlySettingAsFlowUseCase,
+    val saveAutomaticDuplicateDownloadDeletionSettingUseCase: SaveAutomaticDuplicateDownloadDeletionSettingUseCase,
+    val getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase: GetAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase,
+    val saveLeftSwipeActionSettingUseCase: SaveLeftSwipeActionSettingUseCase,
+    val getLeftSwipeActionSettingAsFlowUseCase: GetLeftSwipeActionSettingAsFlowUseCase,
+    val saveRightSwipeActionSettingUseCase: SaveRightSwipeActionSettingUseCase,
+    val getRightSwipeActionSettingAsFlowUseCase: GetRightSwipeActionSettingAsFlowUseCase,
     val saveAutomaticUpdatesSettingUseCase: SaveAutomaticUpdatesSettingUseCase,
     val getAutomaticUpdatesSettingAsFlowUseCase: GetAutomaticUpdatesSettingAsFlowUseCase,
     val saveAutomaticDependencyUpdatesSettingUseCase: SaveAutomaticDependencyUpdatesSettingUseCase,
     val getAutomaticDependencyUpdatesSettingAsFlowUseCase: GetAutomaticDependencyUpdatesSettingAsFlowUseCase,
-    val saveAutomaticDuplicateDownloadDeletionSettingUseCase: SaveAutomaticDuplicateDownloadDeletionSettingUseCase,
-    val getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase: GetAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetLeftSwipeActionSettingAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetLeftSwipeActionSettingAsFlowUseCase.kt
@@ -1,0 +1,14 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class GetLeftSwipeActionSettingAsFlowUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    operator fun invoke(): Flow<DownloadSwipeAction> {
+        return settingsRepository.getLeftSwipeActionAsFlow()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetRightSwipeActionSettingAsFlowUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/GetRightSwipeActionSettingAsFlowUseCase.kt
@@ -1,0 +1,14 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import kotlinx.coroutines.flow.Flow
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class GetRightSwipeActionSettingAsFlowUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    operator fun invoke(): Flow<DownloadSwipeAction> {
+        return settingsRepository.getRightSwipeActionAsFlow()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveLeftSwipeActionSettingUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveLeftSwipeActionSettingUseCase.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class SaveLeftSwipeActionSettingUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(action: DownloadSwipeAction) {
+        settingsRepository.saveLeftSwipeAction(action)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveRightSwipeActionSettingUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/settings/SaveRightSwipeActionSettingUseCase.kt
@@ -1,0 +1,13 @@
+package org.strigate.ferrot.domain.usecase.settings
+
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
+import org.strigate.ferrot.domain.repository.SettingsRepository
+import javax.inject.Inject
+
+class SaveRightSwipeActionSettingUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+) {
+    suspend operator fun invoke(action: DownloadSwipeAction) {
+        settingsRepository.saveRightSwipeAction(action)
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DropdownMenu.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DropdownMenu.kt
@@ -1,0 +1,38 @@
+package org.strigate.ferrot.presentation.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.material3.DropdownMenu as MaterialDropdownMenu
+
+@Composable
+fun DropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    items: List<DropdownMenuItem>,
+    offset: DpOffset = DpOffset.Zero,
+) {
+    MaterialDropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        offset = offset,
+    ) {
+        items.forEach { item ->
+            androidx.compose.material3.DropdownMenuItem(
+                text = {
+                    Text(item.text)
+                },
+                onClick = {
+                    onDismissRequest()
+                    item.onClick()
+                },
+            )
+        }
+    }
+}
+
+data class DropdownMenuItem(
+    val id: String,
+    val text: String,
+    val onClick: () -> Unit,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/DropdownSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/DropdownSetting.kt
@@ -1,0 +1,153 @@
+package org.strigate.ferrot.presentation.component.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import org.strigate.ferrot.presentation.component.DropdownMenu
+import org.strigate.ferrot.presentation.component.DropdownMenuItem
+
+data class DropdownSettingOption(
+    val id: String,
+    val text: String,
+)
+
+@Composable
+fun DropdownSetting(
+    text: String,
+    selectedText: String,
+    options: List<DropdownSettingOption>,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    onOptionSelected: (DropdownSettingOption) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val chipColor = MaterialTheme.colorScheme.surface
+    val chipTextColor = MaterialTheme.colorScheme.onSurface
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    interactionSource = interactionSource,
+                    indication = ripple(),
+                    onClick = {
+                        expanded = true
+                    },
+                )
+                .padding(
+                    horizontal = 16.dp,
+                    vertical = 12.dp,
+                ),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 24.dp),
+                ) {
+                    Text(
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = text,
+                    )
+                    description?.let {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            text = it,
+                        )
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier,
+                        contentAlignment = Alignment.TopEnd,
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(999.dp))
+                                .background(chipColor)
+                                .padding(
+                                    start = 12.dp,
+                                    end = 8.dp,
+                                    top = 6.dp,
+                                    bottom = 6.dp,
+                                ),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = selectedText,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = chipTextColor,
+                            )
+                            Icon(
+                                modifier = Modifier
+                                    .padding(start = 4.dp)
+                                    .size(20.dp),
+                                imageVector = Icons.Filled.ArrowDropDown,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                contentDescription = null,
+                            )
+                        }
+
+                        DropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = {
+                                expanded = false
+                            },
+                            items = options.map { option ->
+                                DropdownMenuItem(
+                                    id = option.id,
+                                    text = option.text,
+                                    onClick = {
+                                        onOptionSelected(option)
+                                    },
+                                )
+                            },
+                            offset = DpOffset(x = 0.dp, y = 4.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadSwipeActionUiMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadSwipeActionUiMappers.kt
@@ -1,0 +1,18 @@
+package org.strigate.ferrot.presentation.mapper
+
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
+
+fun DownloadSwipeAction.toUiData(): DownloadSwipeActionUiData = when (this) {
+    DownloadSwipeAction.NONE -> DownloadSwipeActionUiData.NONE
+    DownloadSwipeAction.ARCHIVE -> DownloadSwipeActionUiData.ARCHIVE
+    DownloadSwipeAction.SEEN -> DownloadSwipeActionUiData.SEEN
+    DownloadSwipeAction.DELETE -> DownloadSwipeActionUiData.DELETE
+}
+
+fun DownloadSwipeActionUiData.toDomain(): DownloadSwipeAction = when (this) {
+    DownloadSwipeActionUiData.NONE -> DownloadSwipeAction.NONE
+    DownloadSwipeActionUiData.ARCHIVE -> DownloadSwipeAction.ARCHIVE
+    DownloadSwipeActionUiData.SEEN -> DownloadSwipeAction.SEEN
+    DownloadSwipeActionUiData.DELETE -> DownloadSwipeAction.DELETE
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadSwipeActionUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadSwipeActionUiData.kt
@@ -1,0 +1,8 @@
+package org.strigate.ferrot.presentation.model
+
+enum class DownloadSwipeActionUiData {
+    NONE,
+    ARCHIVE,
+    SEEN,
+    DELETE,
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadsUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadsUiData.kt
@@ -4,4 +4,6 @@ data class DownloadsUiData(
     val downloads: List<DownloadItemUiData>,
     val availableUpdate: AvailableUpdateUiData?,
     val pendingDeleteIds: Set<Long>,
+    val leftSwipeAction: DownloadSwipeActionUiData,
+    val rightSwipeAction: DownloadSwipeActionUiData,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/SettingsUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/SettingsUiData.kt
@@ -3,4 +3,6 @@ package org.strigate.ferrot.presentation.model
 data class SettingsUiData(
     val downloadWifiOnly: Boolean,
     val automaticDuplicateDownloadDeletion: Boolean,
+    val leftSwipeAction: DownloadSwipeActionUiData,
+    val rightSwipeAction: DownloadSwipeActionUiData,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -52,6 +52,8 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.SwipeToDismissBoxValue.EndToStart
+import androidx.compose.material3.SwipeToDismissBoxValue.StartToEnd
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -61,6 +63,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -105,6 +108,7 @@ import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.event.DownloadsEvent
 import org.strigate.ferrot.presentation.model.DownloadItemUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.model.isActive
 import org.strigate.ferrot.presentation.model.isFailed
 import org.strigate.ferrot.presentation.state.DownloadsUiState
@@ -118,6 +122,8 @@ import kotlin.math.abs
 
 private const val SEARCH_FOCUS_DELAY_MILLIS = 357L
 private const val RETRY_FAILED_SCROLL_DELAY_MILLIS = 357L
+private const val SNAP_BACK_SWIPE_THRESHOLD_RATIO = 0.3f
+private const val DISMISS_SWIPE_THRESHOLD_RATIO = 0.5f
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -199,7 +205,7 @@ fun DownloadsScreen(
         viewModel.setArchived(archived)
     }
     LaunchedEffect(Unit) {
-        viewModel.events.collectLatest { event ->
+        viewModel.events.collect { event ->
             when (event) {
                 is DownloadsEvent.InstallUpdate -> {
                     InstallHelper.requestInstallApkIfExists(context, event.path)
@@ -616,6 +622,8 @@ fun DownloadsScreen(
                                 archivingIds = archivingIds,
                                 pendingDeleteIds = pendingDeleteIds,
                                 archived = isArchived,
+                                leftSwipeAction = leftSwipeAction,
+                                rightSwipeAction = rightSwipeAction,
                                 hasAvailableUpdateBanner = availableUpdate != null,
                                 searchQuery = searchQuery.text,
                                 lazyListState = lazyListState,
@@ -661,6 +669,9 @@ fun DownloadsScreen(
                                         downloadIds = setOf(itemId),
                                         archived = !isArchived,
                                     )
+                                },
+                                onToggleSeen = { itemId ->
+                                    viewModel.toggleDownloadsSeen(setOf(itemId))
                                 },
                                 onMarkPendingDelete = viewModel::markDownloadsPendingDelete,
                             )
@@ -734,6 +745,8 @@ private fun DownloadsList(
     archivingIds: Set<Long>,
     pendingDeleteIds: Set<Long>,
     archived: Boolean,
+    leftSwipeAction: DownloadSwipeActionUiData,
+    rightSwipeAction: DownloadSwipeActionUiData,
     hasAvailableUpdateBanner: Boolean,
     searchQuery: String,
     lazyListState: LazyListState,
@@ -742,18 +755,19 @@ private fun DownloadsList(
     onSelectionChange: (Set<Long>) -> Unit,
     onBulkDismissAnimationFinished: (Long) -> Unit,
     onBulkArchiveAnimationFinished: (Long) -> Unit,
+    onToggleSeen: (Long) -> Unit,
     onMarkPendingDelete: (Set<Long>) -> Unit,
 ) {
     val dimens = LocalDimens.current
+
     val coroutineScope = rememberCoroutineScope()
-    val itemIds = remember(items) { items.map(DownloadItemUiData::id) }
+    val itemIds = remember(items) {
+        items.map(DownloadItemUiData::id)
+    }
     val animatingOutIds = remember { mutableStateMapOf<Long, Boolean>() }
-    var trackedAutoScrollDownloadId by remember {
-        mutableStateOf<Long?>(null)
-    }
-    var trackedAutoScrollWasActive by remember {
-        mutableStateOf(false)
-    }
+    val swipeActionIds = remember { mutableStateMapOf<Long, DownloadSwipeActionUiData>() }
+    var trackedAutoScrollDownloadId by remember { mutableStateOf<Long?>(null) }
+    var trackedAutoScrollWasActive by remember { mutableStateOf(false) }
 
     val showScrollToBottom by remember {
         derivedStateOf {
@@ -763,12 +777,8 @@ private fun DownloadsList(
             !atBottom && (lazyListState.firstVisibleItemIndex > 0 || lazyListState.firstVisibleItemScrollOffset > 0)
         }
     }
-    var previousItemIds by remember {
-        mutableStateOf<List<Long>>(emptyList())
-    }
-    var previousPendingDeleteIds by remember {
-        mutableStateOf<Set<Long>>(emptySet())
-    }
+    var previousItemIds by remember { mutableStateOf<List<Long>>(emptyList()) }
+    var previousPendingDeleteIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
     val restoringItemIds = getRestoredItemIds(
         previousPendingDeleteIds = previousPendingDeleteIds,
         currentItemIds = itemIds,
@@ -886,14 +896,28 @@ private fun DownloadsList(
                     onSelectionChange = onSelectionChange,
                     isPendingDismiss = animatingOutIds[item.id] == true
                             || item.id in dismissingIds
-                            || item.id in archivingIds,
-                    onSwipeActionPerformed = { itemId ->
-                        animatingOutIds[itemId] = true
-                        onSelectionChange(selectedIds - itemId)
+                            || item.id in archivingIds
+                            || item.id in swipeActionIds,
+                    archived = archived,
+                    seen = item.seen,
+                    leftSwipeAction = leftSwipeAction,
+                    rightSwipeAction = rightSwipeAction,
+                    onSwipeActionPerformed = { itemId, action ->
+                        if (action == DownloadSwipeActionUiData.SEEN) {
+                            onToggleSeen(itemId)
+                        } else {
+                            animatingOutIds[itemId] = true
+                            swipeActionIds[itemId] = action
+                            onSelectionChange(selectedIds - itemId)
+                        }
                     },
                     onDismissAnimationFinished = { itemId ->
-                        if (animatingOutIds.remove(itemId) == true) {
+                        val swipeAction = swipeActionIds.remove(itemId)
+                        if (animatingOutIds.remove(itemId) == true && swipeAction == DownloadSwipeActionUiData.DELETE) {
                             onMarkPendingDelete(setOf(itemId))
+                        }
+                        if (swipeAction == DownloadSwipeActionUiData.ARCHIVE) {
+                            onBulkArchiveAnimationFinished(itemId)
                         }
                         if (itemId in dismissingIds) {
                             onBulkDismissAnimationFinished(itemId)
@@ -929,17 +953,41 @@ private fun DownloadsListRow(
     selectedIds: Set<Long>,
     isPendingDismiss: Boolean,
     isRestoring: Boolean,
+    archived: Boolean,
+    seen: Boolean,
+    leftSwipeAction: DownloadSwipeActionUiData,
+    rightSwipeAction: DownloadSwipeActionUiData,
     onItemClick: (DownloadItemUiData) -> Unit,
     onPauseResume: (DownloadItemUiData) -> Unit,
     onSelectionChange: (Set<Long>) -> Unit,
-    onSwipeActionPerformed: (Long) -> Unit,
+    onSwipeActionPerformed: (Long, DownloadSwipeActionUiData) -> Unit,
     onDismissAnimationFinished: (Long) -> Unit,
 ) {
-    val dimens = LocalDimens.current
-
+    val coroutineScope = rememberCoroutineScope()
     val swipeEnabled = selectedIds.isEmpty()
+            && (leftSwipeAction != DownloadSwipeActionUiData.NONE || rightSwipeAction != DownloadSwipeActionUiData.NONE)
+
+    val longClickEnabled = selectedIds.isEmpty()
     val isSelected = selectedIds.contains(item.id)
-    val dismissState = rememberSwipeToDismissBoxState()
+    var currentSwipeThresholdRatio by remember(
+        item.id,
+        leftSwipeAction,
+        rightSwipeAction,
+    ) {
+        mutableFloatStateOf(DISMISS_SWIPE_THRESHOLD_RATIO)
+    }
+
+    var hasHandledCurrentSwipe by remember(item.id) { mutableStateOf(false) }
+    var pendingSnapBackSwipeAction by remember(item.id) {
+        mutableStateOf<DownloadSwipeActionUiData?>(null)
+    }
+    val dismissState = key(item.id, leftSwipeAction, rightSwipeAction) {
+        rememberSwipeToDismissBoxState(
+            positionalThreshold = { totalDistance ->
+                totalDistance * currentSwipeThresholdRatio
+            },
+        )
+    }
     var rowWidthPx by remember { mutableFloatStateOf(0f) }
     val visibilityState = remember(item.id) {
         MutableTransitionState(!isRestoring)
@@ -966,6 +1014,22 @@ private fun DownloadsListRow(
             onDismissAnimationFinished(item.id)
         }
     }
+    LaunchedEffect(isPendingDismiss) {
+        if (!isPendingDismiss) {
+            hasHandledCurrentSwipe = false
+        }
+    }
+    LaunchedEffect(dismissState, leftSwipeAction, rightSwipeAction) {
+        snapshotFlow { runCatching { dismissState.requireOffset() }.getOrDefault(0f) }
+            .distinctUntilChanged()
+            .collectLatest { offsetPx ->
+                currentSwipeThresholdRatio = getSwipeThresholdRatio(
+                    offsetPx = offsetPx,
+                    leftSwipeAction = leftSwipeAction,
+                    rightSwipeAction = rightSwipeAction,
+                )
+            }
+    }
 
     AnimatedVisibility(
         visibleState = visibilityState,
@@ -981,33 +1045,46 @@ private fun DownloadsListRow(
         ) {
             SwipeToDismissBox(
                 state = dismissState,
-                enableDismissFromStartToEnd = false,
-                enableDismissFromEndToStart = swipeEnabled,
-                backgroundContent = {
-                    Surface(
-                        color = MaterialTheme.colorScheme.errorContainer,
-                        shape = MaterialTheme.shapes.medium,
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize(),
-                            contentAlignment = Alignment.CenterEnd,
-                        ) {
-                            Icon(
-                                modifier = Modifier
-                                    .padding(end = dimens.spacingMedium),
-                                imageVector = Icons.Filled.Delete,
-                                tint = MaterialTheme.colorScheme.onErrorContainer,
-                                contentDescription = null,
-                            )
-                        }
+                enableDismissFromStartToEnd = swipeEnabled && rightSwipeAction != DownloadSwipeActionUiData.NONE,
+                enableDismissFromEndToStart = swipeEnabled && leftSwipeAction != DownloadSwipeActionUiData.NONE,
+                onDismiss = { dismissValue ->
+                    if (hasHandledCurrentSwipe) {
+                        return@SwipeToDismissBox
                     }
+                    val swipeAction = getSwipeActionForDismissValue(
+                        dismissValue = dismissValue,
+                        leftSwipeAction = leftSwipeAction,
+                        rightSwipeAction = rightSwipeAction,
+                    )
+                    if (swipeAction == DownloadSwipeActionUiData.NONE) {
+                        return@SwipeToDismissBox
+                    }
+                    hasHandledCurrentSwipe = true
+                    if (isSnapBackSwipeAction(swipeAction)) {
+                        pendingSnapBackSwipeAction = swipeAction
+                        coroutineScope.launch {
+                            runCatching {
+                                dismissState.reset()
+                            }
+                        }
+                    } else {
+                        onSwipeActionPerformed(item.id, swipeAction)
+                    }
+                },
+                backgroundContent = {
+                    SwipeActionBackground(
+                        archived = archived,
+                        seen = seen,
+                        leftSwipeAction = leftSwipeAction,
+                        rightSwipeAction = rightSwipeAction,
+                        offsetPx = runCatching { dismissState.requireOffset() }.getOrDefault(0f),
+                    )
                 },
             ) {
                 DownloadItem(
                     item = item,
                     isSelected = isSelected,
-                    longClickEnabled = swipeEnabled,
+                    longClickEnabled = longClickEnabled,
                     onClick = {
                         if (selectedIds.isNotEmpty()) {
                             onSelectionChange(toggleSelection(selectedIds, item.id))
@@ -1033,7 +1110,7 @@ private fun DownloadsListRow(
         }
     }
 
-    LaunchedEffect(dismissState) {
+    LaunchedEffect(dismissState, leftSwipeAction, rightSwipeAction) {
         snapshotFlow {
             Pair(
                 dismissState.currentValue,
@@ -1042,13 +1119,163 @@ private fun DownloadsListRow(
         }
             .distinctUntilChanged()
             .collectLatest { (value, offsetPx) ->
-                val fullyAtEnd = value == SwipeToDismissBoxValue.EndToStart &&
-                        rowWidthPx > 0f &&
-                        abs(offsetPx) >= (rowWidthPx - 1f)
-                if (fullyAtEnd) {
-                    onSwipeActionPerformed(item.id)
+                if (value == SwipeToDismissBoxValue.Settled && abs(offsetPx) < 1f) {
+                    pendingSnapBackSwipeAction?.let { swipeAction ->
+                        pendingSnapBackSwipeAction = null
+                        onSwipeActionPerformed(item.id, swipeAction)
+                    }
+                    hasHandledCurrentSwipe = false
                 }
             }
+    }
+    LaunchedEffect(dismissState, rowWidthPx, leftSwipeAction, rightSwipeAction) {
+        snapshotFlow { runCatching { dismissState.requireOffset() }.getOrDefault(0f) }
+            .distinctUntilChanged()
+            .collectLatest { offsetPx ->
+                if (rowWidthPx <= 0f || hasHandledCurrentSwipe || pendingSnapBackSwipeAction != null) {
+                    return@collectLatest
+                }
+                val swipeAction = when {
+                    offsetPx > 0f -> rightSwipeAction
+                    offsetPx < 0f -> leftSwipeAction
+                    else -> DownloadSwipeActionUiData.NONE
+                }
+                if (!isSnapBackSwipeAction(swipeAction)) {
+                    return@collectLatest
+                }
+                val triggerDistancePx = rowWidthPx * SNAP_BACK_SWIPE_THRESHOLD_RATIO
+                if (abs(offsetPx) < triggerDistancePx) {
+                    return@collectLatest
+                }
+                hasHandledCurrentSwipe = true
+                pendingSnapBackSwipeAction = swipeAction
+                coroutineScope.launch {
+                    runCatching {
+                        dismissState.reset()
+                    }
+                }
+            }
+    }
+
+}
+
+private fun isSnapBackSwipeAction(
+    swipeAction: DownloadSwipeActionUiData,
+): Boolean {
+    return swipeAction == DownloadSwipeActionUiData.SEEN
+}
+
+private fun getSwipeThresholdRatio(
+    offsetPx: Float,
+    leftSwipeAction: DownloadSwipeActionUiData,
+    rightSwipeAction: DownloadSwipeActionUiData,
+): Float {
+    val swipeAction = when {
+        offsetPx > 0f -> rightSwipeAction
+        offsetPx < 0f -> leftSwipeAction
+        else -> DownloadSwipeActionUiData.NONE
+    }
+    return if (isSnapBackSwipeAction(swipeAction)) {
+        SNAP_BACK_SWIPE_THRESHOLD_RATIO
+    } else {
+        DISMISS_SWIPE_THRESHOLD_RATIO
+    }
+}
+
+@Composable
+private fun SwipeActionBackground(
+    archived: Boolean,
+    seen: Boolean,
+    leftSwipeAction: DownloadSwipeActionUiData,
+    rightSwipeAction: DownloadSwipeActionUiData,
+    offsetPx: Float,
+) {
+    val dimens = LocalDimens.current
+    val swipeAction = when {
+        offsetPx > 0f -> rightSwipeAction
+        offsetPx < 0f -> leftSwipeAction
+        else -> DownloadSwipeActionUiData.NONE
+    }
+    val isEndToStart = offsetPx < 0f
+    val containerColor = when (swipeAction) {
+        DownloadSwipeActionUiData.DELETE -> MaterialTheme.colorScheme.errorContainer
+        DownloadSwipeActionUiData.ARCHIVE -> MaterialTheme.colorScheme.secondaryContainer
+        DownloadSwipeActionUiData.SEEN -> MaterialTheme.colorScheme.tertiaryContainer
+        DownloadSwipeActionUiData.NONE -> Color.Transparent
+    }
+    val contentColor = when (swipeAction) {
+        DownloadSwipeActionUiData.DELETE -> MaterialTheme.colorScheme.onErrorContainer
+        DownloadSwipeActionUiData.ARCHIVE -> MaterialTheme.colorScheme.onSecondaryContainer
+        DownloadSwipeActionUiData.SEEN -> MaterialTheme.colorScheme.onTertiaryContainer
+        DownloadSwipeActionUiData.NONE -> Color.Transparent
+    }
+    Surface(
+        color = containerColor,
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = if (isEndToStart) {
+                Alignment.CenterEnd
+            } else {
+                Alignment.CenterStart
+            },
+        ) {
+            Icon(
+                modifier = Modifier
+                    .padding(
+                        start = if (isEndToStart) dimens.zero else dimens.spacingMedium,
+                        end = if (isEndToStart) dimens.spacingMedium else dimens.zero,
+                    ),
+                imageVector = getSwipeActionIcon(
+                    action = swipeAction,
+                    archived = archived,
+                    seen = seen,
+                ),
+                tint = contentColor,
+                contentDescription = null,
+            )
+        }
+    }
+}
+
+private fun getSwipeActionIcon(
+    action: DownloadSwipeActionUiData,
+    archived: Boolean,
+    seen: Boolean,
+): ImageVector {
+    return when (action) {
+        DownloadSwipeActionUiData.NONE -> Icons.Filled.MoreVert
+        DownloadSwipeActionUiData.ARCHIVE -> {
+            if (archived) {
+                Icons.Filled.Unarchive
+            } else {
+                Icons.Filled.Archive
+            }
+        }
+
+        DownloadSwipeActionUiData.SEEN -> {
+            if (seen) {
+                Icons.Filled.VisibilityOff
+            } else {
+                Icons.Filled.Visibility
+            }
+        }
+
+        DownloadSwipeActionUiData.DELETE -> Icons.Filled.Delete
+    }
+}
+
+private fun getSwipeActionForDismissValue(
+    dismissValue: SwipeToDismissBoxValue,
+    leftSwipeAction: DownloadSwipeActionUiData,
+    rightSwipeAction: DownloadSwipeActionUiData,
+): DownloadSwipeActionUiData {
+    return when (dismissValue) {
+        StartToEnd -> rightSwipeAction
+        EndToStart -> leftSwipeAction
+        SwipeToDismissBoxValue.Settled -> DownloadSwipeActionUiData.NONE
     }
 }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -29,11 +29,14 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.Screen
+import org.strigate.ferrot.presentation.component.settings.DropdownSetting
+import org.strigate.ferrot.presentation.component.settings.DropdownSettingOption
 import org.strigate.ferrot.presentation.component.settings.ExpandableSettingsSection
 import org.strigate.ferrot.presentation.component.settings.SwitchSetting
 import org.strigate.ferrot.presentation.component.settings.TextNavigateSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import org.strigate.ferrot.presentation.theme.FerrotTopAppBarDefaults
 import org.strigate.ferrot.presentation.theme.LocalDimens
@@ -49,6 +52,38 @@ fun SettingsScreen(
     val dimens = LocalDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
+
+    val noneSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_none)
+    val archiveSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_archive)
+    val seenSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_seen)
+    val deleteSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_delete)
+    val swipeActionLabel: (DownloadSwipeActionUiData) -> String = { action ->
+        when (action) {
+            DownloadSwipeActionUiData.NONE -> noneSwipeActionLabel
+            DownloadSwipeActionUiData.ARCHIVE -> archiveSwipeActionLabel
+            DownloadSwipeActionUiData.SEEN -> seenSwipeActionLabel
+            DownloadSwipeActionUiData.DELETE -> deleteSwipeActionLabel
+        }
+    }
+
+    val swipeActionOptions = listOf(
+        DropdownSettingOption(
+            id = DownloadSwipeActionUiData.NONE.name,
+            text = noneSwipeActionLabel,
+        ),
+        DropdownSettingOption(
+            id = DownloadSwipeActionUiData.ARCHIVE.name,
+            text = archiveSwipeActionLabel,
+        ),
+        DropdownSettingOption(
+            id = DownloadSwipeActionUiData.SEEN.name,
+            text = seenSwipeActionLabel,
+        ),
+        DropdownSettingOption(
+            id = DownloadSwipeActionUiData.DELETE.name,
+            text = deleteSwipeActionLabel,
+        ),
+    )
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -118,6 +153,34 @@ fun SettingsScreen(
                                         checked = automaticDuplicateDownloadDeletion,
                                         onCheckedChange = { checked ->
                                             viewModel.setAutomaticDuplicateDownloadDeletion(checked)
+                                        },
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                ExpandableSettingsSection(
+                                    text = stringResource(id = R.string.settings_section_swipe_actions),
+                                    initialExpanded = true,
+                                ) {
+                                    DropdownSetting(
+                                        text = stringResource(R.string.settings_title_swipe_left),
+                                        description = stringResource(R.string.settings_description_swipe_left),
+                                        selectedText = swipeActionLabel(leftSwipeAction),
+                                        options = swipeActionOptions,
+                                        onOptionSelected = { option ->
+                                            viewModel.setLeftSwipeAction(
+                                                DownloadSwipeActionUiData.valueOf(option.id),
+                                            )
+                                        },
+                                    )
+                                    DropdownSetting(
+                                        text = stringResource(R.string.settings_title_swipe_right),
+                                        description = stringResource(R.string.settings_description_swipe_right),
+                                        selectedText = swipeActionLabel(rightSwipeAction),
+                                        options = swipeActionOptions,
+                                        onOptionSelected = { option ->
+                                            viewModel.setRightSwipeAction(
+                                                DownloadSwipeActionUiData.valueOf(option.id),
+                                            )
                                         },
                                     )
                                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -28,6 +28,7 @@ import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
@@ -53,6 +54,7 @@ class DownloadsViewModel @Inject constructor(
     private val downloadProgressUseCase: DownloadProgressUseCase,
     private val downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
+    private val settingsUseCase: SettingsUseCase,
 ) : ViewModel() {
     private val _archived = MutableStateFlow(savedStateHandle[Screen.ARG_ARCHIVED] ?: false)
     val isArchived: StateFlow<Boolean> = _archived
@@ -81,13 +83,23 @@ class DownloadsViewModel @Inject constructor(
                 downloadWithMetadataUseCase.getDownloadsWithMetadataAsFlowUseCase(archived = archived)
             }
         val availableUpdateFlow = availableUpdateUseCase.getAvailableUpdateAsFlowUseCase()
+        val leftSwipeActionFlow = settingsUseCase.getLeftSwipeActionSettingAsFlowUseCase()
+        val rightSwipeActionFlow = settingsUseCase.getRightSwipeActionSettingAsFlowUseCase()
+        val swipeActionsFlow = combine(
+            leftSwipeActionFlow,
+            rightSwipeActionFlow,
+        ) { leftSwipeAction, rightSwipeAction ->
+            leftSwipeAction.toUiData() to rightSwipeAction.toUiData()
+        }
 
         return combine(
             archivedFlow,
             downloadsWithMetadataFlow,
             availableUpdateFlow,
             searchTextFlow,
-        ) { archived, downloadsWithMetadata, availableUpdate, query ->
+            swipeActionsFlow,
+        ) { archived, downloadsWithMetadata, availableUpdate, query, swipeActions ->
+            val (leftSwipeAction, rightSwipeAction) = swipeActions
             val pendingDeleteIds = downloadsWithMetadata
                 .asSequence()
                 .filter { it.pendingDelete }
@@ -117,6 +129,8 @@ class DownloadsViewModel @Inject constructor(
                     downloads = filteredDownloads,
                     availableUpdate = availableUpdateUiData,
                     pendingDeleteIds = pendingDeleteIds,
+                    leftSwipeAction = leftSwipeAction,
+                    rightSwipeAction = rightSwipeAction,
                 ),
             )
         }.flowOn(Dispatchers.Default)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModel.kt
@@ -13,6 +13,9 @@ import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.ApplyUseCase
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.presentation.mapper.toDomain
+import org.strigate.ferrot.presentation.mapper.toUiData
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.model.SettingsUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import javax.inject.Inject
@@ -33,11 +36,15 @@ class SettingsViewModel @Inject constructor(
         return combine(
             settingsUseCase.getDownloadWifiOnlySettingAsFlowUseCase(),
             settingsUseCase.getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase(),
-        ) { downloadWifiOnly, automaticDuplicateDownloadDeletion ->
+            settingsUseCase.getLeftSwipeActionSettingAsFlowUseCase(),
+            settingsUseCase.getRightSwipeActionSettingAsFlowUseCase(),
+        ) { downloadWifiOnly, automaticDuplicateDownloadDeletion, leftSwipeAction, rightSwipeAction ->
             SettingsUiState.Data(
                 SettingsUiData(
                     downloadWifiOnly = downloadWifiOnly,
                     automaticDuplicateDownloadDeletion = automaticDuplicateDownloadDeletion,
+                    leftSwipeAction = leftSwipeAction.toUiData(),
+                    rightSwipeAction = rightSwipeAction.toUiData(),
                 )
             )
         }
@@ -58,6 +65,18 @@ class SettingsViewModel @Inject constructor(
             applyUseCase.applyAutomaticDuplicateDownloadDeletionSettingUseCase(
                 automaticDuplicateDownloadDeletion = enabled,
             )
+        }
+    }
+
+    fun setLeftSwipeAction(action: DownloadSwipeActionUiData) {
+        viewModelScope.launch {
+            settingsUseCase.saveLeftSwipeActionSettingUseCase(action.toDomain())
+        }
+    }
+
+    fun setRightSwipeAction(action: DownloadSwipeActionUiData) {
+        viewModelScope.launch {
+            settingsUseCase.saveRightSwipeActionSettingUseCase(action.toDomain())
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="toast_no_dependency_updates_available">No dependency updates available</string>
 
     <string name="settings_section_general">General</string>
+    <string name="settings_section_swipe_actions">Swipe actions</string>
     <string name="settings_section_app_info">App info</string>
     <string name="settings_section_app">App</string>
     <string name="settings_section_dependencies">Dependencies</string>
@@ -105,6 +106,8 @@
 
     <string name="settings_title_download_wifi_only">Download over Wi-Fi only</string>
     <string name="settings_title_automatic_duplicate_deletion">Automatically delete duplicate downloads</string>
+    <string name="settings_title_swipe_left">Swipe left</string>
+    <string name="settings_title_swipe_right">Swipe right</string>
     <string name="settings_title_automatic_app_updates">Automatic app updates</string>
     <string name="settings_title_check_for_app_updates">Check for app updates</string>
     <string name="settings_title_last_checked_for_app_updates">Last checked for app updates</string>
@@ -118,12 +121,19 @@
 
     <string name="settings_description_download_wifi_only">Restrict downloads to Wi-Fi connections only</string>
     <string name="settings_description_automatic_duplicate_deletion">Automatically delete older downloads when an exact duplicate is found.</string>
+    <string name="settings_description_swipe_left">Select the left swipe action</string>
+    <string name="settings_description_swipe_right">Select the right swipe action</string>
     <string name="settings_description_automatic_updates">Automatically check for and download app updates, and notify when ready to install</string>
     <string name="settings_description_check_for_app_updates">Check for app updates now</string>
     <string name="settings_description_automatic_dependency_updates">Automatically download and apply updates for dependencies</string>
     <string name="settings_description_check_dependencies_now">Check for dependency updates now</string>
     <string name="settings_description_privacy">View Privacy Policy</string>
     <string name="settings_description_license">GNU General Public License v3.0</string>
+
+    <string name="settings_value_swipe_action_none">None</string>
+    <string name="settings_value_swipe_action_archive">Archive</string>
+    <string name="settings_value_swipe_action_seen">Mark seen</string>
+    <string name="settings_value_swipe_action_delete">Delete</string>
 
     <string name="error_failed_to_load_downloads">Failed to load downloads</string>
     <string name="error_failed_to_load_download">Failed to load download</string>

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
@@ -1,6 +1,8 @@
 package org.strigate.ferrot.data.repository
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -18,6 +20,11 @@ import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DEPEND
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_DOWNLOAD_WIFI_ONLY
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_LEFT_SWIPE_ACTION
+import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_RIGHT_SWIPE_ACTION
+import org.strigate.ferrot.app.Constants.Settings.KEY_LEFT_SWIPE_ACTION
+import org.strigate.ferrot.app.Constants.Settings.KEY_RIGHT_SWIPE_ACTION
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -50,6 +57,14 @@ class SettingsRepositoryImplTest {
             DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION,
             repository.getAutomaticDuplicateDownloadDeletionAsFlow().first(),
         )
+        assertEquals(
+            DownloadSwipeAction.fromStorageValue(DEFAULT_VALUE_LEFT_SWIPE_ACTION),
+            repository.getLeftSwipeActionAsFlow().first(),
+        )
+        assertEquals(
+            DownloadSwipeAction.fromStorageValue(DEFAULT_VALUE_RIGHT_SWIPE_ACTION),
+            repository.getRightSwipeActionAsFlow().first(),
+        )
     }
 
     @Test
@@ -60,11 +75,37 @@ class SettingsRepositoryImplTest {
         repository.saveAutomaticUpdates(false)
         repository.saveAutomaticDependencyUpdates(false)
         repository.saveAutomaticDuplicateDownloadDeletion(false)
+        repository.saveLeftSwipeAction(DownloadSwipeAction.NONE)
+        repository.saveRightSwipeAction(DownloadSwipeAction.ARCHIVE)
 
         assertEquals(false, repository.getDownloadWifiOnlyAsFlow().first())
         assertEquals(false, repository.getAutomaticUpdatesAsFlow().first())
         assertEquals(false, repository.getAutomaticDependencyUpdatesAsFlow().first())
         assertEquals(false, repository.getAutomaticDuplicateDownloadDeletionAsFlow().first())
+        assertEquals(DownloadSwipeAction.NONE, repository.getLeftSwipeActionAsFlow().first())
+        assertEquals(
+            DownloadSwipeAction.ARCHIVE,
+            repository.getRightSwipeActionAsFlow().first()
+        )
+    }
+
+    @Test
+    fun swipeGetters_useSideDefaults_forInvalidValue() = runTest(testDispatcher) {
+        val tempFile =
+            Files.createTempFile("settings-repository-invalid-swipe-test", ".preferences_pb")
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { tempFile.toFile() },
+        )
+        val repository = SettingsRepositoryImpl(dataStore)
+
+        dataStore.edit {
+            it[stringPreferencesKey(KEY_LEFT_SWIPE_ACTION)] = "wat"
+            it[stringPreferencesKey(KEY_RIGHT_SWIPE_ACTION)] = "broken"
+        }
+
+        assertEquals(DownloadSwipeAction.ARCHIVE, repository.getLeftSwipeActionAsFlow().first())
+        assertEquals(DownloadSwipeAction.DELETE, repository.getRightSwipeActionAsFlow().first())
     }
 
     @After

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadSwipeActionUiMappersTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadSwipeActionUiMappersTest.kt
@@ -1,0 +1,28 @@
+package org.strigate.ferrot.presentation.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
+
+class DownloadSwipeActionUiMappersTest {
+    @Test
+    fun toUiData_mapsEveryDomainSwipeAction() {
+        val mapped = DownloadSwipeAction.entries.associateWith { it.toUiData() }
+
+        assertEquals(DownloadSwipeActionUiData.NONE, mapped[DownloadSwipeAction.NONE])
+        assertEquals(DownloadSwipeActionUiData.ARCHIVE, mapped[DownloadSwipeAction.ARCHIVE])
+        assertEquals(DownloadSwipeActionUiData.SEEN, mapped[DownloadSwipeAction.SEEN])
+        assertEquals(DownloadSwipeActionUiData.DELETE, mapped[DownloadSwipeAction.DELETE])
+    }
+
+    @Test
+    fun toDomain_mapsEveryUiSwipeAction() {
+        val mapped = DownloadSwipeActionUiData.entries.associateWith { it.toDomain() }
+
+        assertEquals(DownloadSwipeAction.NONE, mapped[DownloadSwipeActionUiData.NONE])
+        assertEquals(DownloadSwipeAction.ARCHIVE, mapped[DownloadSwipeActionUiData.ARCHIVE])
+        assertEquals(DownloadSwipeAction.SEEN, mapped[DownloadSwipeActionUiData.SEEN])
+        assertEquals(DownloadSwipeAction.DELETE, mapped[DownloadSwipeActionUiData.DELETE])
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -31,12 +31,14 @@ import org.mockito.MockitoAnnotations
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.AvailableUpdate
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.model.DownloadWithMetadata
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.availableupdate.GetAvailableUpdateAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeletePendingDownloadsDelayedUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestDeletePendingDownloadsImmediateUseCase
@@ -45,10 +47,13 @@ import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsPendingDeleteUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetLeftSwipeActionSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetRightSwipeActionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadprogress.UpdateDownloadProgressUseCase
 import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.event.DownloadsEvent
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import kotlin.time.Duration.Companion.seconds
 
@@ -105,6 +110,15 @@ class DownloadsViewModelTest {
     @Mock
     private lateinit var clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase
 
+    @Mock
+    private lateinit var settingsUseCase: SettingsUseCase
+
+    @Mock
+    private lateinit var getLeftSwipeActionSettingAsFlowUseCase: GetLeftSwipeActionSettingAsFlowUseCase
+
+    @Mock
+    private lateinit var getRightSwipeActionSettingAsFlowUseCase: GetRightSwipeActionSettingAsFlowUseCase
+
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
@@ -145,6 +159,8 @@ class DownloadsViewModelTest {
         assertEquals("v1.2.3", state.data.availableUpdate?.tag)
         assertEquals("/tmp/update.apk", state.data.availableUpdate?.localFilePath)
         assertTrue(state.data.pendingDeleteIds.isEmpty())
+        assertEquals(DownloadSwipeActionUiData.ARCHIVE, state.data.leftSwipeAction)
+        assertEquals(DownloadSwipeActionUiData.DELETE, state.data.rightSwipeAction)
 
         collector.cancel()
     }
@@ -575,6 +591,14 @@ class DownloadsViewModelTest {
             .thenReturn(updateDownloadsPendingDeleteUseCase)
         `when`(downloadProgressUseCase.updateDownloadProgressUseCase)
             .thenReturn(updateDownloadProgressUseCase)
+        `when`(getLeftSwipeActionSettingAsFlowUseCase.invoke())
+            .thenReturn(MutableStateFlow(DownloadSwipeAction.ARCHIVE))
+        `when`(getRightSwipeActionSettingAsFlowUseCase.invoke())
+            .thenReturn(MutableStateFlow(DownloadSwipeAction.DELETE))
+        `when`(settingsUseCase.getLeftSwipeActionSettingAsFlowUseCase)
+            .thenReturn(getLeftSwipeActionSettingAsFlowUseCase)
+        `when`(settingsUseCase.getRightSwipeActionSettingAsFlowUseCase)
+            .thenReturn(getRightSwipeActionSettingAsFlowUseCase)
 
         return DownloadsViewModel(
             savedStateHandle = SavedStateHandle(),
@@ -586,6 +610,7 @@ class DownloadsViewModelTest {
             downloadProgressUseCase = downloadProgressUseCase,
             downloadWithMetadataUseCase = downloadWithMetadataUseCase,
             clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
+            settingsUseCase = settingsUseCase,
         )
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
@@ -22,14 +22,20 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 import org.strigate.ferrot.domain.usecase.ApplyUseCase
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
 import org.strigate.ferrot.domain.usecase.apply.ApplyAutomaticDuplicateDownloadDeletionSettingUseCase
 import org.strigate.ferrot.domain.usecase.apply.ApplyWifiOnlyPolicyUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetLeftSwipeActionSettingAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.settings.GetRightSwipeActionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveAutomaticDuplicateDownloadDeletionSettingUseCase
 import org.strigate.ferrot.domain.usecase.settings.SaveDownloadWifiOnlySettingUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveLeftSwipeActionSettingUseCase
+import org.strigate.ferrot.domain.usecase.settings.SaveRightSwipeActionSettingUseCase
+import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import kotlin.time.Duration.Companion.seconds
 
@@ -65,6 +71,18 @@ class SettingsViewModelTest {
     @Mock
     private lateinit var applyAutomaticDuplicateDownloadDeletionSettingUseCase: ApplyAutomaticDuplicateDownloadDeletionSettingUseCase
 
+    @Mock
+    private lateinit var getLeftSwipeActionSettingAsFlowUseCase: GetLeftSwipeActionSettingAsFlowUseCase
+
+    @Mock
+    private lateinit var getRightSwipeActionSettingAsFlowUseCase: GetRightSwipeActionSettingAsFlowUseCase
+
+    @Mock
+    private lateinit var saveLeftSwipeActionSettingUseCase: SaveLeftSwipeActionSettingUseCase
+
+    @Mock
+    private lateinit var saveRightSwipeActionSettingUseCase: SaveRightSwipeActionSettingUseCase
+
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
@@ -76,9 +94,13 @@ class SettingsViewModelTest {
     fun uiState_exposesMappedSettings() = runTest(testDispatcher) {
         val downloadWifiOnlyFlow = MutableStateFlow(true)
         val automaticDeletionFlow = MutableStateFlow(false)
+        val leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.ARCHIVE)
+        val rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.DELETE)
         val viewModel = createViewModel(
             downloadWifiOnlyFlow = downloadWifiOnlyFlow,
             automaticDeletionFlow = automaticDeletionFlow,
+            leftSwipeActionFlow = leftSwipeActionFlow,
+            rightSwipeActionFlow = rightSwipeActionFlow,
         )
 
         val collector = backgroundScope.launch {
@@ -89,6 +111,8 @@ class SettingsViewModelTest {
         val state = viewModel.uiState.value as SettingsUiState.Data
         assertEquals(true, state.data.downloadWifiOnly)
         assertEquals(false, state.data.automaticDuplicateDownloadDeletion)
+        assertEquals(DownloadSwipeActionUiData.ARCHIVE, state.data.leftSwipeAction)
+        assertEquals(DownloadSwipeActionUiData.DELETE, state.data.rightSwipeAction)
 
         collector.cancel()
     }
@@ -98,6 +122,8 @@ class SettingsViewModelTest {
         val viewModel = createViewModel(
             downloadWifiOnlyFlow = MutableStateFlow(false),
             automaticDeletionFlow = MutableStateFlow(false),
+            leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.ARCHIVE),
+            rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.DELETE),
         )
 
         viewModel.logShown()
@@ -111,6 +137,8 @@ class SettingsViewModelTest {
         val viewModel = createViewModel(
             downloadWifiOnlyFlow = MutableStateFlow(false),
             automaticDeletionFlow = MutableStateFlow(false),
+            leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.ARCHIVE),
+            rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.DELETE),
         )
 
         viewModel.setDownloadWifiOnly(true)
@@ -127,6 +155,8 @@ class SettingsViewModelTest {
         val viewModel = createViewModel(
             downloadWifiOnlyFlow = MutableStateFlow(false),
             automaticDeletionFlow = MutableStateFlow(false),
+            leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.ARCHIVE),
+            rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.DELETE),
         )
 
         viewModel.setAutomaticDuplicateDownloadDeletion(true)
@@ -140,6 +170,38 @@ class SettingsViewModelTest {
             )
     }
 
+    @Test
+    fun setLeftSwipeAction_savesSetting() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadWifiOnlyFlow = MutableStateFlow(false),
+            automaticDeletionFlow = MutableStateFlow(false),
+            leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.ARCHIVE),
+            rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.DELETE),
+        )
+
+        viewModel.setLeftSwipeAction(DownloadSwipeActionUiData.NONE)
+        advanceUntilIdle()
+
+        verify(saveLeftSwipeActionSettingUseCase)
+            .invoke(DownloadSwipeAction.NONE)
+    }
+
+    @Test
+    fun setRightSwipeAction_savesSetting() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadWifiOnlyFlow = MutableStateFlow(false),
+            automaticDeletionFlow = MutableStateFlow(false),
+            leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.ARCHIVE),
+            rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.DELETE),
+        )
+
+        viewModel.setRightSwipeAction(DownloadSwipeActionUiData.ARCHIVE)
+        advanceUntilIdle()
+
+        verify(saveRightSwipeActionSettingUseCase)
+            .invoke(DownloadSwipeAction.ARCHIVE)
+    }
+
     @After
     fun tearDown() {
         Dispatchers.resetMain()
@@ -149,19 +211,33 @@ class SettingsViewModelTest {
     private fun createViewModel(
         downloadWifiOnlyFlow: MutableStateFlow<Boolean>,
         automaticDeletionFlow: MutableStateFlow<Boolean>,
+        leftSwipeActionFlow: MutableStateFlow<DownloadSwipeAction>,
+        rightSwipeActionFlow: MutableStateFlow<DownloadSwipeAction>,
     ): SettingsViewModel {
         `when`(getDownloadWifiOnlySettingAsFlowUseCase.invoke())
             .thenReturn(downloadWifiOnlyFlow)
         `when`(getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase.invoke())
             .thenReturn(automaticDeletionFlow)
+        `when`(getLeftSwipeActionSettingAsFlowUseCase.invoke())
+            .thenReturn(leftSwipeActionFlow)
+        `when`(getRightSwipeActionSettingAsFlowUseCase.invoke())
+            .thenReturn(rightSwipeActionFlow)
         `when`(settingsUseCase.getDownloadWifiOnlySettingAsFlowUseCase)
             .thenReturn(getDownloadWifiOnlySettingAsFlowUseCase)
         `when`(settingsUseCase.getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase)
             .thenReturn(getAutomaticDuplicateDownloadDeletionSettingAsFlowUseCase)
+        `when`(settingsUseCase.getLeftSwipeActionSettingAsFlowUseCase)
+            .thenReturn(getLeftSwipeActionSettingAsFlowUseCase)
+        `when`(settingsUseCase.getRightSwipeActionSettingAsFlowUseCase)
+            .thenReturn(getRightSwipeActionSettingAsFlowUseCase)
         `when`(settingsUseCase.saveDownloadWifiOnlySettingUseCase)
             .thenReturn(saveDownloadWifiOnlySettingUseCase)
         `when`(settingsUseCase.saveAutomaticDuplicateDownloadDeletionSettingUseCase)
             .thenReturn(saveAutomaticDuplicateDownloadDeletionSettingUseCase)
+        `when`(settingsUseCase.saveLeftSwipeActionSettingUseCase)
+            .thenReturn(saveLeftSwipeActionSettingUseCase)
+        `when`(settingsUseCase.saveRightSwipeActionSettingUseCase)
+            .thenReturn(saveRightSwipeActionSettingUseCase)
         `when`(applyUseCase.applyWifiOnlyPolicyUseCase)
             .thenReturn(applyWifiOnlyPolicyUseCase)
         `when`(applyUseCase.applyAutomaticDuplicateDownloadDeletionSettingUseCase)


### PR DESCRIPTION
- Add `DownloadSwipeAction` domain model with storage mapping
- Add `DownloadSwipeActionUiData` and mapping extensions
- Add `leftSwipeAction` and `rightSwipeAction` to `DownloadsUiData`
- Inject `SettingsUseCase` into `DownloadsViewModel`
- Combine swipe action flows into downloads UI state
- Add swipe handling logic with snap-back support in `DownloadsScreen`
- Add `SwipeActionBackground` and dynamic icon rendering
- Support `SEEN`, `ARCHIVE`, and `DELETE` swipe behaviors
- Add threshold logic via `getSwipeThresholdRatio` and constants
- Add settings keys `KEY_LEFT_SWIPE_ACTION` and `KEY_RIGHT_SWIPE_ACTION`
- Persist swipe actions in `SettingsRepositoryImpl`
- Add `GetLeftSwipeActionSettingAsFlowUseCase` and `GetRightSwipeActionSettingAsFlowUseCase`
- Add `SaveLeftSwipeActionSettingUseCase` and `SaveRightSwipeActionSettingUseCase`
- Extend `SettingsUseCase` with swipe action use cases
- Update `SettingsViewModel` to expose and save swipe actions
- Extend `SettingsUiData` with swipe actions
- Add swipe action dropdowns in `SettingsScreen`
- Add `DropdownSetting` and `DropdownMenu` components
- Add string resources for swipe actions and labels
- Update tests for repository, viewmodels, and mappers
- Ensure invalid stored values fall back to defaults