### PR TITLE
feat: Add icons and header component for settings sections

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/ExpandableSettingsSection.kt
@@ -2,9 +2,7 @@ package org.strigate.ferrot.presentation.component.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -17,7 +15,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -25,14 +22,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun ExpandableSettingsSection(
-    text: String,
     modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    title: String? = null,
     initialExpanded: Boolean = false,
     content: @Composable () -> Unit,
 ) {
@@ -55,18 +53,13 @@ fun ExpandableSettingsSection(
                 }
                 .padding(vertical = 16.dp),
         ) {
-            Row(
+            SettingsSectionHeader(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
+                icon = icon,
+                title = title,
             ) {
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
                 Icon(
                     modifier = Modifier
                         .size(20.dp),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SettingsSectionHeader.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/SettingsSectionHeader.kt
@@ -1,0 +1,52 @@
+package org.strigate.ferrot.presentation.component.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun SettingsSectionHeader(
+    icon: ImageVector?,
+    title: String?,
+    modifier: Modifier = Modifier,
+    trailingContent: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (icon != null) {
+            Icon(
+                modifier = Modifier
+                    .size(20.dp),
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (icon != null && title != null) {
+            Spacer(modifier = Modifier.width(12.dp))
+        }
+        if (title != null) {
+            Text(
+                modifier = Modifier
+                    .weight(1f),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                text = title,
+            )
+        } else {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+        trailingContent?.invoke()
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/StaticSettingsSection.kt
@@ -8,16 +8,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun StaticSettingsSection(
     modifier: Modifier = Modifier,
-    text: String? = null,
+    icon: ImageVector? = null,
+    title: String? = null,
     content: @Composable () -> Unit,
 ) {
     Surface(
@@ -32,14 +33,13 @@ fun StaticSettingsSection(
                 .fillMaxWidth()
                 .padding(vertical = 16.dp),
         ) {
-            text?.let {
-                Text(
+            if (title != null || icon != null) {
+                SettingsSectionHeader(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    text = it,
+                    icon = icon,
+                    title = title,
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextNavigateSetting.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
@@ -21,12 +22,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun TextNavigateSetting(
     text: String,
     modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
     description: String? = null,
     onClick: () -> Unit,
 ) {
@@ -54,6 +57,16 @@ fun TextNavigateSetting(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
+                if (icon != null) {
+                    Icon(
+                        modifier = Modifier
+                            .size(20.dp),
+                        imageVector = icon,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        contentDescription = null,
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                }
                 Column(
                     modifier = Modifier
                         .weight(1f)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -112,7 +113,8 @@ fun AboutScreen(
                         .verticalScroll(rememberScrollState()),
                 ) {
                     StaticSettingsSection(
-                        text = stringResource(R.string.settings_section_app_info),
+                        icon = Icons.Outlined.Info,
+                        title = stringResource(R.string.settings_section_app_info),
                     ) {
                         TextSetting(
                             text = stringResource(R.string.settings_title_build),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -10,6 +10,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.SwapHoriz
+import androidx.compose.material.icons.outlined.SystemUpdate
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -135,7 +139,8 @@ fun SettingsScreen(
                                     .verticalScroll(rememberScrollState()),
                             ) {
                                 ExpandableSettingsSection(
-                                    text = stringResource(id = R.string.settings_section_general),
+                                    icon = Icons.Outlined.Tune,
+                                    title = stringResource(id = R.string.settings_section_general),
                                     initialExpanded = true,
                                 ) {
                                     SwitchSetting(
@@ -158,7 +163,8 @@ fun SettingsScreen(
                                 }
                                 Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 ExpandableSettingsSection(
-                                    text = stringResource(id = R.string.settings_section_swipe_actions),
+                                    icon = Icons.Outlined.SwapHoriz,
+                                    title = stringResource(id = R.string.settings_section_swipe_actions),
                                     initialExpanded = true,
                                 ) {
                                     DropdownSetting(
@@ -186,12 +192,14 @@ fun SettingsScreen(
                                 }
                                 Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 TextNavigateSetting(
+                                    icon = Icons.Outlined.SystemUpdate,
                                     text = stringResource(R.string.settings_navigate_title_updates),
                                 ) {
                                     navController.navigate(Screen.Updates.route)
                                 }
                                 Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 TextNavigateSetting(
+                                    icon = Icons.Outlined.Info,
                                     text = stringResource(R.string.settings_navigate_title_about),
                                 ) {
                                     navController.navigate(Screen.About.route)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Extension
+import androidx.compose.material.icons.outlined.SystemUpdate
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -109,7 +111,8 @@ fun UpdatesScreen(
                                     .verticalScroll(rememberScrollState()),
                             ) {
                                 StaticSettingsSection(
-                                    text = stringResource(R.string.settings_section_app),
+                                    icon = Icons.Outlined.SystemUpdate,
+                                    title = stringResource(R.string.settings_section_app),
                                 ) {
                                     SwitchSetting(
                                         text = stringResource(R.string.settings_title_automatic_app_updates),
@@ -135,7 +138,8 @@ fun UpdatesScreen(
                                 }
                                 Spacer(modifier = Modifier.height(dimens.spacingSmall))
                                 StaticSettingsSection(
-                                    text = stringResource(R.string.settings_section_dependencies),
+                                    icon = Icons.Outlined.Extension,
+                                    title = stringResource(R.string.settings_section_dependencies),
                                 ) {
                                     SwitchSetting(
                                         text = stringResource(R.string.settings_title_automatic_dependency_updates),


### PR DESCRIPTION
- Add `SettingsSectionHeader` composable with support for `icon`, `title`, and optional trailing content
- Update `StaticSettingsSection` to use `SettingsSectionHeader` instead of inline `Text`
- Update `ExpandableSettingsSection` to use `SettingsSectionHeader` and support `icon` and `title`
- Add optional `icon` parameter to `TextNavigateSetting` and render icon when provided
- Update `SettingsScreen` to pass icons to section headers and navigation items
- Update `UpdatesScreen` to use icons and `title` instead of `text` for sections
- Update `AboutScreen` to use icon-based section header
- Replace `text` parameter with `title` across settings section APIs