### PR TITLE
fix: Update About resources links

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -135,7 +135,6 @@ fun AboutScreen(
                     ) {
                         val urlWebsite = stringResource(R.string.url_website)
                         val urlGitHub = stringResource(R.string.url_github)
-                        val urlX = stringResource(R.string.url_x)
                         val urlPrivacy = stringResource(R.string.url_privacy)
                         val urlLicense = stringResource(R.string.url_license)
                         TextSetting(
@@ -155,15 +154,6 @@ fun AboutScreen(
                             },
                         ) {
                             viewModel.onUrlClicked(urlGitHub)
-                        }
-                        TextSetting(
-                            text = stringResource(R.string.settings_title_x),
-                            description = stringResource(R.string.settings_description_x),
-                            onLongClick = {
-                                context.copyToClipboard(urlX)
-                            },
-                        ) {
-                            viewModel.onUrlClicked(urlX)
                         }
                         TextSetting(
                             text = stringResource(R.string.settings_title_privacy),

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -11,8 +11,7 @@
     <!-- External links -->
     <string name="url_website" translatable="false">https://ferrot.org/</string>
     <string name="url_github" translatable="false">https://github.com/strigate/ferrot</string>
-    <string name="url_x" translatable="false">https://x.com/ferrotapp</string>
-    <string name="url_strigate" translatable="false">https://x.com/strigate</string>
+    <string name="url_strigate" translatable="false">https://strigate.org/</string>
     <string name="url_privacy" translatable="false">https://github.com/strigate/ferrot/blob/main/PRIVACY.md</string>
     <string name="url_license" translatable="false">https://github.com/strigate/ferrot/blob/main/LICENSE</string>
 
@@ -20,9 +19,7 @@
     <string name="download_url" translatable="false">URL</string>
     <string name="percent_0" translatable="false">0%</string>
     <string name="settings_title_github" translatable="false">GitHub</string>
-    <string name="settings_title_x" translatable="false">X</string>
     <string name="settings_description_website" translatable="false">ferrot.org</string>
     <string name="settings_description_github" translatable="false">github.com/strigate/ferrot</string>
-    <string name="settings_description_x" translatable="false">x.com/ferrotapp</string>
     <string name="settings_description_license" translatable="false">GNU General Public License v3.0</string>
 </resources>


### PR DESCRIPTION
- Remove the `X` resource from `AboutScreen`
- Point `url_strigate` to `https://strigate.org/`
- Remove unused `url_x`, `settings_title_x`, and `settings_description_x`