### PR TITLE
chore: Add worker unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -330,6 +330,7 @@ dependencies {
     testImplementation(libs.byte.buddy)
     testImplementation(libs.byte.buddy.agent)
     testImplementation(libs.mockito.core)
+    testImplementation(libs.json)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/test/kotlin/org/strigate/ferrot/work/DeleteAllDuplicateDownloadsWorkerTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/work/DeleteAllDuplicateDownloadsWorkerTest.kt
@@ -1,0 +1,208 @@
+package org.strigate.ferrot.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadMetadata
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.model.DownloadVideo
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
+import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadIdsBySourceAndVideoIdUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadMetadataByIdAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadIdsBySha256UseCase
+import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadVideoByDownloadIdAsFlowUseCase
+import org.strigate.ferrot.test.MainDispatcherRule
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeleteAllDuplicateDownloadsWorkerTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var downloadVideoUseCase: DownloadVideoUseCase
+
+    @Mock
+    private lateinit var downloadMetadataUseCase: DownloadMetadataUseCase
+
+    @Mock
+    private lateinit var getAllDownloadsUseCase: GetAllDownloadsUseCase
+
+    @Mock
+    private lateinit var getDownloadMetadataByIdAsFlowUseCase: GetDownloadMetadataByIdAsFlowUseCase
+
+    @Mock
+    private lateinit var getDownloadIdsBySourceAndVideoIdUseCase: GetDownloadIdsBySourceAndVideoIdUseCase
+
+    @Mock
+    private lateinit var getDownloadVideoByDownloadIdAsFlowUseCase: GetDownloadVideoByDownloadIdAsFlowUseCase
+
+    @Mock
+    private lateinit var getDownloadIdsBySha256UseCase: GetDownloadIdsBySha256UseCase
+
+    @Mock
+    private lateinit var deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        `when`(downloadUseCase.getAllDownloadsUseCase)
+            .thenReturn(getAllDownloadsUseCase)
+        `when`(downloadMetadataUseCase.getDownloadMetadataByIdAsFlowUseCase)
+            .thenReturn(getDownloadMetadataByIdAsFlowUseCase)
+        `when`(downloadMetadataUseCase.getDownloadIdsBySourceAndVideoIdUseCase)
+            .thenReturn(getDownloadIdsBySourceAndVideoIdUseCase)
+        `when`(downloadVideoUseCase.getDownloadVideoByDownloadIdAsFlowUseCase)
+            .thenReturn(getDownloadVideoByDownloadIdAsFlowUseCase)
+        `when`(downloadVideoUseCase.getDownloadIdsBySha256UseCase)
+            .thenReturn(getDownloadIdsBySha256UseCase)
+    }
+
+    @Test
+    fun doWork_deletesOlderCompletedMetadataDuplicates() = runTest(testDispatcher) {
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(
+                listOf(
+                    download(1L, DownloadStatus.COMPLETED),
+                    download(2L, DownloadStatus.COMPLETED),
+                    download(3L, DownloadStatus.FAILED),
+                )
+            )
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(1L))
+            .thenReturn(flowOf(metadata(1L)))
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(2L))
+            .thenReturn(flowOf(metadata(2L)))
+        `when`(getDownloadIdsBySourceAndVideoIdUseCase.invoke("youtube", "abc"))
+            .thenReturn(listOf(1L, 2L, 3L))
+        `when`(deleteDownloadAndRelatedCombinedUseCase.invoke(1L))
+            .thenReturn(true)
+        `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(2L))
+            .thenReturn(flowOf(null))
+
+        doWorkWithLogMock()
+
+        verify(deleteDownloadAndRelatedCombinedUseCase).invoke(1L)
+        verify(deleteDownloadAndRelatedCombinedUseCase, never()).invoke(2L)
+        verify(deleteDownloadAndRelatedCombinedUseCase, never()).invoke(3L)
+    }
+
+    @Test
+    fun doWork_deletesOlderCompletedShaDuplicates() = runTest(testDispatcher) {
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(
+                listOf(
+                    download(4L, DownloadStatus.COMPLETED),
+                    download(7L, DownloadStatus.COMPLETED)
+                )
+            )
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(4L))
+            .thenReturn(flowOf(null))
+        `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(7L))
+            .thenReturn(flowOf(null))
+        `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(4L))
+            .thenReturn(flowOf(video(4L)))
+        `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(7L))
+            .thenReturn(flowOf(video(7L)))
+        `when`(getDownloadIdsBySha256UseCase.invoke("sha"))
+            .thenReturn(listOf(4L, 7L))
+        `when`(deleteDownloadAndRelatedCombinedUseCase.invoke(4L))
+            .thenReturn(true)
+
+        doWorkWithLogMock()
+
+        verify(deleteDownloadAndRelatedCombinedUseCase).invoke(4L)
+        verify(deleteDownloadAndRelatedCombinedUseCase, never()).invoke(7L)
+    }
+
+    @After
+    fun tearDown() {
+        autoCloseable.close()
+    }
+
+    private suspend fun doWorkWithLogMock() = withContext(Dispatchers.IO) {
+        mockStatic(Log::class.java).use {
+            createWorker().doWork()
+        }
+    }
+
+    private fun createWorker() = DeleteAllDuplicateDownloadsWorker(
+        appContext = appContext,
+        workerParameters = mockWorkerParameters(),
+        downloadUseCase = downloadUseCase,
+        downloadVideoUseCase = downloadVideoUseCase,
+        downloadMetadataUseCase = downloadMetadataUseCase,
+        deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
+    )
+
+    private fun download(id: Long, status: DownloadStatus) = Download(
+        id = id,
+        uid = "uid-$id",
+        url = "https://example.com/$id",
+        status = status,
+        seen = false,
+    )
+
+    private fun metadata(downloadId: Long) = DownloadMetadata(
+        downloadId = downloadId,
+        videoId = "abc",
+        source = "youtube",
+        title = null,
+        thumbnailFilePath = null,
+        durationSeconds = null,
+    )
+
+    private fun video(downloadId: Long) = DownloadVideo(
+        downloadId = downloadId,
+        filePath = "/tmp/video-$downloadId.mp4",
+        fileExtension = "mp4",
+        sha256 = "sha",
+    )
+
+    private fun mockWorkerParameters(
+        inputData: Data = Data.EMPTY,
+        runAttemptCount: Int = 0,
+    ): WorkerParameters {
+        val workerParameters = mock(WorkerParameters::class.java)
+        `when`(workerParameters.id)
+            .thenReturn(UUID.randomUUID())
+        `when`(workerParameters.inputData)
+            .thenReturn(inputData)
+        `when`(workerParameters.runAttemptCount)
+            .thenReturn(runAttemptCount)
+
+        return workerParameters
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/work/DeleteAllOrphanDownloadFilesWorkerTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/work/DeleteAllOrphanDownloadFilesWorkerTest.kt
@@ -1,0 +1,200 @@
+package org.strigate.ferrot.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.app.provider.DownloadPathProvider
+import org.strigate.ferrot.domain.model.Download
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadAudioUseCase
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.download.GetAllDownloadsUseCase
+import org.strigate.ferrot.domain.usecase.downloadaudio.GetAllDownloadAudioFilePathsUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.GetAllDownloadThumbnailFilePathsUseCase
+import org.strigate.ferrot.domain.usecase.downloadvideo.GetAllDownloadVideoFilePathsUseCase
+import org.strigate.ferrot.test.MainDispatcherRule
+import java.io.File
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeleteAllOrphanDownloadFilesWorkerTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var downloadPathProvider: DownloadPathProvider
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var downloadAudioUseCase: DownloadAudioUseCase
+
+    @Mock
+    private lateinit var downloadVideoUseCase: DownloadVideoUseCase
+
+    @Mock
+    private lateinit var downloadMetadataUseCase: DownloadMetadataUseCase
+
+    @Mock
+    private lateinit var getAllDownloadsUseCase: GetAllDownloadsUseCase
+
+    @Mock
+    private lateinit var getAllDownloadAudioFilePathsUseCase: GetAllDownloadAudioFilePathsUseCase
+
+    @Mock
+    private lateinit var getAllDownloadVideoFilePathsUseCase: GetAllDownloadVideoFilePathsUseCase
+
+    @Mock
+    private lateinit var getAllDownloadThumbnailFilePathsUseCase: GetAllDownloadThumbnailFilePathsUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        `when`(downloadUseCase.getAllDownloadsUseCase)
+            .thenReturn(getAllDownloadsUseCase)
+        `when`(downloadAudioUseCase.getAllDownloadAudioFilePathsUseCase)
+            .thenReturn(getAllDownloadAudioFilePathsUseCase)
+        `when`(downloadVideoUseCase.getAllDownloadVideoFilePathsUseCase)
+            .thenReturn(getAllDownloadVideoFilePathsUseCase)
+        `when`(downloadMetadataUseCase.getAllDownloadThumbnailFilePathsUseCase)
+            .thenReturn(getAllDownloadThumbnailFilePathsUseCase)
+    }
+
+    @Test
+    fun doWork_deletesOnlyUnreferencedFilesOutsideProtectedDownloads() = runTest(testDispatcher) {
+        val root = temporaryFolder.newFolder("downloads")
+        val referenced = File(root, "done/referenced.mp4").apply {
+            parentFile?.mkdirs()
+            writeText("kept")
+        }
+        val orphan = File(root, "done/orphan.mp4").apply { writeText("deleted") }
+        val protected = File(root, "active/protected.part").apply {
+            parentFile?.mkdirs()
+            writeText("active")
+        }
+        stubPaths(root)
+        `when`(downloadPathProvider.uidDir("active"))
+            .thenReturn(File(root, "active"))
+        `when`(getAllDownloadAudioFilePathsUseCase.invoke())
+            .thenReturn(listOf(referenced.absolutePath))
+        `when`(getAllDownloadVideoFilePathsUseCase.invoke())
+            .thenReturn(emptyList())
+        `when`(getAllDownloadThumbnailFilePathsUseCase.invoke())
+            .thenReturn(emptyList())
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(
+                listOf(download(uid = "active", status = DownloadStatus.DOWNLOADING))
+            )
+
+        val result = doWorkWithLogMock()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        assertTrue(referenced.exists())
+        assertFalse(orphan.exists())
+        assertTrue(protected.exists())
+    }
+
+    @Test
+    fun doWork_succeedsWhenRootDoesNotExist() = runTest(testDispatcher) {
+        val missingRoot = File(temporaryFolder.root, "missing")
+        stubPaths(missingRoot)
+        stubNoReferencedFilesOrDownloads()
+
+        val result = doWorkWithLogMock()
+
+        assertTrue(result is ListenableWorker.Result.Success)
+        assertFalse(missingRoot.exists())
+    }
+
+    @After
+    fun tearDown() {
+        autoCloseable.close()
+    }
+
+    private suspend fun doWorkWithLogMock() = withContext(Dispatchers.IO) {
+        mockStatic(Log::class.java).use {
+            createWorker().doWork()
+        }
+    }
+
+    private fun stubPaths(root: File) {
+        `when`(downloadPathProvider.outputDir())
+            .thenReturn(root)
+    }
+
+    private suspend fun stubNoReferencedFilesOrDownloads() {
+        `when`(getAllDownloadAudioFilePathsUseCase.invoke())
+            .thenReturn(emptyList())
+        `when`(getAllDownloadVideoFilePathsUseCase.invoke())
+            .thenReturn(emptyList())
+        `when`(getAllDownloadThumbnailFilePathsUseCase.invoke())
+            .thenReturn(emptyList())
+        `when`(getAllDownloadsUseCase.invoke())
+            .thenReturn(emptyList())
+    }
+
+    private fun createWorker() = DeleteAllOrphanDownloadFilesWorker(
+        appContext = appContext,
+        workerParameters = mockWorkerParameters(),
+        downloadPathProvider = downloadPathProvider,
+        downloadUseCase = downloadUseCase,
+        downloadAudioUseCase = downloadAudioUseCase,
+        downloadVideoUseCase = downloadVideoUseCase,
+        downloadMetadataUseCase = downloadMetadataUseCase,
+    )
+
+    private fun download(uid: String, status: DownloadStatus) = Download(
+        id = 1L,
+        uid = uid,
+        url = "https://example.com/video",
+        status = status,
+        seen = false,
+    )
+
+    private fun mockWorkerParameters(
+        inputData: Data = Data.EMPTY,
+        runAttemptCount: Int = 0,
+    ): WorkerParameters {
+        val workerParameters = mock(WorkerParameters::class.java)
+        `when`(workerParameters.id)
+            .thenReturn(UUID.randomUUID())
+        `when`(workerParameters.inputData)
+            .thenReturn(inputData)
+        `when`(workerParameters.runAttemptCount)
+            .thenReturn(runAttemptCount)
+
+        return workerParameters
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorkerTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/work/DownloadAvailableUpdateWorkerTest.kt
@@ -1,0 +1,213 @@
+package org.strigate.ferrot.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.anyLong
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.R
+import org.strigate.ferrot.app.NotificationService
+import org.strigate.ferrot.app.provider.UpdatePathProvider
+import org.strigate.ferrot.domain.model.AvailableUpdate
+import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
+import org.strigate.ferrot.domain.usecase.StateUseCase
+import org.strigate.ferrot.domain.usecase.availableupdate.ClearAvailableUpdateFilesAndDataUseCase
+import org.strigate.ferrot.domain.usecase.availableupdate.GetAvailableUpdateAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.state.SaveLastAvailableUpdateCheckMillisUseCase
+import org.strigate.ferrot.test.MainDispatcherRule
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+import java.net.URLStreamHandlerFactory
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadAvailableUpdateWorkerTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
+
+    private var logMock: MockedStatic<Log>? = null
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var notificationService: NotificationService
+
+    @Mock
+    private lateinit var stateUseCase: StateUseCase
+
+    @Mock
+    private lateinit var updatePathProvider: UpdatePathProvider
+
+    @Mock
+    private lateinit var availableUpdateUseCase: AvailableUpdateUseCase
+
+    @Mock
+    private lateinit var getAvailableUpdateAsFlowUseCase: GetAvailableUpdateAsFlowUseCase
+
+    @Mock
+    private lateinit var clearAvailableUpdateFilesAndDataUseCase: ClearAvailableUpdateFilesAndDataUseCase
+
+    @Mock
+    private lateinit var saveLastAvailableUpdateCheckMillisUseCase: SaveLastAvailableUpdateCheckMillisUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        logMock = mockStatic(Log::class.java)
+        TestUrlHandler.responseJson = "{}"
+        `when`(appContext.getString(R.string.github_latest_release))
+            .thenReturn("test://latest-release")
+        `when`(availableUpdateUseCase.getAvailableUpdateAsFlowUseCase)
+            .thenReturn(getAvailableUpdateAsFlowUseCase)
+        `when`(availableUpdateUseCase.clearAvailableUpdateFilesAndDataUseCase)
+            .thenReturn(clearAvailableUpdateFilesAndDataUseCase)
+        `when`(stateUseCase.saveLastAvailableUpdateCheckMillisUseCase)
+            .thenReturn(saveLastAvailableUpdateCheckMillisUseCase)
+        `when`(getAvailableUpdateAsFlowUseCase.invoke())
+            .thenReturn(flowOf(null))
+        `when`(updatePathProvider.apkFileFor("v9.9.9"))
+            .thenReturn(File(temporaryFolder.root, "ferrot-v9.9.9.apk"))
+    }
+
+    @Test
+    fun doWork_clearsSavedUpdateAndMarksCheckSuccessful_whenLatestReleaseIsDraft() =
+        runTest(testDispatcher) {
+            TestUrlHandler.responseJson = """
+            {
+              "tag_name": "v9.9.9",
+              "draft": true,
+              "prerelease": false,
+              "assets": []
+            }
+        """.trimIndent()
+            `when`(getAvailableUpdateAsFlowUseCase.invoke())
+                .thenReturn(flowOf(AvailableUpdate(tag = "v9.9.8", localFilePath = null)))
+
+            val result = createWorker().doWork()
+
+            assertTrue(
+                "Expected success, was ${result.javaClass.name}: $result",
+                result is ListenableWorker.Result.Success,
+            )
+            verify(clearAvailableUpdateFilesAndDataUseCase).invoke()
+            verify(saveLastAvailableUpdateCheckMillisUseCase).invoke(anyLong())
+        }
+
+    @Test
+    fun doWork_clearsSavedUpdateAndMarksCheckSuccessful_whenNoApkAssetExists() =
+        runTest(testDispatcher) {
+            TestUrlHandler.responseJson = """
+            {
+              "tag_name": "v9.9.9",
+              "draft": false,
+              "prerelease": false,
+              "assets": [
+                { "name": "notes.txt", "browser_download_url": "test://notes", "size": 5 }
+              ]
+            }
+        """.trimIndent()
+
+            val result = createWorker().doWork()
+
+            assertTrue(
+                "Expected success, was ${result.javaClass.name}: $result",
+                result is ListenableWorker.Result.Success,
+            )
+            verify(clearAvailableUpdateFilesAndDataUseCase).invoke()
+            verify(saveLastAvailableUpdateCheckMillisUseCase).invoke(anyLong())
+        }
+
+    @After
+    fun tearDown() {
+        logMock?.close()
+        autoCloseable.close()
+    }
+
+    private fun createWorker() = DownloadAvailableUpdateWorker(
+        appContext = appContext,
+        workerParameters = mockWorkerParameters(),
+        notificationService = notificationService,
+        stateUseCase = stateUseCase,
+        updatePathProvider = updatePathProvider,
+        availableUpdateUseCase = availableUpdateUseCase,
+    )
+
+    private fun mockWorkerParameters(
+        inputData: Data = Data.EMPTY,
+        runAttemptCount: Int = 0,
+    ): WorkerParameters {
+        val workerParameters = mock(WorkerParameters::class.java)
+        `when`(workerParameters.id)
+            .thenReturn(UUID.randomUUID())
+        `when`(workerParameters.inputData)
+            .thenReturn(inputData)
+        `when`(workerParameters.runAttemptCount)
+            .thenReturn(runAttemptCount)
+        return workerParameters
+    }
+
+    private class TestConnection(url: URL) : HttpURLConnection(url) {
+        override fun connect() = Unit
+
+        override fun disconnect() = Unit
+
+        override fun usingProxy(): Boolean = false
+
+        override fun getResponseCode(): Int = HTTP_OK
+
+        override fun getInputStream(): InputStream = ByteArrayInputStream(
+            TestUrlHandler.responseJson.toByteArray()
+        )
+    }
+
+    private object TestUrlHandler : URLStreamHandler() {
+        var responseJson: String = "{}"
+
+        override fun openConnection(url: URL): URLConnection = TestConnection(url)
+    }
+
+    private class TestUrlHandlerFactory : URLStreamHandlerFactory {
+        override fun createURLStreamHandler(protocol: String): URLStreamHandler? {
+            return if (protocol == "test") TestUrlHandler else null
+        }
+    }
+
+    companion object {
+        init {
+            runCatching {
+                URL.setURLStreamHandlerFactory(TestUrlHandlerFactory())
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/work/DownloadWorkerTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/work/DownloadWorkerTest.kt
@@ -1,0 +1,186 @@
+package org.strigate.ferrot.work
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.strigate.ferrot.analytics.AnalyticsLogger
+import org.strigate.ferrot.app.Constants.Work.Name.KEY_ID
+import org.strigate.ferrot.app.NotificationService
+import org.strigate.ferrot.app.provider.DownloadPathProvider
+import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.usecase.DownloadAudioUseCase
+import org.strigate.ferrot.domain.usecase.DownloadMetadataUseCase
+import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
+import org.strigate.ferrot.domain.usecase.DownloadUseCase
+import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
+import org.strigate.ferrot.domain.usecase.SettingsUseCase
+import org.strigate.ferrot.domain.usecase.YoutubeDlAndroidUseCase
+import org.strigate.ferrot.domain.usecase.combined.DeleteDownloadAndRelatedCombinedUseCase
+import org.strigate.ferrot.domain.usecase.download.DeleteDownloadFilesUseCase
+import org.strigate.ferrot.domain.usecase.download.GetDownloadByIdUseCase
+import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
+import org.strigate.ferrot.domain.usecase.downloadprogress.UpdateDownloadProgressUseCase
+import org.strigate.ferrot.test.MainDispatcherRule
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadWorkerTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
+    private lateinit var autoCloseable: AutoCloseable
+
+    private var logMock: MockedStatic<Log>? = null
+
+    @Mock
+    private lateinit var appContext: Context
+
+    @Mock
+    private lateinit var analyticsLogger: AnalyticsLogger
+
+    @Mock
+    private lateinit var notificationService: NotificationService
+
+    @Mock
+    private lateinit var settingsUseCase: SettingsUseCase
+
+    @Mock
+    private lateinit var downloadPathProvider: DownloadPathProvider
+
+    @Mock
+    private lateinit var youtubeDlAndroidUseCase: YoutubeDlAndroidUseCase
+
+    @Mock
+    private lateinit var downloadUseCase: DownloadUseCase
+
+    @Mock
+    private lateinit var downloadVideoUseCase: DownloadVideoUseCase
+
+    @Mock
+    private lateinit var downloadAudioUseCase: DownloadAudioUseCase
+
+    @Mock
+    private lateinit var downloadProgressUseCase: DownloadProgressUseCase
+
+    @Mock
+    private lateinit var downloadMetadataUseCase: DownloadMetadataUseCase
+
+    @Mock
+    private lateinit var deleteDownloadAndRelatedCombinedUseCase: DeleteDownloadAndRelatedCombinedUseCase
+
+    @Mock
+    private lateinit var getDownloadByIdUseCase: GetDownloadByIdUseCase
+
+    @Mock
+    private lateinit var updateDownloadStatusUseCase: UpdateDownloadStatusUseCase
+
+    @Mock
+    private lateinit var deleteDownloadFilesUseCase: DeleteDownloadFilesUseCase
+
+    @Mock
+    private lateinit var updateDownloadProgressUseCase: UpdateDownloadProgressUseCase
+
+    @Before
+    fun setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this)
+        logMock = mockStatic(Log::class.java)
+        `when`(downloadUseCase.getDownloadByIdUseCase)
+            .thenReturn(getDownloadByIdUseCase)
+        `when`(downloadUseCase.updateDownloadStatusUseCase)
+            .thenReturn(updateDownloadStatusUseCase)
+        `when`(downloadUseCase.deleteDownloadFilesUseCase)
+            .thenReturn(deleteDownloadFilesUseCase)
+        `when`(downloadProgressUseCase.updateDownloadProgressUseCase)
+            .thenReturn(updateDownloadProgressUseCase)
+    }
+
+    @Test
+    fun doWork_failsWithoutTouchingState_whenDownloadIdIsInvalid() = runTest(testDispatcher) {
+        val result = createWorker(downloadId = -1L).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Failure)
+        verify(getDownloadByIdUseCase, never()).invoke(-1L)
+        verify(updateDownloadStatusUseCase, never()).invoke(-1L, DownloadStatus.FAILED)
+    }
+
+    @Test
+    fun doWork_marksDownloadFailed_whenDownloadRecordIsMissing() = runTest(testDispatcher) {
+        `when`(getDownloadByIdUseCase.invoke(42L))
+            .thenReturn(null)
+
+        val result = createWorker(downloadId = 42L).doWork()
+
+        assertTrue(result is ListenableWorker.Result.Failure)
+        verify(deleteDownloadFilesUseCase).invoke(42L)
+        verify(updateDownloadProgressUseCase).invoke(
+            id = 42L,
+            progressPercent = 0f,
+            bytesDownloaded = 0L,
+            etaSeconds = null,
+        )
+        verify(updateDownloadStatusUseCase).invoke(42L, DownloadStatus.FAILED)
+    }
+
+    @After
+    fun tearDown() {
+        logMock?.close()
+        autoCloseable.close()
+    }
+
+    private fun createWorker(
+        downloadId: Long,
+        runAttemptCount: Int = 0,
+    ) = DownloadWorker(
+        appContext = appContext,
+        workerParameters = mockWorkerParameters(
+            inputData = Data.Builder().putLong(KEY_ID, downloadId).build(),
+            runAttemptCount = runAttemptCount,
+        ),
+        analyticsLogger = analyticsLogger,
+        notificationService = notificationService,
+        settingsUseCase = settingsUseCase,
+        downloadPathProvider = downloadPathProvider,
+        youtubeDlAndroidUseCase = youtubeDlAndroidUseCase,
+        downloadUseCase = downloadUseCase,
+        downloadVideoUseCase = downloadVideoUseCase,
+        downloadAudioUseCase = downloadAudioUseCase,
+        downloadProgressUseCase = downloadProgressUseCase,
+        downloadMetadataUseCase = downloadMetadataUseCase,
+        deleteDownloadAndRelatedCombinedUseCase = deleteDownloadAndRelatedCombinedUseCase,
+    )
+
+    private fun mockWorkerParameters(
+        inputData: Data = Data.EMPTY,
+        runAttemptCount: Int = 0,
+    ): WorkerParameters {
+        val workerParameters = mock(WorkerParameters::class.java)
+        `when`(workerParameters.id)
+            .thenReturn(UUID.randomUUID())
+        `when`(workerParameters.inputData)
+            .thenReturn(inputData)
+        `when`(workerParameters.runAttemptCount)
+            .thenReturn(runAttemptCount)
+
+        return workerParameters
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ espressoCore = "3.7.0"
 coroutinesTest = "1.11.0"
 mockito = "5.23.0"
 byteBuddy = "1.18.10"
+json = "20260522"
 agp = "9.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.9"
@@ -84,6 +85,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 byte-buddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "byteBuddy" }
 byte-buddy-agent = { group = "net.bytebuddy", name = "byte-buddy-agent", version.ref = "byteBuddy" }
+json = { group = "org.json", name = "json", version.ref = "json" }
 # Debug
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
- Cover duplicate cleanup behavior in `DeleteAllDuplicateDownloadsWorker`
- Cover orphan cleanup behavior in `DeleteAllOrphanDownloadFilesWorker`
- Cover early failure behavior in `DownloadWorker`
- Cover release filtering behavior in `DownloadAvailableUpdateWorker`
- Add JVM test support for `JSONObject`