### PR TITLE
fix: Correct combined delete success reporting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,12 +49,13 @@ android {
         versionName = BuildInfo.VERSION_NAME
         stringField("VERSION", BuildInfo.BASE_VERSION)
         stringField("VERSION_TAG", "v${BuildInfo.BASE_VERSION}")
-        applyFirebaseProperties()
         ndk {
             ndkVersion = "29.0.14206865"
             abiFilters += listOf("arm64-v8a", "x86_64")
         }
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        applyFirebaseProperties()
     }
     signingConfigs {
         if (keystorePropertiesFile.exists()) {

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCase.kt
@@ -22,25 +22,12 @@ class DeleteDownloadAndRelatedCombinedUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(downloadId: Long): Boolean = withContext(Dispatchers.IO) {
         clearNotificationsByDownloadIdUseCase(downloadId)
-
-        val downloadFilesDeleted = downloadUseCase
-            .deleteDownloadFilesUseCase(downloadId)
-        val downloadMetadataDeleted = downloadMetadataUseCase
-            .deleteDownloadMetadataByDownloadIdUseCase(downloadId)
-        val downloadProgressDeleted = downloadProgressUseCase
-            .deleteDownloadProgressByDownloadIdUseCase(downloadId)
-        val downloadAudioDeleted = downloadAudioUseCase
-            .deleteDownloadAudioUseCase(downloadId)
-        val downloadVideoDeleted = downloadVideoUseCase
-            .deleteDownloadVideoUseCase(downloadId)
-        val downloadDeleted = downloadUseCase
-            .deleteDownloadByIdUseCase(downloadId)
-
-        downloadFilesDeleted
-                && downloadAudioDeleted
-                && downloadVideoDeleted
-                && downloadMetadataDeleted
-                && downloadProgressDeleted
-                && downloadDeleted
+        val downloadFilesDeleted = downloadUseCase.deleteDownloadFilesUseCase(downloadId)
+        downloadMetadataUseCase.deleteDownloadMetadataByDownloadIdUseCase(downloadId)
+        downloadProgressUseCase.deleteDownloadProgressByDownloadIdUseCase(downloadId)
+        downloadAudioUseCase.deleteDownloadAudioUseCase(downloadId)
+        downloadVideoUseCase.deleteDownloadVideoUseCase(downloadId)
+        val downloadDeleted = downloadUseCase.deleteDownloadByIdUseCase(downloadId)
+        downloadFilesDeleted && downloadDeleted
     }
 }

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/combined/DeleteDownloadAndRelatedCombinedUseCaseTest.kt
@@ -110,23 +110,60 @@ class DeleteDownloadAndRelatedCombinedUseCaseTest {
     }
 
     @Test
-    fun invoke_returnsFalse_whenAnyDeleteFails() = runTest(testDispatcher) {
+    fun invoke_returnsTrue_whenRelatedRowsAreAlreadyMissing() = runTest(testDispatcher) {
         stubDeletes(
             files = true,
             metadata = false,
-            progress = true,
-            audio = true,
-            video = true,
+            progress = false,
+            audio = false,
+            video = false,
             download = true
         )
 
         val result = createUseCase().invoke(32L)
 
+        assertTrue(result)
+        verifyDeleteSequence(32L)
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenFileDeletionFails() = runTest(testDispatcher) {
+        stubDeletes(
+            files = false,
+            metadata = true,
+            progress = true,
+            audio = true,
+            video = true,
+            download = true,
+        )
+
+        val result = createUseCase().invoke(33L)
+
         assertFalse(result)
         verify(clearNotificationsByDownloadIdUseCase)
-            .invoke(32L)
+            .invoke(33L)
         verify(deleteDownloadByIdUseCase)
-            .invoke(32L)
+            .invoke(33L)
+    }
+
+    @Test
+    fun invoke_returnsFalse_whenPrimaryDownloadDeleteFails() = runTest(testDispatcher) {
+        stubDeletes(
+            files = true,
+            metadata = true,
+            progress = true,
+            audio = true,
+            video = true,
+            download = false,
+        )
+
+        val result = createUseCase().invoke(34L)
+
+        assertFalse(result)
+        verify(clearNotificationsByDownloadIdUseCase)
+            .invoke(34L)
+        verify(deleteDownloadByIdUseCase)
+            .invoke(34L)
     }
 
     private suspend fun stubDeletes(


### PR DESCRIPTION
- Treat missing child-row cleanup from `DeleteDownloadAndRelatedCombinedUseCase` as best-effort
- Keep `DeleteDownloadAndRelatedCombinedUseCase` success tied to file removal and primary download deletion
- Expand `DeleteDownloadAndRelatedCombinedUseCaseTest` to cover missing related rows and primary failure cases