### PR TITLE
chore: Add `prepareRelease` distribution flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,10 +28,14 @@ object BuildInfo {
     const val BASE_VERSION = "1.8.1"
     const val VERSION_CODE = 30
     const val VERSION_NAME = "$BASE_VERSION-$VERSION_CODE"
-    const val RELEASE_APK_NAME = "ferrot"
-    const val DEBUG_VARIANT_SUFFIX = "debug"
-    const val RELEASE_VARIANT_SUFFIX = "release"
+    const val ARTIFACT_BASE_NAME = "ferrot"
 }
+
+val releaseArtifactName = "${BuildInfo.ARTIFACT_BASE_NAME}-release"
+extra["prepareReleaseAabFileName"] = "$releaseArtifactName.aab"
+extra["prepareReleaseApkFileName"] = "$releaseArtifactName.apk"
+
+apply(from = "$rootDir/app/prepare-release.gradle.kts")
 
 android {
     namespace = BuildInfo.PACKAGE_NAME
@@ -120,26 +124,6 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
-registerArtifactRenameTask(
-    taskName = "renameDebugApk",
-    outputDirectory = "outputs/apk/debug",
-    sourceFileName = "app-debug.apk",
-    variantSuffix = BuildInfo.DEBUG_VARIANT_SUFFIX,
-    extension = "apk",
-    listingTaskName = "createDebugApkListingFileRedirect",
-    buildTaskName = "assembleDebug",
-)
-
-registerArtifactRenameTask(
-    taskName = "renameReleaseApk",
-    outputDirectory = "outputs/apk/release",
-    sourceFileName = "app-release.apk",
-    variantSuffix = BuildInfo.RELEASE_VARIANT_SUFFIX,
-    extension = "apk",
-    listingTaskName = "createReleaseApkListingFileRedirect",
-    buildTaskName = "assembleRelease",
-)
-
 private fun ApplicationDefaultConfig.applyFirebaseProperties(
     includeResString: Boolean = true,
 ) {
@@ -173,34 +157,6 @@ private fun Properties.getString(key: String): String {
 
 private fun String.escapeForBuildConfig(): String {
     return "\"" + this.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
-}
-
-private fun registerArtifactRenameTask(
-    taskName: String,
-    outputDirectory: String,
-    sourceFileName: String,
-    variantSuffix: String,
-    extension: String,
-    listingTaskName: String,
-    buildTaskName: String,
-) {
-    tasks.register<Copy>(taskName) {
-        val releaseDir = layout.buildDirectory.dir(outputDirectory)
-        from(releaseDir)
-        include(sourceFileName)
-        into(releaseDir)
-        rename(sourceFileName, artifactFileName(variantSuffix, extension))
-    }
-    tasks.named(taskName) {
-        mustRunAfter(listingTaskName)
-    }
-    tasks.matching { it.name == buildTaskName }.configureEach {
-        finalizedBy(taskName)
-    }
-}
-
-private fun artifactFileName(variantSuffix: String, extension: String): String {
-    return "${BuildInfo.RELEASE_APK_NAME}-$variantSuffix.$extension"
 }
 
 dependencies {

--- a/app/prepare-release.gradle.kts
+++ b/app/prepare-release.gradle.kts
@@ -1,0 +1,112 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+val releaseApkTargetFileNameFromBuild = extra["prepareReleaseApkFileName"] as String
+val releaseAabTargetFileNameFromBuild = extra["prepareReleaseAabFileName"] as String
+
+abstract class PrepareReleaseTask : DefaultTask() {
+    @get:Input
+    abstract val releaseArtifactsDirectoryPath: Property<String>
+
+    @get:Input
+    abstract val debugUnitTestReportPath: Property<String>
+
+    @get:Input
+    abstract val releaseApkSourcePath: Property<String>
+
+    @get:Input
+    abstract val releaseAabSourcePath: Property<String>
+
+    @get:Input
+    abstract val releaseMappingSourcePath: Property<String>
+
+    @get:Input
+    abstract val releaseApkTargetFileName: Property<String>
+
+    @get:Input
+    abstract val releaseAabTargetFileName: Property<String>
+
+    @TaskAction
+    fun prepareRelease() {
+        val releaseDir = File(releaseArtifactsDirectoryPath.get())
+        releaseDir.deleteRecursively()
+        releaseDir.mkdirs()
+
+        copyArtifact(
+            sourcePath = releaseApkSourcePath.get(),
+            targetPath = File(releaseDir, releaseApkTargetFileName.get()).absolutePath,
+        )
+        copyArtifact(
+            sourcePath = releaseAabSourcePath.get(),
+            targetPath = File(releaseDir, releaseAabTargetFileName.get()).absolutePath,
+        )
+        copyArtifact(
+            sourcePath = releaseMappingSourcePath.get(),
+            targetPath = File(releaseDir, "mapping.txt").absolutePath,
+        )
+        println()
+        println("Release artifacts prepared in: ${releaseArtifactsDirectoryPath.get()}")
+        println("Test report: ${debugUnitTestReportPath.get()}")
+    }
+
+    private fun copyArtifact(
+        sourcePath: String,
+        targetPath: String,
+    ) {
+        val sourceFile = File(sourcePath)
+        check(sourceFile.exists()) {
+            "Expected artifact was not found: $sourcePath"
+        }
+        sourceFile.copyTo(File(targetPath), overwrite = true)
+    }
+}
+
+tasks.configureEach {
+    val isCleanTask = name == "clean" || name.contains("Clean")
+    if (!isCleanTask && name != "prepareRelease") {
+        mustRunAfter("clean")
+    }
+    if (name.contains("Release") && !isCleanTask && name != "prepareRelease") {
+        mustRunAfter("testDebugUnitTest")
+    }
+}
+
+tasks.register("prepareRelease", PrepareReleaseTask::class.java) {
+    group = "distribution"
+    description = buildString {
+        append("Cleans the build, runs debug unit tests, ")
+        append("builds release APK and AAB and collects ")
+        append("them into one directory.")
+    }
+    dependsOn(
+        "clean",
+        "testDebugUnitTest",
+        "assembleRelease",
+        "bundleRelease",
+    )
+    releaseArtifactsDirectoryPath.set(
+        layout.buildDirectory.dir("outputs/release")
+            .map { it.asFile.absolutePath },
+    )
+    debugUnitTestReportPath.set(
+        layout.buildDirectory.file("reports/tests/testDebugUnitTest/index.html")
+            .map { it.asFile.absolutePath },
+    )
+    releaseApkSourcePath.set(
+        layout.buildDirectory.file("outputs/apk/release/app-release.apk")
+            .map { it.asFile.absolutePath },
+    )
+    releaseAabSourcePath.set(
+        layout.buildDirectory.file("outputs/bundle/release/app-release.aab")
+            .map { it.asFile.absolutePath },
+    )
+    releaseMappingSourcePath.set(
+        layout.buildDirectory.file("outputs/mapping/release/mapping.txt")
+            .map { it.asFile.absolutePath },
+    )
+    releaseApkTargetFileName.set(releaseApkTargetFileNameFromBuild)
+    releaseAabTargetFileName.set(releaseAabTargetFileNameFromBuild)
+}


### PR DESCRIPTION
- Add `PrepareReleaseTask` to collect the release APK, AAB, and `mapping.txt`
- Configure `releaseArtifactName` and export `prepareRelease` output file names
- Apply `prepare-release.gradle.kts` from the app build configuration
- Remove legacy artifact rename tasks from the release build flow