### PR TITLE
fix: Add divider sizing to `RefineryDimens`

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -100,6 +100,7 @@ import org.strigate.ferrot.presentation.state.DownloadUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
 import org.strigate.ferrot.presentation.viewmodel.DownloadViewModel
+import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 import java.io.File
 
@@ -456,6 +457,7 @@ private fun DownloadPageContent(
     onRetryClick: () -> Unit,
     onRefreshMetadataClick: () -> Unit,
 ) {
+    val refineryDimens = LocalRefineryDimens.current
     val dimens = LocalDimens.current
     with(data) {
         LaunchedEffect(id, status, seen, isCurrentPage) {
@@ -466,9 +468,9 @@ private fun DownloadPageContent(
         LaunchedEffect(video?.filePath, audio?.filePath, selectedMedia) {
             val hasVideo = !video?.filePath.isNullOrBlank()
             val hasAudio = !audio?.filePath.isNullOrBlank()
-            val fallback = when {
-                selectedMedia == DownloadMediaType.VIDEO && !hasVideo && hasAudio -> DownloadMediaType.AUDIO
-                selectedMedia == DownloadMediaType.AUDIO && !hasAudio && hasVideo -> DownloadMediaType.VIDEO
+            val fallback = when (selectedMedia) {
+                DownloadMediaType.VIDEO if !hasVideo && hasAudio -> DownloadMediaType.AUDIO
+                DownloadMediaType.AUDIO if !hasAudio && hasVideo -> DownloadMediaType.VIDEO
                 else -> null
             }
             if (fallback != null) {
@@ -581,7 +583,9 @@ private fun DownloadPageContent(
                 )
             }
             Spacer(modifier = Modifier.height(dimens.spacingSmall))
-            HorizontalDivider()
+            HorizontalDivider(
+                thickness = refineryDimens.divider,
+            )
             Spacer(modifier = Modifier.height(dimens.spacingSmall))
             Column {
                 MetaItem(

--- a/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryDimens.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/theme/RefineryDimens.kt
@@ -20,6 +20,14 @@ data class RefineryDimens(
     val spacingXLarge: Dp = 32.dp,
     val spacingXXLarge: Dp = 48.dp,
 
+    val radiusSmall: Dp = 4.dp,
+    val radiusMedium: Dp = 8.dp,
+    val radiusLarge: Dp = 16.dp,
+    val radiusPill: Dp = 999.dp,
+
+    val dividerThin: Dp = Dp.Hairline,
+    val divider: Dp = 1.dp,
+
     val iconXXSmall: Dp = 16.dp,
     val iconXSmallAlt: Dp = 20.dp,
     val iconXSmall: Dp = 24.dp,
@@ -28,11 +36,6 @@ data class RefineryDimens(
     val iconLarge: Dp = 72.dp,
     val iconXLarge: Dp = 96.dp,
     val iconXXLarge: Dp = 128.dp,
-
-    val radiusSmall: Dp = 4.dp,
-    val radiusMedium: Dp = 8.dp,
-    val radiusLarge: Dp = 16.dp,
-    val radiusPill: Dp = 999.dp,
 
     val tonalElevationLow: Dp = 1.dp,
     val tonalElevationHigh: Dp = 4.dp,


### PR DESCRIPTION
- Add `divider` and `dividerThin` to `RefineryDimens`
- Use `LocalRefineryDimens` for `HorizontalDivider`
- Rewrite `DownloadMediaType` fallback selection