### PR TITLE
feat: Add resources links to About screen

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,6 +23,7 @@ import java.util.Calendar
 @Composable
 fun Copyright(
     modifier: Modifier = Modifier,
+    onLogoClick: (() -> Unit)? = null,
 ) {
     val dimens = LocalDimens.current
     Column(
@@ -28,27 +32,48 @@ fun Copyright(
         verticalArrangement = Arrangement.Center,
     ) {
         Spacer(modifier = Modifier.height(dimens.spacingLarge))
-        Icon(
-            modifier = Modifier
-                .height(dimens.iconLarge),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                alpha = 0.8f,
+        Surface(
+            onClick = {
+                onLogoClick?.invoke()
+            },
+            enabled = onLogoClick != null,
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceTint.copy(
+                alpha = 0f,
             ),
-            painter = painterResource(R.drawable.strigate_logo),
-            contentDescription = stringResource(R.string.content_description_strigate_logo),
-        )
-        Text(
-            style = MaterialTheme.typography.labelSmall.copy(
-                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                    alpha = 0.75f,
+        ) {
+            Column(
+                modifier = Modifier.padding(
+                    start = dimens.spacingLarge,
+                    top = dimens.spacingMedium,
+                    end = dimens.spacingLarge,
+                    bottom = dimens.spacingLarge,
                 ),
-            ),
-            textAlign = TextAlign.Center,
-            text = stringResource(
-                R.string.copyright,
-                Calendar.getInstance().get(Calendar.YEAR),
-            ),
-        )
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .height(dimens.iconLarge),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                        alpha = 0.8f,
+                    ),
+                    painter = painterResource(R.drawable.strigate_logo),
+                    contentDescription = stringResource(R.string.content_description_strigate_logo),
+                )
+                Text(
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                            alpha = 0.75f,
+                        ),
+                    ),
+                    textAlign = TextAlign.Center,
+                    text = stringResource(
+                        R.string.copyright,
+                        Calendar.getInstance().get(Calendar.YEAR),
+                    ),
+                )
+            }
+        }
         Spacer(modifier = Modifier.height(dimens.spacingLarge))
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/settings/TextSetting.kt
@@ -23,10 +23,11 @@ fun TextSetting(
     text: String,
     modifier: Modifier = Modifier,
     description: String? = null,
+    enabled: Boolean = true,
     onLongClick: (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
 ) {
-    val clickableModifier = if (onClick != null || onLongClick != null) {
+    val clickableModifier = if (enabled && (onClick != null || onLongClick != null)) {
         Modifier
             .combinedClickable(
                 interactionSource = remember { MutableInteractionSource() },
@@ -39,6 +40,17 @@ fun TextSetting(
                 },
             )
     } else Modifier
+
+    val textColor = if (enabled) {
+        MaterialTheme.colorScheme.onSurface
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+    }
+    val descriptionColor = if (enabled) {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+    } else {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+    }
 
     Column(
         modifier = modifier
@@ -62,14 +74,14 @@ fun TextSetting(
             ) {
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = textColor,
                     text = text,
                 )
                 description?.let {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        color = descriptionColor,
                         text = it,
                     )
                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -50,6 +51,7 @@ fun AboutScreen(
     val dimens = LocalDimens.current
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val urlStrigate = stringResource(R.string.url_strigate)
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -127,25 +129,57 @@ fun AboutScreen(
                         }
                     }
                     Spacer(modifier = Modifier.height(dimens.spacingSmall))
-                    StaticSettingsSection {
+                    StaticSettingsSection(
+                        icon = Icons.Outlined.Link,
+                        title = stringResource(R.string.settings_section_links),
+                    ) {
                         val urlWebsite = stringResource(R.string.url_website)
+                        val urlGitHub = stringResource(R.string.url_github)
+                        val urlX = stringResource(R.string.url_x)
                         val urlPrivacy = stringResource(R.string.url_privacy)
                         val urlLicense = stringResource(R.string.url_license)
                         TextSetting(
                             text = stringResource(R.string.settings_title_website),
                             description = stringResource(R.string.settings_description_website),
+                            onLongClick = {
+                                context.copyToClipboard(urlWebsite)
+                            },
                         ) {
                             viewModel.onUrlClicked(urlWebsite)
                         }
                         TextSetting(
+                            text = stringResource(R.string.settings_title_github),
+                            description = stringResource(R.string.settings_description_github),
+                            onLongClick = {
+                                context.copyToClipboard(urlGitHub)
+                            },
+                        ) {
+                            viewModel.onUrlClicked(urlGitHub)
+                        }
+                        TextSetting(
+                            text = stringResource(R.string.settings_title_x),
+                            description = stringResource(R.string.settings_description_x),
+                            onLongClick = {
+                                context.copyToClipboard(urlX)
+                            },
+                        ) {
+                            viewModel.onUrlClicked(urlX)
+                        }
+                        TextSetting(
                             text = stringResource(R.string.settings_title_privacy),
                             description = stringResource(R.string.settings_description_privacy),
+                            onLongClick = {
+                                context.copyToClipboard(urlPrivacy)
+                            },
                         ) {
                             viewModel.onUrlClicked(urlPrivacy)
                         }
                         TextSetting(
                             text = stringResource(R.string.settings_title_license),
                             description = stringResource(R.string.settings_description_license),
+                            onLongClick = {
+                                context.copyToClipboard(urlLicense)
+                            },
                         ) {
                             viewModel.onUrlClicked(urlLicense)
                         }
@@ -153,6 +187,9 @@ fun AboutScreen(
                     Copyright(
                         modifier = Modifier
                             .fillMaxWidth(),
+                        onLogoClick = {
+                            viewModel.onUrlClicked(urlStrigate)
+                        },
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="settings_section_general">General</string>
     <string name="settings_section_swipe_actions">Swipe actions</string>
     <string name="settings_section_app_info">App info</string>
+    <string name="settings_section_links">Resources</string>
     <string name="settings_section_app">App</string>
     <string name="settings_section_dependencies">Dependencies</string>
 
@@ -116,6 +117,8 @@
     <string name="settings_title_last_checked_for_dependency_updates">Last checked for dependency updates</string>
     <string name="settings_title_build">Build</string>
     <string name="settings_title_website">Website</string>
+    <string name="settings_title_github">GitHub</string>
+    <string name="settings_title_x">X</string>
     <string name="settings_title_privacy">Privacy</string>
     <string name="settings_title_license">License</string>
 
@@ -127,6 +130,8 @@
     <string name="settings_description_check_for_app_updates">Check for app updates now</string>
     <string name="settings_description_automatic_dependency_updates">Automatically download and apply updates for dependencies</string>
     <string name="settings_description_check_dependencies_now">Check for dependency updates now</string>
+    <string name="settings_description_github">github.com/strigate/ferrot</string>
+    <string name="settings_description_x">x.com/ferrotapp</string>
     <string name="settings_description_privacy">View Privacy Policy</string>
     <string name="settings_description_license">GNU General Public License v3.0</string>
 

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -4,6 +4,9 @@
     <string name="file_provider">fileprovider</string>
     <string name="settings_description_website">ferrot.org</string>
     <string name="url_website">https://ferrot.org/</string>
+    <string name="url_github">https://github.com/strigate/ferrot</string>
+    <string name="url_x">https://x.com/ferrotapp</string>
+    <string name="url_strigate">https://x.com/strigate</string>
     <string name="url_privacy">https://github.com/strigate/ferrot/blob/main/PRIVACY.md</string>
     <string name="url_license">https://github.com/strigate/ferrot/blob/main/LICENSE</string>
     <string name="github_latest_release">https://api.github.com/repos/strigate/ferrot/releases/latest</string>


### PR DESCRIPTION
- Add `GitHub` and `X` entries to the resources section
- Enable long-press copying for `Website`, `GitHub`, `X`, `Privacy`, and `License` links
- Add optional `onLogoClick` support to `Copyright`
- Add disabled-state styling support to `TextSetting`