### PR TITLE
fix: Scope retry failed downloads to visible non-pending items

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadsUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadsUiData.kt
@@ -4,6 +4,7 @@ data class DownloadsUiData(
     val downloads: List<DownloadItemUiData>,
     val availableUpdate: AvailableUpdateUiData?,
     val pendingDeleteIds: Set<Long>,
+    val retryFailedDownloadIds: Set<Long>,
     val leftSwipeAction: DownloadSwipeActionUiData,
     val rightSwipeAction: DownloadSwipeActionUiData,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -110,7 +110,6 @@ import org.strigate.ferrot.presentation.model.DownloadItemUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.model.isActive
-import org.strigate.ferrot.presentation.model.isFailed
 import org.strigate.ferrot.presentation.state.DownloadsUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.theme.TextStyles
@@ -179,13 +178,14 @@ fun DownloadsScreen(
     val hasDownloads = allIds.isNotEmpty()
     val allSelected = selectedIds.isNotEmpty() && selectedIds.size == allIds.size
     val selectionMode = selectedIds.isNotEmpty()
-    val pendingDeleteIds = (uiState as? DownloadsUiState.Data)?.data?.pendingDeleteIds ?: emptySet()
+    val pendingDeleteIds = (uiState as? DownloadsUiState.Data)
+        ?.data
+        ?.pendingDeleteIds ?: emptySet()
     val hasPendingDeletes = pendingDeleteIds.isNotEmpty()
-
-    val hasFailedDownloads = remember(uiState) {
-        val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
-        downloads.any { it.status.isFailed }
-    }
+    val retryFailedDownloadIds = (uiState as? DownloadsUiState.Data)
+        ?.data
+        ?.retryFailedDownloadIds ?: emptySet()
+    val hasFailedDownloads = retryFailedDownloadIds.isNotEmpty()
     val hasActiveDownloads = remember(uiState) {
         val downloads = (uiState as? DownloadsUiState.Data)?.data?.downloads.orEmpty()
         downloads.any { it.status.isActive }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModel.kt
@@ -36,7 +36,6 @@ import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.event.DownloadsEvent
 import org.strigate.ferrot.presentation.mapper.toUiData
 import org.strigate.ferrot.presentation.model.AvailableUpdateUiData
-import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadsUiData
 import org.strigate.ferrot.presentation.model.isActive
 import org.strigate.ferrot.presentation.state.DownloadsUiState
@@ -105,12 +104,20 @@ class DownloadsViewModel @Inject constructor(
                 .filter { it.pendingDelete }
                 .map { it.id }
                 .toSet()
-            val filteredDownloads = downloadsWithMetadata
+            val visibleDownloads = downloadsWithMetadata
                 .asSequence()
                 .filter { !it.pendingDelete }
                 .filter {
                     query.isBlank() || it.title.contains(query, ignoreCase = true)
                 }
+                .toList()
+            val retryFailedDownloadIds = visibleDownloads
+                .asSequence()
+                .filter { it.status == DownloadStatus.FAILED }
+                .map { it.id }
+                .toSet()
+            val filteredDownloads = visibleDownloads
+                .asSequence()
                 .map { it.toUiData() }
                 .toList()
 
@@ -129,6 +136,7 @@ class DownloadsViewModel @Inject constructor(
                     downloads = filteredDownloads,
                     availableUpdate = availableUpdateUiData,
                     pendingDeleteIds = pendingDeleteIds,
+                    retryFailedDownloadIds = retryFailedDownloadIds,
                     leftSwipeAction = leftSwipeAction,
                     rightSwipeAction = rightSwipeAction,
                 ),
@@ -187,12 +195,7 @@ class DownloadsViewModel @Inject constructor(
 
     fun retryFailedDownloads() {
         val data = uiState.value as? DownloadsUiState.Data ?: return
-        val failedDownloadIds = data.data.downloads
-            .asSequence()
-            .filter { it.status == DownloadStatusUiData.FAILED }
-            .map { it.id }
-            .toList()
-
+        val failedDownloadIds = data.data.retryFailedDownloadIds.toList()
         if (failedDownloadIds.isEmpty()) {
             return
         }

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -160,6 +160,7 @@ class DownloadsViewModelTest {
         assertEquals("v1.2.3", state.data.availableUpdate?.tag)
         assertEquals("/tmp/update.apk", state.data.availableUpdate?.localFilePath)
         assertTrue(state.data.pendingDeleteIds.isEmpty())
+        assertTrue(state.data.retryFailedDownloadIds.isEmpty())
         assertEquals(DownloadSwipeActionUiData.ARCHIVE, state.data.leftSwipeAction)
         assertEquals(DownloadSwipeActionUiData.DELETE, state.data.rightSwipeAction)
 
@@ -191,6 +192,7 @@ class DownloadsViewModelTest {
         val state = viewModel.uiState.value as DownloadsUiState.Data
         assertEquals(listOf(1L), state.data.downloads.map { it.id })
         assertEquals(setOf(2L), state.data.pendingDeleteIds)
+        assertTrue(state.data.retryFailedDownloadIds.isEmpty())
 
         collector.cancel()
     }
@@ -382,6 +384,8 @@ class DownloadsViewModelTest {
         viewModel.retryFailedDownloads()
         advanceUntilIdle()
 
+        val state = viewModel.uiState.value as DownloadsUiState.Data
+        assertEquals(setOf(1L, 4L), state.data.retryFailedDownloadIds)
         verify(analyticsLogger)
             .logEvent(AnalyticsEvents.DOWNLOADS_RETRY)
         verify(startDownloadUseCase)
@@ -390,6 +394,101 @@ class DownloadsViewModelTest {
             .invoke(4L)
         verify(startDownloadUseCase, never())
             .invoke(2L)
+        verify(startDownloadUseCase, never())
+            .invoke(3L)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun retryFailedDownloads_skipsPendingDelete() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(
+                listOf(
+                    createDownload(
+                        id = 1L,
+                        title = "Failed",
+                        status = DownloadStatus.FAILED,
+                    ),
+                    createDownload(
+                        id = 2L,
+                        title = "Pending Delete",
+                        status = DownloadStatus.FAILED,
+                        pendingDelete = true,
+                    ),
+                )
+            ),
+            updateFlow = MutableStateFlow(null),
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadsUiState.Data ?: return@waitForUiState false
+            data.data.pendingDeleteIds == setOf(2L) &&
+                    data.data.retryFailedDownloadIds == setOf(1L)
+        }
+
+        viewModel.retryFailedDownloads()
+        advanceUntilIdle()
+
+        verify(analyticsLogger)
+            .logEvent(AnalyticsEvents.DOWNLOADS_RETRY)
+        verify(startDownloadUseCase)
+            .invoke(1L)
+        verify(startDownloadUseCase, never())
+            .invoke(2L)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun retryFailedDownloads_respectsSearch() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            downloadsFlow = MutableStateFlow(
+                listOf(
+                    createDownload(
+                        id = 1L,
+                        title = "Alpha Failed",
+                        status = DownloadStatus.FAILED,
+                    ),
+                    createDownload(
+                        id = 2L,
+                        title = "Beta Failed",
+                        status = DownloadStatus.FAILED,
+                    ),
+                    createDownload(
+                        id = 3L,
+                        title = "Beta Stopped",
+                        status = DownloadStatus.STOPPED
+                    ),
+                )
+            ),
+            updateFlow = MutableStateFlow(null),
+        )
+
+        val collector = backgroundScope.launch {
+            viewModel.uiState.collect()
+        }
+        waitForUiState(viewModel) { it is DownloadsUiState.Data }
+
+        viewModel.updateSearchQuery(TextFieldValue("Beta", TextRange(4)))
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadsUiState.Data ?: return@waitForUiState false
+            data.data.downloads.map { it.id } == listOf(2L, 3L) &&
+                    data.data.retryFailedDownloadIds == setOf(2L)
+        }
+
+        viewModel.retryFailedDownloads()
+        advanceUntilIdle()
+
+        verify(analyticsLogger)
+            .logEvent(AnalyticsEvents.DOWNLOADS_RETRY)
+        verify(startDownloadUseCase)
+            .invoke(2L)
+        verify(startDownloadUseCase, never())
+            .invoke(1L)
         verify(startDownloadUseCase, never())
             .invoke(3L)
         collector.cancel()


### PR DESCRIPTION
- Add `retryFailedDownloadIds` to `DownloadsUiData`
- Derive `retryFailedDownloadIds` from visible downloads with `pendingDelete` disabled and matching search results
- Use `retryFailedDownloadIds` to control the `Retry failed` menu state
- Retry only downloads from `retryFailedDownloadIds`
- Cover pending-delete and search-filter retry behavior in `DownloadsViewModelTest`