### PR TITLE
refactor: Extract shared UI into `:refinery`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 *.iml
-.externalNativeBuild
+.externalNativeBuild/
 .DS_Store
-.cxx
+.cxx/
 .gradle/
 .kotlin/
 .idea/
-/build
-/captures
+build/
+captures/
 local.properties
 keystore.properties
 google-services.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,6 +160,8 @@ private fun String.escapeForBuildConfig(): String {
 }
 
 dependencies {
+    // Modules
+    implementation(project(":refinery"))
     // Android
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,8 +32,10 @@ import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL_UID
 import org.strigate.ferrot.app.Constants.LOG_TAG
 import org.strigate.ferrot.helper.InstallHelper
-import org.strigate.ferrot.presentation.theme.FerrotTheme
+import org.strigate.ferrot.presentation.theme.Dimens
+import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.util.isAtLeastTiramisu
+import org.strigate.refinery.theme.RefineryTheme
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -114,61 +117,65 @@ class MainActivity : ComponentActivity() {
         }
         enableEdgeToEdge()
         setContent {
-            FerrotTheme {
-                val navController = rememberNavController()
-                var permissionsRequested by rememberSaveable { mutableStateOf(false) }
-                val navigateRoute by viewModel
-                    .navigateRoute
-                    .collectAsStateWithLifecycle(initialValue = null)
+            RefineryTheme {
+                CompositionLocalProvider(
+                    LocalDimens provides Dimens(),
+                ) {
+                    val navController = rememberNavController()
+                    var permissionsRequested by rememberSaveable { mutableStateOf(false) }
+                    val navigateRoute by viewModel
+                        .navigateRoute
+                        .collectAsStateWithLifecycle(initialValue = null)
 
-                LaunchedEffect(navigateRoute) {
-                    val routeEvent =
-                        navigateRoute as? NavigationEvent.Route ?: return@LaunchedEffect
+                    LaunchedEffect(navigateRoute) {
+                        val routeEvent =
+                            navigateRoute as? NavigationEvent.Route ?: return@LaunchedEffect
 
-                    val targetRoute = routeEvent.route
-                    val popUpToRoute = routeEvent.popUpToRoute
-                    val currentRoute = navController.currentDestination?.route
-                    if (targetRoute == currentRoute) {
-                        viewModel.resetNavigate()
-                        return@LaunchedEffect
-                    }
-                    try {
-                        navController.currentBackStackEntryFlow.first()
-                        val resolvedPopUpToRoute = when {
-                            popUpToRoute == null -> null
-                            runCatching { navController.getBackStackEntry(popUpToRoute) }
-                                .isSuccess -> popUpToRoute
-
-                            runCatching { navController.getBackStackEntry(Screen.Downloads.route) }
-                                .isSuccess -> Screen.Downloads.route
-
-                            else -> null
+                        val targetRoute = routeEvent.route
+                        val popUpToRoute = routeEvent.popUpToRoute
+                        val currentRoute = navController.currentDestination?.route
+                        if (targetRoute == currentRoute) {
+                            viewModel.resetNavigate()
+                            return@LaunchedEffect
                         }
-                        navController.navigate(targetRoute) {
-                            resolvedPopUpToRoute?.let { route ->
-                                popUpTo(route) {
-                                    inclusive = targetRoute == route
-                                    saveState = false
-                                }
+                        try {
+                            navController.currentBackStackEntryFlow.first()
+                            val resolvedPopUpToRoute = when {
+                                popUpToRoute == null -> null
+                                runCatching { navController.getBackStackEntry(popUpToRoute) }
+                                    .isSuccess -> popUpToRoute
+
+                                runCatching { navController.getBackStackEntry(Screen.Downloads.route) }
+                                    .isSuccess -> Screen.Downloads.route
+
+                                else -> null
                             }
-                            launchSingleTop = true
-                            restoreState = false
+                            navController.navigate(targetRoute) {
+                                resolvedPopUpToRoute?.let { route ->
+                                    popUpTo(route) {
+                                        inclusive = targetRoute == route
+                                        saveState = false
+                                    }
+                                }
+                                launchSingleTop = true
+                                restoreState = false
+                            }
+                        } catch (throwable: Throwable) {
+                            Log.w(LOG_TAG, "Navigation failed: ${throwable.message}", throwable)
+                        } finally {
+                            viewModel.resetNavigate()
                         }
-                    } catch (throwable: Throwable) {
-                        Log.w(LOG_TAG, "Navigation failed: ${throwable.message}", throwable)
-                    } finally {
-                        viewModel.resetNavigate()
                     }
-                }
-                LaunchedEffect(Unit) {
-                    if (!permissionsRequested) {
-                        requestNotificationsPermissionsIfNeeded()
-                        permissionsRequested = true
+                    LaunchedEffect(Unit) {
+                        if (!permissionsRequested) {
+                            requestNotificationsPermissionsIfNeeded()
+                            permissionsRequested = true
+                        }
                     }
+                    MainNavHost(
+                        navController = navController,
+                    )
                 }
-                MainNavHost(
-                    navController = navController,
-                )
             }
         }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/ActionIconButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/ActionIconButton.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun ActionIconButton(
@@ -25,6 +26,7 @@ fun ActionIconButton(
     imageVector: ImageVector,
     contentDescription: String,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     val dimens = LocalDimens.current
     Box(
         modifier = modifier
@@ -36,7 +38,7 @@ fun ActionIconButton(
                 indication = LocalIndication.current,
                 onClick = onClick,
             )
-            .padding(dimens.spacingSmall),
+            .padding(refineryDimens.spacingSmall),
         contentAlignment = Alignment.Center,
     ) {
         Icon(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/AvailableUpdateBanner.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/AvailableUpdateBanner.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import org.strigate.ferrot.R
-import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun AvailableUpdateBanner(
@@ -28,7 +28,7 @@ fun AvailableUpdateBanner(
     onClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     if (!localFilePath.isNullOrBlank()) {
         Surface(
             modifier = modifier
@@ -37,15 +37,15 @@ fun AvailableUpdateBanner(
                 },
             shape = RectangleShape,
             color = MaterialTheme.colorScheme.secondaryContainer,
-            tonalElevation = dimens.zero,
-            shadowElevation = dimens.zero,
+            tonalElevation = refineryDimens.zero,
+            shadowElevation = refineryDimens.zero,
         ) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
-                        horizontal = dimens.spacingMedium,
-                        vertical = dimens.spacingMediumAlt,
+                        horizontal = refineryDimens.spacingMedium,
+                        vertical = refineryDimens.spacingMediumAlt,
                     ),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -54,7 +54,7 @@ fun AvailableUpdateBanner(
                     imageVector = Icons.Filled.SystemUpdate,
                     contentDescription = null,
                 )
-                Spacer(Modifier.width(dimens.spacingMediumAlt))
+                Spacer(Modifier.width(refineryDimens.spacingMediumAlt))
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import org.strigate.ferrot.R
-import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 import java.util.Calendar
 
 @Composable
@@ -25,13 +25,13 @@ fun Copyright(
     modifier: Modifier = Modifier,
     onLogoClick: (() -> Unit)? = null,
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        Spacer(modifier = Modifier.height(dimens.spacingLarge))
+        Spacer(modifier = Modifier.height(refineryDimens.spacingLarge))
         Surface(
             onClick = {
                 onLogoClick?.invoke()
@@ -44,16 +44,16 @@ fun Copyright(
         ) {
             Column(
                 modifier = Modifier.padding(
-                    start = dimens.spacingLarge,
-                    top = dimens.spacingMedium,
-                    end = dimens.spacingLarge,
-                    bottom = dimens.spacingLarge,
+                    start = refineryDimens.spacingLarge,
+                    top = refineryDimens.spacingMedium,
+                    end = refineryDimens.spacingLarge,
+                    bottom = refineryDimens.spacingLarge,
                 ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Icon(
                     modifier = Modifier
-                        .height(dimens.iconLarge),
+                        .height(refineryDimens.iconLarge),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
                         alpha = 0.8f,
                     ),
@@ -74,6 +74,6 @@ fun Copyright(
                 )
             }
         }
-        Spacer(modifier = Modifier.height(dimens.spacingLarge))
+        Spacer(modifier = Modifier.height(refineryDimens.spacingLarge))
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -28,6 +28,7 @@ import coil3.request.crossfade
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 import java.io.File
 
 @Composable
@@ -38,8 +39,9 @@ fun DownloadPrimaryActionButton(
     onPauseResume: () -> Unit,
     onOpen: () -> Unit,
 ) {
-    val dimens = LocalDimens.current
     val context = LocalContext.current
+    val refineryDimens = LocalRefineryDimens.current
+    val dimens = LocalDimens.current
 
     val actionConfig = when (status) {
         DownloadStatusUiData.QUEUED,
@@ -76,7 +78,7 @@ fun DownloadPrimaryActionButton(
         modifier = modifier
             .wrapContentSize(),
         shape = MaterialTheme.shapes.medium,
-        tonalElevation = dimens.tonalElevationHigh,
+        tonalElevation = refineryDimens.tonalElevationHigh,
     ) {
         Box(
             modifier = Modifier

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressBar.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressBar.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun DownloadProgressBar(
@@ -17,7 +17,7 @@ fun DownloadProgressBar(
     progress: Float?,
     forcePrimary: Boolean = false,
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     val barColor = when {
         forcePrimary -> MaterialTheme.colorScheme.primary
         running -> MaterialTheme.colorScheme.primary
@@ -27,7 +27,7 @@ fun DownloadProgressBar(
         LinearProgressIndicator(
             modifier = modifier
                 .fillMaxWidth()
-                .height(dimens.spacingXSmall),
+                .height(refineryDimens.spacingXSmall),
             color = barColor,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )
@@ -44,7 +44,7 @@ fun DownloadProgressBar(
             },
             modifier = modifier
                 .fillMaxWidth()
-                .height(dimens.spacingXSmall),
+                .height(refineryDimens.spacingXSmall),
             color = barColor,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
         )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
-import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun DownloadProgressSection(
@@ -32,7 +32,7 @@ fun DownloadProgressSection(
     forcePrimaryBar: Boolean = false,
     alwaysShowBar: Boolean = true,
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     val running = when (status) {
         DownloadStatusUiData.QUEUED,
         DownloadStatusUiData.METADATA,
@@ -56,11 +56,11 @@ fun DownloadProgressSection(
                 running = running,
                 forcePrimary = forcePrimaryBar,
             )
-            Spacer(modifier = Modifier.height(dimens.spacingXSmall))
+            Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
         }
         Box(
             modifier = Modifier
-                .heightIn(min = dimens.spacingLarge),
+                .heightIn(min = refineryDimens.spacingLarge),
         ) {
             StatusSizeEtaRow(
                 status = status,
@@ -129,10 +129,10 @@ private fun InfoLine(
     modifier: Modifier = Modifier,
     isError: Boolean = false,
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     Row(
         modifier = modifier
-            .padding(top = dimens.spacingSmall)
+            .padding(top = refineryDimens.spacingSmall)
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun EmptyState(
@@ -27,6 +28,7 @@ fun EmptyState(
     icon: ImageVector? = null,
     iconContentDescription: String? = null,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     val dimens = LocalDimens.current
     Column(
         modifier = modifier
@@ -38,13 +40,13 @@ fun EmptyState(
         icon?.let {
             Icon(
                 modifier = Modifier
-                    .size(dimens.iconXLarge),
+                    .size(refineryDimens.iconXLarge),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 imageVector = it,
                 contentDescription = iconContentDescription,
             )
         }
-        Spacer(modifier = Modifier.height(dimens.spacingMedium))
+        Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
         Column(
             modifier = Modifier
                 .widthIn(max = dimens.contentMaxWidth),
@@ -56,7 +58,7 @@ fun EmptyState(
                 textAlign = TextAlign.Center,
                 text = title,
             )
-            Spacer(modifier = Modifier.height(dimens.spacingSmall))
+            Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
             Text(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun ErrorState(
@@ -25,6 +26,7 @@ fun ErrorState(
     text: String? = null,
 ) {
     val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     Box(
         modifier = modifier,
         contentAlignment = alignment,
@@ -35,13 +37,13 @@ fun ErrorState(
         ) {
             Icon(
                 modifier = Modifier
-                    .size(dimens.iconXLarge),
+                    .size(refineryDimens.iconXLarge),
                 tint = MaterialTheme.colorScheme.error,
                 imageVector = Icons.Outlined.ErrorOutline,
                 contentDescription = null,
             )
             text?.let {
-                Spacer(modifier = Modifier.height(dimens.spacingMedium))
+                Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
                 Column(
                     modifier = Modifier
                         .widthIn(max = dimens.contentMaxWidth),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -35,12 +35,12 @@ import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.copyToClipboard
 import org.strigate.ferrot.presentation.component.Copyright
-import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
-import org.strigate.ferrot.presentation.component.settings.TextSetting
 import org.strigate.ferrot.presentation.event.AboutEvent
-import org.strigate.ferrot.presentation.theme.FerrotTopAppBarDefaults
-import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.viewmodel.AboutViewModel
+import org.strigate.refinery.component.settings.StaticSettingsSection
+import org.strigate.refinery.component.settings.TextSetting
+import org.strigate.refinery.theme.LocalRefineryDimens
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,8 +48,8 @@ fun AboutScreen(
     modifier: Modifier = Modifier,
     viewModel: AboutViewModel = hiltViewModel(),
 ) {
-    val dimens = LocalDimens.current
     val context = LocalContext.current
+    val refineryDimens = LocalRefineryDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val urlStrigate = stringResource(R.string.url_strigate)
 
@@ -81,7 +81,7 @@ fun AboutScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                colors = FerrotTopAppBarDefaults.colors(),
+                colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
                         onClick = {
@@ -111,7 +111,7 @@ fun AboutScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(horizontal = dimens.spacingMediumAlt)
+                        .padding(horizontal = refineryDimens.spacingMediumAlt)
                         .verticalScroll(rememberScrollState()),
                 ) {
                     StaticSettingsSection(
@@ -128,7 +128,7 @@ fun AboutScreen(
                             viewModel.onBuildClicked()
                         }
                     }
-                    Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                    Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                     StaticSettingsSection(
                         icon = Icons.Outlined.Link,
                         title = stringResource(R.string.settings_section_links),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -97,10 +97,10 @@ import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
-import org.strigate.ferrot.presentation.theme.FerrotTopAppBarDefaults
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
 import org.strigate.ferrot.presentation.viewmodel.DownloadViewModel
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -180,7 +180,7 @@ fun DownloadScreen(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
-                colors = FerrotTopAppBarDefaults.colors(),
+                colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
                         onClick = {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -112,12 +112,12 @@ import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.model.isActive
 import org.strigate.ferrot.presentation.model.isFailed
 import org.strigate.ferrot.presentation.state.DownloadsUiState
-import org.strigate.ferrot.presentation.theme.FerrotTopAppBarDefaults
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.theme.TextStyles
 import org.strigate.ferrot.presentation.transitions.Transitions
 import org.strigate.ferrot.presentation.util.LifecycleEffect
 import org.strigate.ferrot.presentation.viewmodel.DownloadsViewModel
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 import kotlin.math.abs
 
 private const val SEARCH_FOCUS_DELAY_MILLIS = 357L
@@ -240,7 +240,7 @@ fun DownloadsScreen(
         topBar = {
             if (selectionMode) {
                 TopAppBar(
-                    colors = FerrotTopAppBarDefaults.colors(),
+                    colors = RefineryTopAppBarDefaults.colors(),
                     navigationIcon = {
                         IconButton(
                             onClick = {
@@ -342,7 +342,7 @@ fun DownloadsScreen(
                 )
             } else {
                 TopAppBar(
-                    colors = FerrotTopAppBarDefaults.colors(),
+                    colors = RefineryTopAppBarDefaults.colors(),
                     navigationIcon = {
                         if (isArchived) {
                             IconButton(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -33,18 +33,18 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.Screen
-import org.strigate.ferrot.presentation.component.settings.DropdownSetting
-import org.strigate.ferrot.presentation.component.settings.DropdownSettingOption
-import org.strigate.ferrot.presentation.component.settings.ExpandableSettingsSection
-import org.strigate.ferrot.presentation.component.settings.SwitchSetting
-import org.strigate.ferrot.presentation.component.settings.TextNavigateSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
-import org.strigate.ferrot.presentation.theme.FerrotTopAppBarDefaults
-import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.viewmodel.SettingsViewModel
+import org.strigate.refinery.component.settings.DropdownSetting
+import org.strigate.refinery.component.settings.DropdownSettingOption
+import org.strigate.refinery.component.settings.ExpandableSettingsSection
+import org.strigate.refinery.component.settings.SwitchSetting
+import org.strigate.refinery.component.settings.TextNavigateSetting
+import org.strigate.refinery.theme.LocalRefineryDimens
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,7 +53,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
 
@@ -96,7 +96,7 @@ fun SettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                colors = FerrotTopAppBarDefaults.colors(),
+                colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
                         onClick = {
@@ -135,7 +135,7 @@ fun SettingsScreen(
                         with(state.data) {
                             Column(
                                 modifier = Modifier
-                                    .padding(horizontal = dimens.spacingMediumAlt)
+                                    .padding(horizontal = refineryDimens.spacingMediumAlt)
                                     .verticalScroll(rememberScrollState()),
                             ) {
                                 ExpandableSettingsSection(
@@ -151,7 +151,7 @@ fun SettingsScreen(
                                             viewModel.setDownloadWifiOnly(checked)
                                         },
                                     )
-                                    Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                    Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                     SwitchSetting(
                                         text = stringResource(id = R.string.settings_title_automatic_duplicate_deletion),
                                         description = stringResource(id = R.string.settings_description_automatic_duplicate_deletion),
@@ -161,7 +161,7 @@ fun SettingsScreen(
                                         },
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                 ExpandableSettingsSection(
                                     icon = Icons.Outlined.SwapHoriz,
                                     title = stringResource(id = R.string.settings_section_swipe_actions),
@@ -190,21 +190,21 @@ fun SettingsScreen(
                                         },
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                 TextNavigateSetting(
                                     icon = Icons.Outlined.SystemUpdate,
                                     text = stringResource(R.string.settings_navigate_title_updates),
                                 ) {
                                     navController.navigate(Screen.Updates.route)
                                 }
-                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                 TextNavigateSetting(
                                     icon = Icons.Outlined.Info,
                                     text = stringResource(R.string.settings_navigate_title_about),
                                 ) {
                                     navController.navigate(Screen.About.route)
                                 }
-                                Spacer(modifier = Modifier.height(dimens.spacingMedium))
+                                Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
                             }
                         }
                     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -31,17 +31,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.toast
-import org.strigate.ferrot.presentation.component.settings.StaticSettingsSection
-import org.strigate.ferrot.presentation.component.settings.SwitchSetting
-import org.strigate.ferrot.presentation.component.settings.TextSetting
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.event.UpdatesEvent
 import org.strigate.ferrot.presentation.state.UpdatesUiState
-import org.strigate.ferrot.presentation.theme.FerrotTopAppBarDefaults
-import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
 import org.strigate.ferrot.presentation.viewmodel.UpdatesViewModel
+import org.strigate.refinery.component.settings.StaticSettingsSection
+import org.strigate.refinery.component.settings.SwitchSetting
+import org.strigate.refinery.component.settings.TextSetting
+import org.strigate.refinery.theme.LocalRefineryDimens
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -49,7 +49,7 @@ fun UpdatesScreen(
     modifier: Modifier = Modifier,
     viewModel: UpdatesViewModel = hiltViewModel(),
 ) {
-    val dimens = LocalDimens.current
+    val refineryDimens = LocalRefineryDimens.current
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
@@ -70,7 +70,7 @@ fun UpdatesScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                colors = FerrotTopAppBarDefaults.colors(),
+                colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
                         onClick = { backDispatcher?.onBackPressed() },
@@ -107,7 +107,7 @@ fun UpdatesScreen(
                             Column(
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .padding(horizontal = dimens.spacingMediumAlt)
+                                    .padding(horizontal = refineryDimens.spacingMediumAlt)
                                     .verticalScroll(rememberScrollState()),
                             ) {
                                 StaticSettingsSection(
@@ -136,7 +136,7 @@ fun UpdatesScreen(
                                         ),
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                 StaticSettingsSection(
                                     icon = Icons.Outlined.Extension,
                                     title = stringResource(R.string.settings_section_dependencies),
@@ -163,7 +163,7 @@ fun UpdatesScreen(
                                         ),
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(dimens.spacingSmall))
+                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                             }
                         }
                     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
@@ -1,50 +1,8 @@
 package org.strigate.ferrot.presentation.theme
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
-
-val Typography = Typography(
-    bodySmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.4.sp,
-    ),
-    bodyMedium = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 14.sp,
-        lineHeight = 20.sp,
-        letterSpacing = 0.25.sp,
-    ),
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp,
-    ),
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 20.sp,
-        lineHeight = 26.sp,
-        letterSpacing = 0.sp,
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp,
-    ),
-)
 
 object TextStyles {
     @Composable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.kotlin.compose) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/refinery/build.gradle.kts
+++ b/refinery/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.compose)
+}
+
+android {
+    namespace = "org.strigate.refinery"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 27
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    buildFeatures {
+        compose = true
+    }
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}
+
+dependencies {
+    api(platform(libs.androidx.compose.bom))
+    api(libs.androidx.compose.ui)
+    api(libs.androidx.compose.ui.graphics)
+    api(libs.androidx.compose.material.icons.extended)
+    api(libs.androidx.compose.material3)
+}

--- a/refinery/src/main/AndroidManifest.xml
+++ b/refinery/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
@@ -1,0 +1,125 @@
+package org.strigate.refinery.component.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import org.strigate.refinery.theme.LocalRefineryDimens
+
+import java.util.Locale
+
+@Composable
+fun ColorPickerSetting(
+    text: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+    onClick: (() -> Unit)? = null,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+    val chipColor = MaterialTheme.colorScheme.surface
+    val chipTextColor = MaterialTheme.colorScheme.onSurface
+    val clickableModifier = if (onClick != null) {
+        Modifier
+            .combinedClickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(),
+                onClick = {
+                    onClick()
+                },
+            )
+    } else Modifier
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(clickableModifier)
+            .padding(
+                horizontal = refineryDimens.spacingMedium,
+                vertical = refineryDimens.spacingMediumAlt,
+            ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = refineryDimens.spacingLarge),
+            ) {
+                Text(
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    text = text,
+                )
+                description?.let { currentDescription ->
+                    Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
+                    Text(
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        text = currentDescription,
+                    )
+                }
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(refineryDimens.radiusPill))
+                        .background(chipColor)
+                        .padding(
+                            start = refineryDimens.spacingSmall,
+                            end = refineryDimens.spacingMediumAlt,
+                            top = refineryDimens.spacingXSmallAlt,
+                            bottom = refineryDimens.spacingXSmallAlt,
+                        ),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(refineryDimens.spacingSmallAlt),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(refineryDimens.iconXSmall)
+                                .clip(RoundedCornerShape(refineryDimens.radiusMedium))
+                                .background(color),
+                        )
+                        Text(
+                            text = color.toHexString(),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = chipTextColor,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun Color.toHexString(): String {
+    val rgb = toArgb() and 0x00FFFFFF
+    return String.format(Locale.US, "#%06X", rgb)
+}

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/DropdownSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/DropdownSetting.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -28,9 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
-import org.strigate.ferrot.presentation.component.DropdownMenu
-import org.strigate.ferrot.presentation.component.DropdownMenuItem
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 data class DropdownSettingOption(
     val id: String,
@@ -46,6 +44,8 @@ fun DropdownSetting(
     description: String? = null,
     onOptionSelected: (DropdownSettingOption) -> Unit,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
+
     var expanded by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     val chipColor = MaterialTheme.colorScheme.surface
@@ -66,8 +66,8 @@ fun DropdownSetting(
                     },
                 )
                 .padding(
-                    horizontal = 16.dp,
-                    vertical = 12.dp,
+                    horizontal = refineryDimens.spacingMedium,
+                    vertical = refineryDimens.spacingMediumAlt,
                 ),
         ) {
             Row(
@@ -79,19 +79,19 @@ fun DropdownSetting(
                 Column(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(end = 24.dp),
+                        .padding(end = refineryDimens.spacingLarge),
                 ) {
                     Text(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                         text = text,
                     )
-                    description?.let {
-                        Spacer(modifier = Modifier.height(4.dp))
+                    description?.let { currentDescription ->
+                        Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
                         Text(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                            text = it,
+                            text = currentDescription,
                         )
                     }
                 }
@@ -104,13 +104,13 @@ fun DropdownSetting(
                     ) {
                         Row(
                             modifier = Modifier
-                                .clip(RoundedCornerShape(999.dp))
+                                .clip(RoundedCornerShape(refineryDimens.radiusPill))
                                 .background(chipColor)
                                 .padding(
-                                    start = 12.dp,
-                                    end = 8.dp,
-                                    top = 6.dp,
-                                    bottom = 6.dp,
+                                    start = refineryDimens.spacingMediumAlt,
+                                    end = refineryDimens.spacingSmall,
+                                    top = refineryDimens.spacingXSmallAlt,
+                                    bottom = refineryDimens.spacingXSmallAlt,
                                 ),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
@@ -121,21 +121,21 @@ fun DropdownSetting(
                             )
                             Icon(
                                 modifier = Modifier
-                                    .padding(start = 4.dp)
-                                    .size(20.dp),
+                                    .padding(start = refineryDimens.spacingXSmall)
+                                    .size(refineryDimens.iconXSmallAlt),
                                 imageVector = Icons.Filled.ArrowDropDown,
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                 contentDescription = null,
                             )
                         }
 
-                        DropdownMenu(
+                        SettingsDropdownMenu(
                             expanded = expanded,
                             onDismissRequest = {
                                 expanded = false
                             },
                             items = options.map { option ->
-                                DropdownMenuItem(
+                                SettingsDropdownMenuItem(
                                     id = option.id,
                                     text = option.text,
                                     onClick = {
@@ -143,7 +143,10 @@ fun DropdownSetting(
                                     },
                                 )
                             },
-                            offset = DpOffset(x = 0.dp, y = 4.dp),
+                            offset = DpOffset(
+                                x = refineryDimens.zero,
+                                y = refineryDimens.spacingXSmall
+                            ),
                         )
                     }
                 }

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ExpandableSettingsSection.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ExpandableSettingsSection.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -24,7 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun ExpandableSettingsSection(
@@ -35,12 +35,14 @@ fun ExpandableSettingsSection(
     content: @Composable () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(initialExpanded) }
+    val refineryDimens = LocalRefineryDimens.current
+
     Surface(
         modifier = modifier,
         color = MaterialTheme.colorScheme.surfaceVariant,
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 4.dp,
-        shadowElevation = 1.dp,
+        tonalElevation = refineryDimens.tonalElevationHigh,
+        shadowElevation = refineryDimens.shadowElevationLow,
     ) {
         Column(
             modifier = Modifier
@@ -51,18 +53,18 @@ fun ExpandableSettingsSection(
                 ) {
                     expanded = !expanded
                 }
-                .padding(vertical = 16.dp),
+                .padding(vertical = refineryDimens.spacingMedium),
         ) {
             SettingsSectionHeader(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = refineryDimens.spacingMedium),
                 icon = icon,
                 title = title,
             ) {
                 Icon(
                     modifier = Modifier
-                        .size(20.dp),
+                        .size(refineryDimens.iconXSmallAlt),
                     imageVector = if (expanded) {
                         Icons.Filled.KeyboardArrowUp
                     } else {
@@ -73,7 +75,7 @@ fun ExpandableSettingsSection(
                 )
             }
             if (expanded) {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                 CompositionLocalProvider(
                     LocalContentColor provides MaterialTheme.colorScheme.onSurfaceVariant
                 ) {

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsDropdownMenu.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsDropdownMenu.kt
@@ -1,0 +1,64 @@
+package org.strigate.refinery.component.settings
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpOffset
+import org.strigate.refinery.theme.LocalRefineryDimens
+
+internal data class SettingsDropdownMenuItem(
+    val id: String,
+    val text: String,
+    val enabled: Boolean = true,
+    val leadingIcon: (@Composable (() -> Unit))? = null,
+    val onClick: () -> Unit,
+)
+
+@Composable
+internal fun SettingsDropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    items: List<SettingsDropdownMenuItem>,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    offset: DpOffset = DpOffset.Zero,
+) {
+    if (!expanded) {
+        return
+    }
+    val refineryDimens = LocalRefineryDimens.current
+    DropdownMenu(
+        modifier = modifier
+            .padding(end = refineryDimens.spacingSmall),
+        onDismissRequest = onDismissRequest,
+        expanded = expanded,
+        shape = MaterialTheme.shapes.medium,
+        containerColor = containerColor,
+        offset = offset,
+        tonalElevation = refineryDimens.zero,
+        shadowElevation = refineryDimens.shadowElevationLow,
+    ) {
+        items.forEach { dropdownMenuItem ->
+            DropdownMenuItem(
+                leadingIcon = dropdownMenuItem.leadingIcon,
+                text = {
+                    Text(
+                        color = textColor,
+                        text = dropdownMenuItem.text,
+                    )
+                },
+                onClick = {
+                    dropdownMenuItem.onClick()
+                    onDismissRequest()
+                },
+                enabled = dropdownMenuItem.enabled,
+            )
+        }
+    }
+}

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsSectionHeader.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsSectionHeader.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 internal fun SettingsSectionHeader(
@@ -20,6 +20,7 @@ internal fun SettingsSectionHeader(
     modifier: Modifier = Modifier,
     trailingContent: (@Composable () -> Unit)? = null,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -27,14 +28,14 @@ internal fun SettingsSectionHeader(
         if (icon != null) {
             Icon(
                 modifier = Modifier
-                    .size(20.dp),
+                    .size(refineryDimens.iconXSmallAlt),
                 imageVector = icon,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         if (icon != null && title != null) {
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(refineryDimens.spacingMediumAlt))
         }
         if (title != null) {
             Text(

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/StaticSettingsSection.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/StaticSettingsSection.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun StaticSettingsSection(
@@ -21,27 +21,28 @@ fun StaticSettingsSection(
     title: String? = null,
     content: @Composable () -> Unit,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     Surface(
         modifier = modifier,
         color = MaterialTheme.colorScheme.surfaceVariant,
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 4.dp,
-        shadowElevation = 1.dp,
+        tonalElevation = refineryDimens.tonalElevationHigh,
+        shadowElevation = refineryDimens.shadowElevationLow,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 16.dp),
+                .padding(vertical = refineryDimens.spacingMedium),
         ) {
             if (title != null || icon != null) {
                 SettingsSectionHeader(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                        .padding(horizontal = refineryDimens.spacingMedium),
                     icon = icon,
                     title = title,
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
             }
             CompositionLocalProvider(
                 LocalContentColor provides MaterialTheme.colorScheme.onSurfaceVariant

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SwitchSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SwitchSetting.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun SwitchSetting(
@@ -28,6 +28,7 @@ fun SwitchSetting(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -38,8 +39,8 @@ fun SwitchSetting(
                 onCheckedChange(!checked)
             }
             .padding(
-                horizontal = 16.dp,
-                vertical = 12.dp,
+                horizontal = refineryDimens.spacingMedium,
+                vertical = refineryDimens.spacingMediumAlt,
             ),
     ) {
         Row(
@@ -51,25 +52,25 @@ fun SwitchSetting(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = 24.dp),
+                    .padding(end = refineryDimens.spacingLarge),
             ) {
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     text = text,
                 )
-                description?.let {
-                    Spacer(modifier = Modifier.height(4.dp))
+                description?.let { currentDescription ->
+                    Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
                     Text(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        text = it,
+                        text = currentDescription,
                     )
                 }
             }
             Switch(
                 modifier = Modifier
-                    .height(24.dp),
+                    .height(refineryDimens.iconXSmall),
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.primary,
                     checkedTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextNavigateSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextNavigateSetting.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -23,7 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun TextNavigateSetting(
@@ -33,12 +33,13 @@ fun TextNavigateSetting(
     description: String? = null,
     onClick: () -> Unit,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     Surface(
         modifier = modifier,
         color = MaterialTheme.colorScheme.surfaceVariant,
         shape = MaterialTheme.shapes.large,
-        tonalElevation = 4.dp,
-        shadowElevation = 1.dp,
+        tonalElevation = refineryDimens.tonalElevationHigh,
+        shadowElevation = refineryDimens.shadowElevationLow,
     ) {
         Column(
             modifier = Modifier
@@ -49,7 +50,7 @@ fun TextNavigateSetting(
                 ) {
                     onClick()
                 }
-                .padding(16.dp),
+                .padding(refineryDimens.spacingMedium),
         ) {
             Row(
                 modifier = Modifier
@@ -60,35 +61,35 @@ fun TextNavigateSetting(
                 if (icon != null) {
                     Icon(
                         modifier = Modifier
-                            .size(20.dp),
+                            .size(refineryDimens.iconXSmallAlt),
                         imageVector = icon,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         contentDescription = null,
                     )
-                    Spacer(modifier = Modifier.width(12.dp))
+                    Spacer(modifier = Modifier.width(refineryDimens.spacingMediumAlt))
                 }
                 Column(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(end = 24.dp),
+                        .padding(end = refineryDimens.spacingLarge),
                 ) {
                     Text(
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                         text = text,
                     )
-                    description?.let {
-                        Spacer(modifier = Modifier.height(4.dp))
+                    description?.let { currentDescription ->
+                        Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
                         Text(
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                            text = it,
+                            text = currentDescription,
                         )
                     }
                 }
                 Icon(
                     modifier = Modifier
-                        .size(20.dp),
+                        .size(refineryDimens.iconXSmallAlt),
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     contentDescription = null,

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextSetting.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.component.settings
+package org.strigate.refinery.component.settings
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import org.strigate.refinery.theme.LocalRefineryDimens
 
 @Composable
 fun TextSetting(
@@ -27,6 +27,7 @@ fun TextSetting(
     onLongClick: (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     val clickableModifier = if (enabled && (onClick != null || onLongClick != null)) {
         Modifier
             .combinedClickable(
@@ -57,8 +58,8 @@ fun TextSetting(
             .fillMaxWidth()
             .then(clickableModifier)
             .padding(
-                horizontal = 16.dp,
-                vertical = 12.dp,
+                horizontal = refineryDimens.spacingMedium,
+                vertical = refineryDimens.spacingMediumAlt,
             ),
     ) {
         Row(
@@ -70,7 +71,7 @@ fun TextSetting(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = 24.dp),
+                    .padding(end = refineryDimens.spacingLarge),
             ) {
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
@@ -78,7 +79,7 @@ fun TextSetting(
                     text = text,
                 )
                 description?.let {
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
                     Text(
                         style = MaterialTheme.typography.bodySmall,
                         color = descriptionColor,

--- a/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryDimens.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryDimens.kt
@@ -1,0 +1,45 @@
+package org.strigate.refinery.theme
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Stable
+data class RefineryDimens(
+    val zero: Dp = 0.dp,
+
+    val spacingXXSmall: Dp = 2.dp,
+    val spacingXSmall: Dp = 4.dp,
+    val spacingXSmallAlt: Dp = 6.dp,
+    val spacingSmall: Dp = 8.dp,
+    val spacingSmallAlt: Dp = 10.dp,
+    val spacingMediumAlt: Dp = 12.dp,
+    val spacingMedium: Dp = 16.dp,
+    val spacingLarge: Dp = 24.dp,
+    val spacingXLarge: Dp = 32.dp,
+    val spacingXXLarge: Dp = 48.dp,
+
+    val iconXXSmall: Dp = 16.dp,
+    val iconXSmallAlt: Dp = 20.dp,
+    val iconXSmall: Dp = 24.dp,
+    val iconSmall: Dp = 32.dp,
+    val iconMedium: Dp = 48.dp,
+    val iconLarge: Dp = 72.dp,
+    val iconXLarge: Dp = 96.dp,
+    val iconXXLarge: Dp = 128.dp,
+
+    val radiusSmall: Dp = 4.dp,
+    val radiusMedium: Dp = 8.dp,
+    val radiusLarge: Dp = 16.dp,
+    val radiusPill: Dp = 999.dp,
+
+    val tonalElevationLow: Dp = 1.dp,
+    val tonalElevationHigh: Dp = 4.dp,
+
+    val shadowElevationLow: Dp = 1.dp,
+)
+
+val LocalRefineryDimens = staticCompositionLocalOf<RefineryDimens> {
+    error("RefineryDimens not provided")
+}

--- a/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryTheme.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryTheme.kt
@@ -1,4 +1,4 @@
-package org.strigate.ferrot.presentation.theme
+package org.strigate.refinery.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -8,10 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 
-val FerrotCoral = Color(0xFFFF8557)
+val RefineryPrimary = Color(0xFFFF8557)
 
 private val LightColorScheme = lightColorScheme(
-    primary = FerrotCoral,
+    primary = RefineryPrimary,
     onPrimary = Color.White,
     primaryContainer = Color(0xFFFFE7DF),
     onPrimaryContainer = Color(0xFF2B140D),
@@ -37,7 +37,7 @@ private val LightColorScheme = lightColorScheme(
     surfaceTint = Color.Transparent,
     inverseSurface = Color(0xFF2F2B2A),
     inverseOnSurface = Color(0xFFF8EEEA),
-    inversePrimary = FerrotCoral,
+    inversePrimary = RefineryPrimary,
 
     error = Color(0xFFB3261E),
     onError = Color.White,
@@ -46,7 +46,7 @@ private val LightColorScheme = lightColorScheme(
 )
 
 private val DarkColorScheme = darkColorScheme(
-    primary = FerrotCoral,
+    primary = RefineryPrimary,
     onPrimary = Color.White,
     primaryContainer = Color(0xFF5C3125),
     onPrimaryContainer = Color(0xFFFFE7DF),
@@ -81,20 +81,21 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 @Composable
-fun FerrotTheme(
-    dimens: Dimens = Dimens(),
+fun RefineryTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dimens: RefineryDimens = RefineryDimens(),
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
-        LocalDimens provides dimens,
+        LocalRefineryDimens provides dimens,
     ) {
         MaterialTheme(
-            colorScheme = if (isSystemInDarkTheme()) {
+            colorScheme = if (darkTheme) {
                 DarkColorScheme
             } else {
                 LightColorScheme
             },
-            typography = Typography,
+            typography = RefineryTypography,
             content = content,
         )
     }

--- a/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryTopAppBarDefaults.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryTopAppBarDefaults.kt
@@ -1,11 +1,11 @@
-package org.strigate.ferrot.presentation.theme
+package org.strigate.refinery.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 
-object FerrotTopAppBarDefaults {
+object RefineryTopAppBarDefaults {
     @Composable
     fun colors(): TopAppBarColors {
         return TopAppBarDefaults.topAppBarColors(

--- a/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryType.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryType.kt
@@ -1,0 +1,45 @@
+package org.strigate.refinery.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+internal val RefineryTypography = Typography(
+    bodySmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.4.sp,
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp,
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp,
+    ),
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 20.sp,
+        lineHeight = 26.sp,
+        letterSpacing = 0.sp,
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp,
+    ),
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,3 +26,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Ferrot"
 include(":app")
+include(":refinery")


### PR DESCRIPTION
- Add the `:refinery` module with shared theme and settings components
- Move `RefineryTheme`, `RefineryTopAppBarDefaults`, `RefineryTypography`, and `RefineryDimens` into the new module
- Update ferrot screens and shared UI to consume refinery-owned settings components and spacing tokens
- Replace the `FerrotTheme` wrapper with direct `RefineryTheme` usage and explicit `LocalDimens` provision
- Remove superseded app-owned settings and theme components
- Normalize `.gitignore` directory entries