### PR TITLE
feat: Add download retry analytics events

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/analytics/AnalyticsEvents.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/analytics/AnalyticsEvents.kt
@@ -4,6 +4,8 @@ object AnalyticsEvents {
     const val DOWNLOAD_STARTED = "download_started"
     const val DOWNLOAD_COMPLETED = "download_completed"
     const val DOWNLOAD_FAILED = "download_failed"
+    const val DOWNLOAD_RETRY = "download_retry"
+    const val DOWNLOADS_RETRY = "downloads_retry"
 
     object Screens {
         const val DOWNLOADS = "downloads_screen"

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -278,6 +278,7 @@ class DownloadViewModel @Inject constructor(
 
     fun retryDownload(id: Long? = null) = viewModelScope.launch {
         val downloadId = id ?: _selectedId.value
+        analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_RETRY)
         startDownloadUseCase(downloadId)
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -180,6 +180,7 @@ class DownloadsViewModel @Inject constructor(
     }
 
     fun retryDownload(downloadId: Long) = viewModelScope.launch {
+        analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_RETRY)
         startDownloadUseCase(downloadId)
     }
 
@@ -195,6 +196,7 @@ class DownloadsViewModel @Inject constructor(
             return
         }
         viewModelScope.launch {
+            analyticsLogger.logEvent(AnalyticsEvents.DOWNLOADS_RETRY)
             failedDownloadIds.forEach { downloadId ->
                 startDownloadUseCase(downloadId)
             }

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -27,6 +27,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -453,6 +454,8 @@ class DownloadViewModelTest {
         viewModel.retryDownload()
         advanceUntilIdle()
 
+        verify(analyticsLogger, times(2))
+            .logEvent(AnalyticsEvents.DOWNLOAD_RETRY)
         verify(startDownloadUseCase)
             .invoke(88L)
         verify(startDownloadUseCase)

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
@@ -351,6 +352,8 @@ class DownloadsViewModelTest {
         viewModel.retryDownload(11L)
         advanceUntilIdle()
 
+        verify(analyticsLogger)
+            .logEvent(AnalyticsEvents.DOWNLOAD_RETRY)
         verify(startDownloadUseCase)
             .invoke(11L)
     }
@@ -377,6 +380,8 @@ class DownloadsViewModelTest {
         viewModel.retryFailedDownloads()
         advanceUntilIdle()
 
+        verify(analyticsLogger)
+            .logEvent(AnalyticsEvents.DOWNLOADS_RETRY)
         verify(startDownloadUseCase)
             .invoke(1L)
         verify(startDownloadUseCase)


### PR DESCRIPTION
- Add `DOWNLOAD_RETRY` and `DOWNLOADS_RETRY` to `AnalyticsEvents`
- Log `DOWNLOAD_RETRY` in `DownloadViewModel.retryDownload`
- Log `DOWNLOAD_RETRY` in `DownloadsViewModel.retryDownload`
- Log `DOWNLOADS_RETRY` in `DownloadsViewModel.retryFailedDownloads`
- Update `DownloadsViewModelTest` to verify `analyticsLogger.logEvent` calls
- Update `DownloadViewModelTest` to verify `analyticsLogger.logEvent` call count using `times`