### PR TITLE
refactor: Remove unused `PAUSED` download status

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadWithMetadataViewDao.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/dao/DownloadWithMetadataViewDao.kt
@@ -20,16 +20,15 @@ interface DownloadWithMetadataViewDao {
                 "    WHEN 'WAITING_FOR_NETWORK' THEN 1\n" +
                 "    WHEN 'WAITING_FOR_WIFI' THEN 2\n" +
                 "    WHEN 'METADATA' THEN 3\n" +
-                "    WHEN 'PAUSED' THEN 4\n" +
-                "    WHEN 'DOWNLOADING' THEN 5\n" +
-                "    WHEN 'COMPLETED' THEN 6\n" +
-                "    WHEN 'FAILED' THEN 7\n" +
-                "    WHEN 'STOPPED' THEN 8\n" +
-                "    ELSE 9\n" +
+                "    WHEN 'DOWNLOADING' THEN 4\n" +
+                "    WHEN 'COMPLETED' THEN 5\n" +
+                "    WHEN 'FAILED' THEN 6\n" +
+                "    WHEN 'STOPPED' THEN 7\n" +
+                "    ELSE 8\n" +
                 "  END,\n" +
                 "  CASE\n" +
                 "    WHEN status = 'COMPLETED' THEN completedAtMillis\n" +
-                "    WHEN status IN ('DOWNLOADING','PAUSED','METADATA') THEN startedAtMillis\n" +
+                "    WHEN status IN ('DOWNLOADING','METADATA') THEN startedAtMillis\n" +
                 "    WHEN status IN ('QUEUED','WAITING_FOR_NETWORK','WAITING_FOR_WIFI','FAILED','STOPPED') THEN enqueuedAtMillis\n" +
                 "    ELSE enqueuedAtMillis\n" +
                 "  END DESC,\n" +

--- a/app/src/main/kotlin/org/strigate/ferrot/data/local/entity/DownloadStatus.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/local/entity/DownloadStatus.kt
@@ -6,7 +6,6 @@ enum class DownloadStatus {
     WAITING_FOR_WIFI,
     METADATA,
     DOWNLOADING,
-    PAUSED,
     COMPLETED,
     FAILED,
     STOPPED,

--- a/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadStatusMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/data/mapper/DownloadStatusMappers.kt
@@ -9,7 +9,6 @@ internal fun EntityStatus.toDomain() = when (this) {
     EntityStatus.WAITING_FOR_WIFI -> DomainStatus.WAITING_FOR_WIFI
     EntityStatus.METADATA -> DomainStatus.METADATA
     EntityStatus.DOWNLOADING -> DomainStatus.DOWNLOADING
-    EntityStatus.PAUSED -> DomainStatus.PAUSED
     EntityStatus.COMPLETED -> DomainStatus.COMPLETED
     EntityStatus.FAILED -> DomainStatus.FAILED
     EntityStatus.STOPPED -> DomainStatus.STOPPED
@@ -21,7 +20,6 @@ internal fun DomainStatus.toEntity() = when (this) {
     DomainStatus.WAITING_FOR_WIFI -> EntityStatus.WAITING_FOR_WIFI
     DomainStatus.METADATA -> EntityStatus.METADATA
     DomainStatus.DOWNLOADING -> EntityStatus.DOWNLOADING
-    DomainStatus.PAUSED -> EntityStatus.PAUSED
     DomainStatus.COMPLETED -> EntityStatus.COMPLETED
     DomainStatus.FAILED -> EntityStatus.FAILED
     DomainStatus.STOPPED -> EntityStatus.STOPPED

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadStatus.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/model/DownloadStatus.kt
@@ -6,7 +6,6 @@ enum class DownloadStatus {
     WAITING_FOR_WIFI,
     METADATA,
     DOWNLOADING,
-    PAUSED,
     COMPLETED,
     FAILED,
     STOPPED,

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/apply/ApplyWifiOnlyPolicyUseCase.kt
@@ -28,7 +28,6 @@ class ApplyWifiOnlyPolicyUseCase @Inject constructor(
                 val downloadStatuses = setOf(
                     DownloadStatus.QUEUED,
                     DownloadStatus.WAITING_FOR_NETWORK,
-                    DownloadStatus.PAUSED,
                     DownloadStatus.METADATA,
                     DownloadStatus.DOWNLOADING,
                 )

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/GetResumableDownloadsCombinedUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/GetResumableDownloadsCombinedUseCase.kt
@@ -12,7 +12,6 @@ class GetResumableDownloadsCombinedUseCase @Inject constructor(
         DownloadStatus.QUEUED,
         DownloadStatus.WAITING_FOR_NETWORK,
         DownloadStatus.WAITING_FOR_WIFI,
-        DownloadStatus.PAUSED,
         DownloadStatus.METADATA,
         DownloadStatus.DOWNLOADING,
     )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -54,7 +54,6 @@ fun DownloadPrimaryActionButton(
             onClick = onPauseResume,
         )
 
-        DownloadStatusUiData.PAUSED,
         DownloadStatusUiData.STOPPED,
         DownloadStatusUiData.FAILED -> ActionConfig(
             icon = Icons.Filled.Refresh,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
@@ -92,7 +92,6 @@ private fun StatusSizeEtaRow(
         DownloadStatusUiData.WAITING_FOR_WIFI -> stringResource(R.string.status_waiting_for_wifi)
         DownloadStatusUiData.METADATA -> stringResource(R.string.status_metadata)
         DownloadStatusUiData.DOWNLOADING -> stringResource(R.string.status_downloading)
-        DownloadStatusUiData.PAUSED -> stringResource(R.string.status_paused)
         DownloadStatusUiData.COMPLETED -> stringResource(R.string.status_completed)
         DownloadStatusUiData.FAILED -> stringResource(R.string.status_failed)
         DownloadStatusUiData.STOPPED -> stringResource(R.string.status_stopped)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadStatusUiMappers.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/mapper/DownloadStatusUiMappers.kt
@@ -9,7 +9,6 @@ fun DownloadStatus.toUiData(): DownloadStatusUiData = when (this) {
     DownloadStatus.WAITING_FOR_WIFI -> DownloadStatusUiData.WAITING_FOR_WIFI
     DownloadStatus.METADATA -> DownloadStatusUiData.METADATA
     DownloadStatus.DOWNLOADING -> DownloadStatusUiData.DOWNLOADING
-    DownloadStatus.PAUSED -> DownloadStatusUiData.PAUSED
     DownloadStatus.COMPLETED -> DownloadStatusUiData.COMPLETED
     DownloadStatus.FAILED -> DownloadStatusUiData.FAILED
     DownloadStatus.STOPPED -> DownloadStatusUiData.STOPPED

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadStatusUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadStatusUiData.kt
@@ -6,7 +6,6 @@ enum class DownloadStatusUiData {
     WAITING_FOR_WIFI,
     METADATA,
     DOWNLOADING,
-    PAUSED,
     COMPLETED,
     FAILED,
     STOPPED,
@@ -20,7 +19,6 @@ val DownloadStatusUiData.isActive: Boolean
         DownloadStatusUiData.METADATA,
         DownloadStatusUiData.DOWNLOADING -> true
 
-        DownloadStatusUiData.PAUSED,
         DownloadStatusUiData.COMPLETED,
         DownloadStatusUiData.FAILED,
         DownloadStatusUiData.STOPPED -> false

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeleteAllOrphanDownloadFilesWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeleteAllOrphanDownloadFilesWorker.kt
@@ -152,8 +152,7 @@ class DeleteAllOrphanDownloadFilesWorker(
             DownloadStatus.WAITING_FOR_NETWORK,
             DownloadStatus.WAITING_FOR_WIFI,
             DownloadStatus.METADATA,
-            DownloadStatus.DOWNLOADING,
-            DownloadStatus.PAUSED -> true
+            DownloadStatus.DOWNLOADING -> true
 
             DownloadStatus.COMPLETED,
             DownloadStatus.FAILED,

--- a/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DownloadWorker.kt
@@ -119,7 +119,6 @@ class DownloadWorker(
                     DownloadStatus.QUEUED,
                     DownloadStatus.WAITING_FOR_NETWORK,
                     DownloadStatus.WAITING_FOR_WIFI,
-                    DownloadStatus.PAUSED,
                     DownloadStatus.FAILED,
                     DownloadStatus.METADATA,
                     DownloadStatus.DOWNLOADING -> true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,6 @@
     <string name="status_waiting_for_wifi">Waiting for Wi-Fi</string>
     <string name="status_metadata">Downloading metadata</string>
     <string name="status_downloading">Downloading</string>
-    <string name="status_paused">Paused</string>
     <string name="status_completed">Completed</string>
     <string name="status_failed">Failed</string>
     <string name="status_stopped">Stopped</string>

--- a/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/data/repository/DownloadRepositoryImplTest.kt
@@ -120,12 +120,12 @@ class DownloadRepositoryImplTest {
     @Test
     fun getByIdAsFlow_mapsEntityToDomain() = runTest(testDispatcher) {
         `when`(downloadDao.getByIdAsFlow(8L))
-            .thenReturn(flowOf(sampleEntity(id = 8L, status = EntityStatus.PAUSED)))
+            .thenReturn(flowOf(sampleEntity(id = 8L, status = EntityStatus.STOPPED)))
 
         val repository = DownloadRepositoryImpl(downloadDao)
         val result = repository.getByIdAsFlow(8L).first()
 
-        assertEquals(sampleDownload(id = 8L, status = DownloadStatus.PAUSED), result)
+        assertEquals(sampleDownload(id = 8L, status = DownloadStatus.STOPPED), result)
     }
 
     @Test

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetResumableDownloadsCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/GetResumableDownloadsCombinedUseCaseTest.kt
@@ -45,12 +45,11 @@ class GetResumableDownloadsCombinedUseCaseTest {
             sampleDownload(1L, DownloadStatus.QUEUED),
             sampleDownload(2L, DownloadStatus.WAITING_FOR_NETWORK),
             sampleDownload(3L, DownloadStatus.WAITING_FOR_WIFI),
-            sampleDownload(4L, DownloadStatus.PAUSED),
-            sampleDownload(5L, DownloadStatus.METADATA),
-            sampleDownload(6L, DownloadStatus.DOWNLOADING),
-            sampleDownload(7L, DownloadStatus.COMPLETED),
-            sampleDownload(8L, DownloadStatus.FAILED),
-            sampleDownload(9L, DownloadStatus.STOPPED),
+            sampleDownload(4L, DownloadStatus.METADATA),
+            sampleDownload(5L, DownloadStatus.DOWNLOADING),
+            sampleDownload(6L, DownloadStatus.COMPLETED),
+            sampleDownload(7L, DownloadStatus.FAILED),
+            sampleDownload(8L, DownloadStatus.STOPPED),
         )
         `when`(getAllDownloadsUseCase.invoke())
             .thenReturn(downloads)
@@ -62,9 +61,8 @@ class GetResumableDownloadsCombinedUseCaseTest {
                 sampleDownload(1L, DownloadStatus.QUEUED),
                 sampleDownload(2L, DownloadStatus.WAITING_FOR_NETWORK),
                 sampleDownload(3L, DownloadStatus.WAITING_FOR_WIFI),
-                sampleDownload(4L, DownloadStatus.PAUSED),
-                sampleDownload(5L, DownloadStatus.METADATA),
-                sampleDownload(6L, DownloadStatus.DOWNLOADING),
+                sampleDownload(4L, DownloadStatus.METADATA),
+                sampleDownload(5L, DownloadStatus.DOWNLOADING),
             ),
             result,
         )

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadStatusUiMappersTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/mapper/DownloadStatusUiMappersTest.kt
@@ -18,7 +18,6 @@ class DownloadStatusUiMappersTest {
         assertEquals(DownloadStatusUiData.WAITING_FOR_WIFI, mapped[DownloadStatus.WAITING_FOR_WIFI])
         assertEquals(DownloadStatusUiData.METADATA, mapped[DownloadStatus.METADATA])
         assertEquals(DownloadStatusUiData.DOWNLOADING, mapped[DownloadStatus.DOWNLOADING])
-        assertEquals(DownloadStatusUiData.PAUSED, mapped[DownloadStatus.PAUSED])
         assertEquals(DownloadStatusUiData.COMPLETED, mapped[DownloadStatus.COMPLETED])
         assertEquals(DownloadStatusUiData.FAILED, mapped[DownloadStatus.FAILED])
         assertEquals(DownloadStatusUiData.STOPPED, mapped[DownloadStatus.STOPPED])


### PR DESCRIPTION
- Remove `PAUSED` from `DownloadStatus`, `DownloadStatusUiData`, and related status mappers
- Drop `PAUSED` handling from `DownloadWorker`, `DeleteAllOrphanDownloadFilesWorker`, `ApplyWifiOnlyPolicyUseCase`, and `GetResumableDownloadsCombinedUseCase`
- Simplify download status ordering and timestamp selection by removing `PAUSED` query branches
- Remove `PAUSED` UI rendering from `DownloadPrimaryActionButton`, `DownloadProgressSection`, and download status strings
- Update repository, mapper, and resumable download tests to reflect the reduced status set