### PR TITLE
feat: Add tests for download update use cases

### DIFF
--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/UpdateDownloadsArchivedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/UpdateDownloadsArchivedUseCaseTest.kt
@@ -1,0 +1,61 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.domain.repository.DownloadRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateDownloadsArchivedUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+
+    @Mock
+    private lateinit var downloadRepository: DownloadRepository
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun invoke_updatesRepository_whenIdsArePresent() = runTest {
+        val useCase = UpdateDownloadsArchivedUseCase(downloadRepository)
+        val downloadIds = setOf(1L, 2L, 3L)
+
+        useCase(downloadIds, archived = false)
+
+        verify(downloadRepository)
+            .updateArchivedByIds(downloadIds, false)
+    }
+
+    @Test
+    fun invoke_usesArchivedTrueByDefault() = runTest {
+        val useCase = UpdateDownloadsArchivedUseCase(downloadRepository)
+        val downloadIds = setOf(4L)
+
+        useCase(downloadIds)
+
+        verify(downloadRepository)
+            .updateArchivedByIds(downloadIds, true)
+    }
+
+    @Test
+    fun invoke_doesNothing_whenIdsAreEmpty() = runTest {
+        val useCase = UpdateDownloadsArchivedUseCase(downloadRepository)
+
+        useCase(emptySet())
+
+        verifyNoInteractions(downloadRepository)
+    }
+
+    @After
+    fun tearDown() {
+        autoCloseable.close()
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/UpdateDownloadsPendingDeleteUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/UpdateDownloadsPendingDeleteUseCaseTest.kt
@@ -1,0 +1,61 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.domain.repository.DownloadRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateDownloadsPendingDeleteUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+
+    @Mock
+    private lateinit var downloadRepository: DownloadRepository
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun invoke_updatesRepository_whenIdsArePresent() = runTest {
+        val useCase = UpdateDownloadsPendingDeleteUseCase(downloadRepository)
+        val downloadIds = setOf(1L, 2L, 3L)
+
+        useCase(downloadIds, pendingDelete = false)
+
+        verify(downloadRepository)
+            .updatePendingDeleteByIds(downloadIds, false)
+    }
+
+    @Test
+    fun invoke_usesPendingDeleteTrueByDefault() = runTest {
+        val useCase = UpdateDownloadsPendingDeleteUseCase(downloadRepository)
+        val downloadIds = setOf(4L)
+
+        useCase(downloadIds)
+
+        verify(downloadRepository)
+            .updatePendingDeleteByIds(downloadIds, true)
+    }
+
+    @Test
+    fun invoke_doesNothing_whenIdsAreEmpty() = runTest {
+        val useCase = UpdateDownloadsPendingDeleteUseCase(downloadRepository)
+
+        useCase(emptySet())
+
+        verifyNoInteractions(downloadRepository)
+    }
+
+    @After
+    fun tearDown() {
+        autoCloseable.close()
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/UpdateDownloadsSeenUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/UpdateDownloadsSeenUseCaseTest.kt
@@ -1,0 +1,61 @@
+package org.strigate.ferrot.domain.usecase.download
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.domain.repository.DownloadRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UpdateDownloadsSeenUseCaseTest {
+    private lateinit var autoCloseable: AutoCloseable
+
+    @Mock
+    private lateinit var downloadRepository: DownloadRepository
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun invoke_updatesRepository_whenIdsArePresent() = runTest {
+        val useCase = UpdateDownloadsSeenUseCase(downloadRepository)
+        val downloadIds = setOf(1L, 2L, 3L)
+
+        useCase(downloadIds, seen = false)
+
+        verify(downloadRepository)
+            .updateSeenByIds(downloadIds, false)
+    }
+
+    @Test
+    fun invoke_usesSeenTrueByDefault() = runTest {
+        val useCase = UpdateDownloadsSeenUseCase(downloadRepository)
+        val downloadIds = setOf(4L)
+
+        useCase(downloadIds)
+
+        verify(downloadRepository)
+            .updateSeenByIds(downloadIds, true)
+    }
+
+    @Test
+    fun invoke_doesNothing_whenIdsAreEmpty() = runTest {
+        val useCase = UpdateDownloadsSeenUseCase(downloadRepository)
+
+        useCase(emptySet())
+
+        verifyNoInteractions(downloadRepository)
+    }
+
+    @After
+    fun tearDown() {
+        autoCloseable.close()
+    }
+}


### PR DESCRIPTION
- Add `UpdateDownloadsSeenUseCaseTest` covering `updateSeenByIds`, default `seen`, and empty input handling
- Add `UpdateDownloadsPendingDeleteUseCaseTest` covering `updatePendingDeleteByIds`, default `pendingDelete`, and empty input handling
- Add `UpdateDownloadsArchivedUseCaseTest` covering `updateArchivedByIds`, default `archived`, and empty input handling
- Verify repository interactions using `verify` and `verifyNoInteractions`