### PR TITLE
fix: Align swipe action default fallbacks

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/Constants.kt
@@ -1,6 +1,7 @@
 package org.strigate.ferrot.app
 
 import org.strigate.ferrot.BuildConfig
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 
 object Constants {
     const val APP_ID = BuildConfig.APPLICATION_ID
@@ -24,9 +25,9 @@ object Constants {
         const val KEY_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION = "auto_duplicate_download_deletion"
         const val DEFAULT_VALUE_AUTOMATIC_DUPLICATE_DOWNLOAD_DELETION = true
         const val KEY_LEFT_SWIPE_ACTION = "left_swipe_action"
-        const val DEFAULT_VALUE_LEFT_SWIPE_ACTION = "archive"
+        val DEFAULT_VALUE_LEFT_SWIPE_ACTION = DownloadSwipeAction.DELETE
         const val KEY_RIGHT_SWIPE_ACTION = "right_swipe_action"
-        const val DEFAULT_VALUE_RIGHT_SWIPE_ACTION = "delete"
+        val DEFAULT_VALUE_RIGHT_SWIPE_ACTION = DownloadSwipeAction.ARCHIVE
         const val KEY_AUTOMATIC_UPDATES = "auto_updates"
         const val DEFAULT_VALUE_AUTOMATIC_UPDATES = true
         const val KEY_AUTOMATIC_DEPENDENCY_UPDATES = "auto_dependency_updates"

--- a/app/src/main/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImpl.kt
@@ -75,8 +75,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override fun getLeftSwipeActionAsFlow(): Flow<DownloadSwipeAction> {
         return preferencesDataStore.data.map {
             DownloadSwipeAction.fromStorageValue(
-                value = it[leftSwipeActionKey] ?: DEFAULT_VALUE_LEFT_SWIPE_ACTION,
-                defaultAction = DownloadSwipeAction.ARCHIVE,
+                value = it[leftSwipeActionKey],
+                defaultAction = DEFAULT_VALUE_LEFT_SWIPE_ACTION,
             )
         }
     }
@@ -90,8 +90,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override fun getRightSwipeActionAsFlow(): Flow<DownloadSwipeAction> {
         return preferencesDataStore.data.map {
             DownloadSwipeAction.fromStorageValue(
-                value = it[rightSwipeActionKey] ?: DEFAULT_VALUE_RIGHT_SWIPE_ACTION,
-                defaultAction = DownloadSwipeAction.DELETE,
+                value = it[rightSwipeActionKey],
+                defaultAction = DEFAULT_VALUE_RIGHT_SWIPE_ACTION,
             )
         }
     }

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/SettingsRepositoryImplTest.kt
@@ -52,11 +52,11 @@ class SettingsRepositoryImplTest {
             repository.getAutomaticDuplicateDownloadDeletionAsFlow().first(),
         )
         assertEquals(
-            DownloadSwipeAction.fromStorageValue(DEFAULT_VALUE_LEFT_SWIPE_ACTION),
+            DEFAULT_VALUE_LEFT_SWIPE_ACTION,
             repository.getLeftSwipeActionAsFlow().first(),
         )
         assertEquals(
-            DownloadSwipeAction.fromStorageValue(DEFAULT_VALUE_RIGHT_SWIPE_ACTION),
+            DEFAULT_VALUE_RIGHT_SWIPE_ACTION,
             repository.getRightSwipeActionAsFlow().first(),
         )
     }
@@ -98,8 +98,14 @@ class SettingsRepositoryImplTest {
             it[stringPreferencesKey(KEY_RIGHT_SWIPE_ACTION)] = "broken"
         }
 
-        assertEquals(DownloadSwipeAction.ARCHIVE, repository.getLeftSwipeActionAsFlow().first())
-        assertEquals(DownloadSwipeAction.DELETE, repository.getRightSwipeActionAsFlow().first())
+        assertEquals(
+            DEFAULT_VALUE_LEFT_SWIPE_ACTION,
+            repository.getLeftSwipeActionAsFlow().first(),
+        )
+        assertEquals(
+            DEFAULT_VALUE_RIGHT_SWIPE_ACTION,
+            repository.getRightSwipeActionAsFlow().first(),
+        )
     }
 
     private fun createRepository(scope: CoroutineScope): SettingsRepositoryImpl {


### PR DESCRIPTION
- Define `DEFAULT_VALUE_LEFT_SWIPE_ACTION` and `DEFAULT_VALUE_RIGHT_SWIPE_ACTION` with `DownloadSwipeAction`
- Use swipe default constants as `defaultAction` fallback values in `SettingsRepositoryImpl`
- Update `SettingsRepositoryImplTest` to cover unset and invalid swipe preference values