### PR TITLE
fix: Preserve search cursor position in downloads query

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -140,9 +140,10 @@ class DownloadsViewModel @Inject constructor(
 
     fun updateSearchQuery(value: TextFieldValue) {
         val trimmed = value.text.take(MAX_SEARCH_LENGTH)
+        val selectionEnd = value.selection.end.coerceAtMost(trimmed.length)
         val normalizedValue = TextFieldValue(
             text = trimmed,
-            selection = TextRange(trimmed.length),
+            selection = TextRange(selectionEnd),
         )
         if (_searchQuery.value == normalizedValue) {
             return

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -220,7 +220,9 @@ class DownloadsViewModelTest {
         assertEquals(100, viewModel.searchQuery.value.text.length)
         assertEquals(100, viewModel.searchQuery.value.selection.start)
 
-        viewModel.updateSearchQuery(TextFieldValue("download 2", TextRange(10)))
+        viewModel.updateSearchQuery(TextFieldValue("download 2", TextRange(4)))
+        assertEquals(4, viewModel.searchQuery.value.selection.start)
+
         waitForUiState(viewModel) { state ->
             val data = state as? DownloadsUiState.Data ?: return@waitForUiState false
             data.data.downloads.size == 1 && data.data.downloads.single().id == 2L


### PR DESCRIPTION
- Clamp `TextFieldValue` selection when `updateSearchQuery` trims input
- Preserve the user cursor position instead of always moving it to the end
- Extend `DownloadsViewModelTest` to verify trimmed input and cursor retention