### PR TITLE
chore: Reuse `MainDispatcherRule` in unit tests

### DIFF
--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImplTest.kt
@@ -23,11 +23,11 @@ import org.strigate.ferrot.domain.model.AvailableUpdate
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AvailableUpdateRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var availableUpdateDao: AvailableUpdateDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/AvailableUpdateRepositoryImplTest.kt
@@ -1,23 +1,22 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.AvailableUpdateDao
 import org.strigate.ferrot.data.local.entity.AvailableUpdateEntity
 import org.strigate.ferrot.domain.model.AvailableUpdate
@@ -27,13 +26,15 @@ class AvailableUpdateRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var availableUpdateDao: AvailableUpdateDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
 
     @Test
@@ -106,7 +107,6 @@ class AvailableUpdateRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
@@ -23,11 +23,11 @@ import org.strigate.ferrot.domain.model.DownloadAudio
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadAudioRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadAudioDao: DownloadAudioDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadAudioRepositoryImplTest.kt
@@ -1,23 +1,22 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.DownloadAudioDao
 import org.strigate.ferrot.data.local.entity.DownloadAudioEntity
 import org.strigate.ferrot.domain.model.DownloadAudio
@@ -27,15 +26,16 @@ class DownloadAudioRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadAudioDao: DownloadAudioDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -88,7 +88,6 @@ class DownloadAudioRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
@@ -1,23 +1,22 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.DownloadMetadataDao
 import org.strigate.ferrot.data.local.entity.DownloadMetadataEntity
 import org.strigate.ferrot.domain.model.DownloadMetadata
@@ -27,15 +26,16 @@ class DownloadMetadataRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadMetadataDao: DownloadMetadataDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -97,7 +97,6 @@ class DownloadMetadataRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadMetadataRepositoryImplTest.kt
@@ -23,11 +23,11 @@ import org.strigate.ferrot.domain.model.DownloadMetadata
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadMetadataRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadMetadataDao: DownloadMetadataDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
@@ -26,11 +26,11 @@ import org.strigate.ferrot.domain.model.DownloadProgress
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadProgressRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadProgressDao: DownloadProgressDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadProgressRepositoryImplTest.kt
@@ -1,18 +1,16 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.eq
@@ -21,6 +19,7 @@ import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.DownloadProgressDao
 import org.strigate.ferrot.data.local.entity.DownloadProgressEntity
 import org.strigate.ferrot.domain.model.DownloadProgress
@@ -30,15 +29,16 @@ class DownloadProgressRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadProgressDao: DownloadProgressDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -103,7 +103,6 @@ class DownloadProgressRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
@@ -27,11 +27,11 @@ import org.strigate.ferrot.data.local.entity.DownloadStatus as EntityStatus
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadDao: DownloadDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
@@ -1,18 +1,16 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito
@@ -20,6 +18,7 @@ import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.DownloadDao
 import org.strigate.ferrot.data.local.entity.DownloadEntity
 import org.strigate.ferrot.domain.model.Download
@@ -31,15 +30,16 @@ class DownloadRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadDao: DownloadDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -187,7 +187,6 @@ class DownloadRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
@@ -1,23 +1,22 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.DownloadVideoDao
 import org.strigate.ferrot.data.local.entity.DownloadVideoEntity
 import org.strigate.ferrot.domain.model.DownloadVideo
@@ -27,15 +26,16 @@ class DownloadVideoRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadVideoDao: DownloadVideoDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun save_insertsMappedEntity() = runTest(testDispatcher) {
@@ -94,7 +94,6 @@ class DownloadVideoRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadVideoRepositoryImplTest.kt
@@ -23,11 +23,11 @@ import org.strigate.ferrot.domain.model.DownloadVideo
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadVideoRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadVideoDao: DownloadVideoDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
@@ -23,11 +23,11 @@ import org.strigate.ferrot.data.local.entity.DownloadStatus as EntityStatus
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadWithMetadataRepositoryImplTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadWithMetadataViewDao: DownloadWithMetadataViewDao

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadWithMetadataRepositoryImplTest.kt
@@ -1,21 +1,20 @@
 package org.strigate.ferrot.data.repository
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.data.local.dao.DownloadWithMetadataViewDao
 import org.strigate.ferrot.data.local.view.DownloadWithMetadataView
 import org.strigate.ferrot.domain.model.DownloadStatus
@@ -27,15 +26,16 @@ class DownloadWithMetadataRepositoryImplTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadWithMetadataViewDao: DownloadWithMetadataViewDao
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun getDownloadsWithMetadataAsFlow_mapsViewsToDomain() = runTest(testDispatcher) {
@@ -72,7 +72,6 @@ class DownloadWithMetadataRepositoryImplTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
@@ -4,18 +4,15 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DEPENDENCY_UPDATES
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION
 import org.strigate.ferrot.app.Constants.Settings.DEFAULT_VALUE_AUTOMATIC_UPDATES
@@ -31,11 +28,8 @@ import java.nio.file.Files
 class SettingsRepositoryImplTest {
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Test
     fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {
@@ -106,11 +100,6 @@ class SettingsRepositoryImplTest {
 
         assertEquals(DownloadSwipeAction.ARCHIVE, repository.getLeftSwipeActionAsFlow().first())
         assertEquals(DownloadSwipeAction.DELETE, repository.getRightSwipeActionAsFlow().first())
-    }
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
     }
 
     private fun createRepository(scope: CoroutineScope): SettingsRepositoryImpl {

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
@@ -26,10 +26,10 @@ import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsRepositoryImplTest {
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
 
     @Test
     fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
@@ -2,18 +2,15 @@ package org.strigate.ferrot.data.repository
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_BOOT_TIME_MILLIS
 import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_LAST_AVAILABLE_UPDATE_CHECK_MILLIS
 import org.strigate.ferrot.app.Constants.State.DEFAULT_VALUE_LAST_DEPENDENCY_UPDATE_CHECK_MILLIS
@@ -23,11 +20,8 @@ import java.nio.file.Files
 class StateRepositoryImplTest {
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
-
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Test
     fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {
@@ -58,11 +52,6 @@ class StateRepositoryImplTest {
         assertEquals(123L, repository.getBootTimeMillisAsFlow().first())
         assertEquals(456L, repository.getLastAvailableUpdateCheckMillisAsFlow().first())
         assertEquals(789L, repository.getLastDependencyUpdateCheckMillisAsFlow().first())
-    }
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
     }
 
     private fun createRepository(scope: CoroutineScope): StateRepositoryImpl {

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/StateRepositoryImplTest.kt
@@ -18,10 +18,10 @@ import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StateRepositoryImplTest {
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
 
     @Test
     fun getters_returnDefaultValues_whenNothingHasBeenSaved() = runTest(testDispatcher) {

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCaseTest.kt
@@ -28,11 +28,11 @@ import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ApplyWifiOnlyPolicyUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var appContext: Context

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCaseTest.kt
@@ -4,21 +4,20 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.integration.DownloadWorkScheduler
 import org.strigate.ferrot.domain.model.Download
 import org.strigate.ferrot.domain.model.DownloadStatus
@@ -31,6 +30,9 @@ import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
 class ApplyWifiOnlyPolicyUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var appContext: Context
@@ -62,7 +64,6 @@ class ApplyWifiOnlyPolicyUseCaseTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
 
         `when`(appContext.getSystemService(Context.CONNECTIVITY_SERVICE))
             .thenReturn(connectivityManager)
@@ -137,7 +138,6 @@ class ApplyWifiOnlyPolicyUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/availableupdate/ClearAvailableUpdateFilesAndDataUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/availableupdate/ClearAvailableUpdateFilesAndDataUseCaseTest.kt
@@ -1,20 +1,19 @@
 package org.strigate.ferrot.domain.usecase.availableupdate
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.provider.UpdatePathProvider
 import org.strigate.ferrot.domain.repository.AvailableUpdateRepository
 import java.io.File
@@ -25,6 +24,9 @@ class ClearAvailableUpdateFilesAndDataUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var availableUpdateRepository: AvailableUpdateRepository
 
@@ -34,7 +36,6 @@ class ClearAvailableUpdateFilesAndDataUseCaseTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
 
     @Test
@@ -92,7 +93,6 @@ class ClearAvailableUpdateFilesAndDataUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/availableupdate/ClearAvailableUpdateFilesAndDataUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/availableupdate/ClearAvailableUpdateFilesAndDataUseCaseTest.kt
@@ -21,11 +21,11 @@ import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ClearAvailableUpdateFilesAndDataUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var availableUpdateRepository: AvailableUpdateRepository

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
@@ -1,16 +1,14 @@
 package org.strigate.ferrot.domain.usecase.combined
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.InOrder
 import org.mockito.Mock
@@ -18,6 +16,7 @@ import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.domain.usecase.DownloadAudioUseCase
 import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
@@ -35,6 +34,9 @@ import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDown
 class DeleteDownloadAndRelatedCombinedUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var downloadUseCase: DownloadUseCase
@@ -75,7 +77,6 @@ class DeleteDownloadAndRelatedCombinedUseCaseTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
 
         `when`(downloadUseCase.deleteDownloadFilesUseCase)
             .thenReturn(deleteDownloadFilesUseCase)
@@ -179,7 +180,6 @@ class DeleteDownloadAndRelatedCombinedUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
@@ -32,11 +32,11 @@ import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDown
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DeleteDownloadAndRelatedCombinedUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadUseCase: DownloadUseCase

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetPendingDownloadsCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetPendingDownloadsCombinedUseCaseTest.kt
@@ -20,11 +20,11 @@ import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GetPendingDownloadsCombinedUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var downloadUseCase: DownloadUseCase

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetPendingDownloadsCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetPendingDownloadsCombinedUseCaseTest.kt
@@ -1,19 +1,18 @@
 package org.strigate.ferrot.domain.usecase.combined
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.domain.model.Download
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
@@ -24,6 +23,9 @@ class GetPendingDownloadsCombinedUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var downloadUseCase: DownloadUseCase
 
@@ -33,7 +35,6 @@ class GetPendingDownloadsCombinedUseCaseTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
         `when`(downloadUseCase.getAllDownloadsUseCase)
             .thenReturn(getAllDownloadsUseCase)
     }
@@ -69,7 +70,6 @@ class GetPendingDownloadsCombinedUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCaseTest.kt
@@ -2,19 +2,17 @@ package org.strigate.ferrot.domain.usecase.combined
 
 import android.util.Log
 import com.yausername.youtubedl_android.mapper.VideoInfo
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockedStatic
@@ -24,6 +22,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.provider.DownloadPathProvider
 import org.strigate.ferrot.domain.model.Download
 import org.strigate.ferrot.domain.model.DownloadMetadata
@@ -43,6 +42,9 @@ import java.nio.file.Files
 class RefreshDownloadMetadataCombinedUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
     private var logMock: MockedStatic<Log>? = null
 
     @Mock
@@ -76,7 +78,6 @@ class RefreshDownloadMetadataCombinedUseCaseTest {
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
         logMock = mockStatic(Log::class.java)
-        Dispatchers.setMain(testDispatcher)
 
         `when`(downloadUseCase.getDownloadByIdUseCase)
             .thenReturn(getDownloadByIdUseCase)
@@ -271,7 +272,6 @@ class RefreshDownloadMetadataCombinedUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         logMock?.close()
         logMock = null
         autoCloseable.close()

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/RefreshDownloadMetadataCombinedUseCaseTest.kt
@@ -40,11 +40,11 @@ import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RefreshDownloadMetadataCombinedUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
     private var logMock: MockedStatic<Log>? = null
 
     @Mock

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/DeleteDownloadFilesUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/DeleteDownloadFilesUseCaseTest.kt
@@ -1,23 +1,22 @@
 package org.strigate.ferrot.domain.usecase.download
 
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockedStatic
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.provider.DownloadPathProvider
 import org.strigate.ferrot.domain.model.Download
 import org.strigate.ferrot.domain.model.DownloadStatus
@@ -28,6 +27,9 @@ import java.nio.file.Files
 class DeleteDownloadFilesUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
     private var logMock: MockedStatic<Log>? = null
 
     @Mock
@@ -40,7 +42,6 @@ class DeleteDownloadFilesUseCaseTest {
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
         logMock = mockStatic(Log::class.java)
-        Dispatchers.setMain(testDispatcher)
     }
 
     @Test
@@ -107,7 +108,6 @@ class DeleteDownloadFilesUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         logMock?.close()
         autoCloseable.close()
     }

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/DeleteDownloadFilesUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/DeleteDownloadFilesUseCaseTest.kt
@@ -25,11 +25,11 @@ import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DeleteDownloadFilesUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
     private var logMock: MockedStatic<Log>? = null
 
     @Mock

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCaseTest.kt
@@ -5,16 +5,14 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockedStatic
@@ -22,6 +20,7 @@ import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.integration.DownloadWorkScheduler
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.usecase.DownloadUseCase
@@ -33,6 +32,9 @@ import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsF
 class StartDownloadUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
     private var logMock: MockedStatic<Log>? = null
 
     @Mock
@@ -69,7 +71,6 @@ class StartDownloadUseCaseTest {
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
         logMock = mockStatic(Log::class.java)
-        Dispatchers.setMain(testDispatcher)
 
         `when`(settingsUseCase.getDownloadWifiOnlySettingAsFlowUseCase)
             .thenReturn(getDownloadWifiOnlySettingAsFlowUseCase)
@@ -131,7 +132,6 @@ class StartDownloadUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         logMock?.close()
         autoCloseable.close()
     }

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/download/StartDownloadUseCaseTest.kt
@@ -30,11 +30,11 @@ import org.strigate.ferrot.domain.usecase.settings.GetDownloadWifiOnlySettingAsF
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StartDownloadUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
     private var logMock: MockedStatic<Log>? = null
 
     @Mock

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCaseTest.kt
@@ -5,20 +5,19 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Bundle
 import android.service.notification.StatusBarNotification
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
@@ -28,6 +27,9 @@ import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_DOWNL
 class ClearNotificationsByDownloadIdUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var appContext: Context
@@ -44,7 +46,6 @@ class ClearNotificationsByDownloadIdUseCaseTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
 
         `when`(appContext.getSystemService(NotificationManager::class.java))
             .thenReturn(notificationManager)
@@ -79,7 +80,6 @@ class ClearNotificationsByDownloadIdUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/notifications/ClearNotificationsByDownloadIdUseCaseTest.kt
@@ -25,11 +25,11 @@ import org.strigate.ferrot.app.Constants.Notifications.Channels.CHANNEL_ID_DOWNL
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ClearNotificationsByDownloadIdUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var appContext: Context

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCaseTest.kt
@@ -2,23 +2,22 @@ package org.strigate.ferrot.domain.usecase.youtubedl_android
 
 import com.yausername.youtubedl_android.YoutubeDLRequest
 import com.yausername.youtubedl_android.YoutubeDLResponse
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.app.YoutubeDlRuntimeInitializer
 import org.strigate.ferrot.app.integration.YoutubeDlClient
 import org.strigate.ferrot.domain.model.DownloadMediaType
@@ -29,6 +28,9 @@ import java.nio.file.Files
 class DownloadWithProgressUseCaseTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
     private lateinit var fakeClient: FakeYoutubeDlClient
 
     @Mock
@@ -37,7 +39,6 @@ class DownloadWithProgressUseCaseTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
         fakeClient = FakeYoutubeDlClient()
     }
 
@@ -135,7 +136,6 @@ class DownloadWithProgressUseCaseTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/youtubedl_android/DownloadWithProgressUseCaseTest.kt
@@ -26,11 +26,11 @@ import java.nio.file.Files
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadWithProgressUseCaseTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
     private lateinit var fakeClient: FakeYoutubeDlClient
 
     @Mock

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
@@ -35,11 +35,11 @@ import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsPendingDeleteU
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
     private var logMock: MockedStatic<Log>? = null
 
     @Mock

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/MainViewModelTest.kt
@@ -1,20 +1,18 @@
 package org.strigate.ferrot.presentation
 
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockedStatic
@@ -25,6 +23,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.domain.model.Download
 import org.strigate.ferrot.domain.model.DownloadStatus
 import org.strigate.ferrot.domain.repository.DownloadRepository
@@ -38,6 +37,9 @@ import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsPendingDeleteU
 class MainViewModelTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
     private var logMock: MockedStatic<Log>? = null
 
     @Mock
@@ -53,9 +55,7 @@ class MainViewModelTest {
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
         logMock = mockStatic(Log::class.java)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun navigateTo_updatesNavigationEvent() {
@@ -226,7 +226,6 @@ class MainViewModelTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         logMock?.close()
         logMock = null
         autoCloseable.close()

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
@@ -22,11 +22,11 @@ import org.strigate.ferrot.presentation.event.AboutEvent
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AboutViewModelTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/AboutViewModelTest.kt
@@ -1,22 +1,21 @@
 package org.strigate.ferrot.presentation.viewmodel
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.presentation.event.AboutEvent
@@ -26,13 +25,15 @@ class AboutViewModelTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger
 
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
 
     @Test
@@ -69,7 +70,6 @@ class AboutViewModelTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -2,7 +2,6 @@ package org.strigate.ferrot.presentation.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,15 +14,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
@@ -31,6 +29,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.Download
@@ -69,6 +68,9 @@ import kotlin.time.Duration.Companion.seconds
 class DownloadViewModelTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger
@@ -130,9 +132,7 @@ class DownloadViewModelTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun init_clearsNotificationsForInitialDownload() = runTest(testDispatcher) {
@@ -769,7 +769,6 @@ class DownloadViewModelTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -66,11 +66,11 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadViewModelTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -59,11 +59,11 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DownloadsViewModelTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -3,7 +3,6 @@ package org.strigate.ferrot.presentation.viewmodel
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.SavedStateHandle
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,15 +12,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
@@ -29,6 +27,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.AvailableUpdate
@@ -62,6 +61,9 @@ import kotlin.time.Duration.Companion.seconds
 class DownloadsViewModelTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger
@@ -123,9 +125,7 @@ class DownloadsViewModelTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun uiState_exposesMappedDownloadsAndAvailableUpdate() = runTest(testDispatcher) {
@@ -568,7 +568,6 @@ class DownloadsViewModelTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
@@ -40,11 +40,11 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
@@ -1,6 +1,5 @@
 package org.strigate.ferrot.presentation.viewmodel
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
@@ -8,18 +7,18 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.DownloadSwipeAction
@@ -43,6 +42,9 @@ import kotlin.time.Duration.Companion.seconds
 class SettingsViewModelTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger
@@ -86,9 +88,7 @@ class SettingsViewModelTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun uiState_exposesMappedSettings() = runTest(testDispatcher) {
@@ -204,7 +204,6 @@ class SettingsViewModelTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
@@ -32,11 +32,11 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpdatesViewModelTest {
-    private lateinit var autoCloseable: AutoCloseable
-    private val testDispatcher: TestDispatcher = StandardTestDispatcher()
-
     @get:Rule
-    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
 
     @Mock
     private lateinit var appContext: Context

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
@@ -1,25 +1,24 @@
 package org.strigate.ferrot.presentation.viewmodel
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.usecase.SettingsUseCase
@@ -35,6 +34,9 @@ import kotlin.time.Duration.Companion.seconds
 class UpdatesViewModelTest {
     private lateinit var autoCloseable: AutoCloseable
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(testDispatcher)
 
     @Mock
     private lateinit var appContext: Context
@@ -63,9 +65,7 @@ class UpdatesViewModelTest {
     @Before
     fun setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this)
-        Dispatchers.setMain(testDispatcher)
     }
-
 
     @Test
     fun uiState_exposesMappedSettingsAndInfo() = runTest(testDispatcher) {
@@ -111,7 +111,6 @@ class UpdatesViewModelTest {
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         autoCloseable.close()
     }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/test/MainDispatcherRule.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/test/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package org.strigate.ferrot.test
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Add shared `MainDispatcherRule` for `Dispatchers.Main`
- Replace manual `Dispatchers.setMain` and `Dispatchers.resetMain` setup in affected tests
- Remove empty `setUp()` and `tearDown()` methods left behind by the refactor