### PR TITLE
fix: Correct restored download scroll behavior

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -888,7 +888,6 @@ private fun DownloadsList(
                 restoredItemIds = restoringItemIds,
                 currentItemIds = itemIds,
                 firstVisibleItemIndex = lazyListState.firstVisibleItemIndex,
-                firstVisibleItemScrollOffset = lazyListState.firstVisibleItemScrollOffset,
             )
         ) {
             lazyListState.scrollToItem(0)
@@ -1586,12 +1585,11 @@ internal fun shouldScrollToTopOnRestore(
     restoredItemIds: Set<Long>,
     currentItemIds: List<Long>,
     firstVisibleItemIndex: Int,
-    firstVisibleItemScrollOffset: Int,
 ): Boolean {
     if (restoredItemIds.isEmpty() || currentItemIds.isEmpty()) {
         return false
     }
-    val userWasNearTop = firstVisibleItemIndex <= 1 || firstVisibleItemScrollOffset == 0
+    val userWasNearTop = firstVisibleItemIndex <= 1
     return userWasNearTop && currentItemIds.first() in restoredItemIds
 }
 

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreenScrollBehaviorTest.kt
@@ -127,19 +127,17 @@ class DownloadsScreenScrollBehaviorTest {
             restoredItemIds = setOf(1L),
             currentItemIds = listOf(1L, 2L, 3L),
             firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
         )
 
         assertTrue(shouldScroll)
     }
 
     @Test
-    fun shouldScrollToTopOnRestore_returnsTrue_whenTopItemWasRestoredAndAnchorShiftedToIndexOne() {
+    fun shouldScrollToTopOnRestore_returnsTrue_whenTopItemWasRestoredAndAnchorShiftedNearTop() {
         val shouldScroll = shouldScrollToTopOnRestore(
             restoredItemIds = setOf(1L),
             currentItemIds = listOf(1L, 2L, 3L),
             firstVisibleItemIndex = 1,
-            firstVisibleItemScrollOffset = 24,
         )
 
         assertTrue(shouldScroll)
@@ -151,7 +149,6 @@ class DownloadsScreenScrollBehaviorTest {
             restoredItemIds = setOf(3L),
             currentItemIds = listOf(1L, 2L, 3L),
             firstVisibleItemIndex = 0,
-            firstVisibleItemScrollOffset = 0,
         )
 
         assertFalse(shouldScroll)
@@ -163,7 +160,17 @@ class DownloadsScreenScrollBehaviorTest {
             restoredItemIds = setOf(1L),
             currentItemIds = listOf(1L, 2L, 3L),
             firstVisibleItemIndex = 2,
-            firstVisibleItemScrollOffset = 64,
+        )
+
+        assertFalse(shouldScroll)
+    }
+
+    @Test
+    fun shouldScrollToTopOnRestore_returnsFalse_whenNoItemsWereRestored() {
+        val shouldScroll = shouldScrollToTopOnRestore(
+            restoredItemIds = emptySet(),
+            currentItemIds = listOf(1L, 2L, 3L),
+            firstVisibleItemIndex = 0,
         )
 
         assertFalse(shouldScroll)


### PR DESCRIPTION
- Remove misleading `firstVisibleItemScrollOffset` input from `shouldScrollToTopOnRestore`
- Keep restore auto-scroll limited to near-top `firstVisibleItemIndex` values
- Add missing guard coverage for empty `restoredItemIds`