### PR TITLE
chore: Bump `byteBuddy` and `ksp`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,10 +21,10 @@ androidxJunit = "1.3.0"
 espressoCore = "3.7.0"
 coroutinesTest = "1.11.0"
 mockito = "5.23.0"
-byteBuddy = "1.18.9"
+byteBuddy = "1.18.10"
 agp = "9.2.1"
 kotlin = "2.3.21"
-ksp = "2.3.7"
+ksp = "2.3.9"
 
 [libraries]
 # Android


### PR DESCRIPTION
- Update `byteBuddy` to `1.18.10`
- Update `ksp` to `2.3.9`