### PR TITLE
fix: Add activity label for `ShareReceiveActivity`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,7 @@
         <activity
             android:name=".app.ShareReceiveActivity"
             android:exported="true"
+            android:label="@string/activity_label_download"
             android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
         <item quantity="other">Deleting downloads</item>
     </plurals>
 
+    <string name="activity_label_download">Download</string>
+
     <string name="screen_title_download">Download</string>
     <string name="screen_title_archived_download">Archived download</string>
     <string name="screen_title_archived">Archived</string>


### PR DESCRIPTION
- Set `android:label` on `ShareReceiveActivity`
- Define the `activity_label_download` string as `Download`