### PR TITLE
fix: Simplify downloads list auto-scroll behavior

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -766,9 +766,6 @@ private fun DownloadsList(
     }
     val animatingOutIds = remember { mutableStateMapOf<Long, Boolean>() }
     val swipeActionIds = remember { mutableStateMapOf<Long, DownloadSwipeActionUiData>() }
-    var trackedAutoScrollDownloadId by remember { mutableStateOf<Long?>(null) }
-    var trackedAutoScrollWasActive by remember { mutableStateOf(false) }
-
     val showScrollToBottom by remember {
         derivedStateOf {
             val layoutInfo = lazyListState.layoutInfo
@@ -784,19 +781,9 @@ private fun DownloadsList(
         currentItemIds = itemIds,
         currentPendingDeleteIds = pendingDeleteIds,
     )
-    val visibleCount by remember(items) {
-        derivedStateOf {
-            items.size
-        }
-    }
+    val visibleCount = items.size
     LaunchedEffect(itemIds, pendingDeleteIds, searchQuery) {
-        if (hasNewItemAtTop(previousItemIds, itemIds, previousPendingDeleteIds, searchQuery)) {
-            trackedAutoScrollDownloadId =
-                itemIds.firstOrNull { it !in previousItemIds && it !in previousPendingDeleteIds }
-            trackedAutoScrollWasActive = items
-                .firstOrNull { it.id == trackedAutoScrollDownloadId }
-                ?.status
-                ?.isActive == true
+        if (hasNewVisibleItem(previousItemIds, itemIds, previousPendingDeleteIds, searchQuery)) {
             lazyListState.scrollToItem(0)
         }
         previousItemIds = itemIds
@@ -812,24 +799,6 @@ private fun DownloadsList(
         ) {
             lazyListState.scrollToItem(0)
         }
-    }
-    LaunchedEffect(items.map { it.id to it.status }, trackedAutoScrollDownloadId) {
-        val trackedId = trackedAutoScrollDownloadId ?: return@LaunchedEffect
-        val trackedIndex = items.indexOfFirst { it.id == trackedId }
-        if (trackedIndex < 0) {
-            trackedAutoScrollDownloadId = null
-            trackedAutoScrollWasActive = false
-            return@LaunchedEffect
-        }
-        val currentStatus = items[trackedIndex].status
-        val isActive = currentStatus.isActive
-        if (trackedAutoScrollWasActive && !isActive) {
-            lazyListState.animateScrollToItem(trackedIndex)
-            trackedAutoScrollDownloadId = null
-            trackedAutoScrollWasActive = false
-            return@LaunchedEffect
-        }
-        trackedAutoScrollWasActive = isActive
     }
     Box(
         modifier = Modifier
@@ -1490,7 +1459,7 @@ internal fun getBulkDeleteVisibleIds(
     return selectedIds.intersect(visibleIds)
 }
 
-internal fun hasNewItemAtTop(
+internal fun hasNewVisibleItem(
     previousItemIds: List<Long>,
     currentItemIds: List<Long>,
     previousPendingDeleteIds: Set<Long>,

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
@@ -27,8 +27,8 @@ class DownloadsScreenScrollBehaviorTest {
     }
 
     @Test
-    fun hasNewItemAtTop_returnsTrue_whenNewItemIsInsertedAtTop() {
-        val shouldScroll = hasNewItemAtTop(
+    fun hasNewVisibleItem_returnsTrue_whenNewItemIsInsertedAtTop() {
+        val shouldScroll = hasNewVisibleItem(
             previousItemIds = listOf(3L, 2L, 1L),
             currentItemIds = listOf(4L, 3L, 2L, 1L),
             previousPendingDeleteIds = emptySet(),
@@ -39,8 +39,8 @@ class DownloadsScreenScrollBehaviorTest {
     }
 
     @Test
-    fun hasNewItemAtTop_returnsFalse_onInitialLoad() {
-        val shouldScroll = hasNewItemAtTop(
+    fun hasNewVisibleItem_returnsFalse_onInitialLoad() {
+        val shouldScroll = hasNewVisibleItem(
             previousItemIds = emptyList(),
             currentItemIds = listOf(3L, 2L, 1L),
             previousPendingDeleteIds = emptySet(),
@@ -51,8 +51,8 @@ class DownloadsScreenScrollBehaviorTest {
     }
 
     @Test
-    fun hasNewItemAtTop_returnsFalse_whenExistingItemMovesToTop() {
-        val shouldScroll = hasNewItemAtTop(
+    fun hasNewVisibleItem_returnsFalse_whenExistingItemMovesToTop() {
+        val shouldScroll = hasNewVisibleItem(
             previousItemIds = listOf(3L, 2L, 1L),
             currentItemIds = listOf(2L, 3L, 1L),
             previousPendingDeleteIds = emptySet(),
@@ -63,8 +63,20 @@ class DownloadsScreenScrollBehaviorTest {
     }
 
     @Test
-    fun hasNewItemAtTop_returnsFalse_whileSearching() {
-        val shouldScroll = hasNewItemAtTop(
+    fun hasNewVisibleItem_returnsFalse_whenExistingItemReordersAfterCompletion() {
+        val shouldScroll = hasNewVisibleItem(
+            previousItemIds = listOf(10L, 9L, 8L, 7L),
+            currentItemIds = listOf(9L, 8L, 7L, 10L),
+            previousPendingDeleteIds = emptySet(),
+            searchQuery = "",
+        )
+
+        assertFalse(shouldScroll)
+    }
+
+    @Test
+    fun hasNewVisibleItem_returnsFalse_whileSearching() {
+        val shouldScroll = hasNewVisibleItem(
             previousItemIds = listOf(3L, 2L, 1L),
             currentItemIds = listOf(4L, 3L, 2L, 1L),
             previousPendingDeleteIds = emptySet(),
@@ -75,8 +87,8 @@ class DownloadsScreenScrollBehaviorTest {
     }
 
     @Test
-    fun hasNewItemAtTop_returnsTrue_whenNewItemIsAddedNotAtTop() {
-        val shouldScroll = hasNewItemAtTop(
+    fun hasNewVisibleItem_returnsTrue_whenNewItemIsAddedNotAtTop() {
+        val shouldScroll = hasNewVisibleItem(
             previousItemIds = listOf(3L, 2L, 1L),
             currentItemIds = listOf(3L, 2L, 1L, 4L),
             previousPendingDeleteIds = emptySet(),
@@ -87,8 +99,8 @@ class DownloadsScreenScrollBehaviorTest {
     }
 
     @Test
-    fun hasNewItemAtTop_returnsFalse_whenUndoReAddsPendingDeleteItem() {
-        val shouldScroll = hasNewItemAtTop(
+    fun hasNewVisibleItem_returnsFalse_whenUndoReAddsPendingDeleteItem() {
+        val shouldScroll = hasNewVisibleItem(
             previousItemIds = listOf(3L, 2L),
             currentItemIds = listOf(3L, 2L, 1L),
             previousPendingDeleteIds = setOf(1L),


### PR DESCRIPTION
- Stop following newly added downloads after status reordering
- Keep auto-scroll focused on newly visible items and restored items
- Rename `hasNewItemAtTop` to `hasNewVisibleItem`
- Add coverage for completion-driven reordering in scroll behavior tests