### PR TITLE
fix: Warn about embedded browser login risk

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/GetCookiesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/GetCookiesScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -251,39 +252,68 @@ fun GetCookiesScreen(
                             .fillMaxWidth(),
                         exit = slideOutVertically { -it } + fadeOut(),
                     ) {
-                        OutlinedTextField(
+                        Column(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(
                                     start = refineryDimens.spacingMediumAlt,
                                     end = refineryDimens.spacingMediumAlt,
                                     bottom = refineryDimens.spacingMediumAlt,
-                                )
-                                .focusRequester(focusRequester),
-                            value = addressText,
-                            onValueChange = { addressText = it },
-                            label = { Text(stringResource(R.string.cookies_label_login_url)) },
-                            singleLine = true,
-                            trailingIcon = {
-                                IconButton(onClick = ::loadAddress) {
-                                    Icon(
-                                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                                        contentDescription = stringResource(R.string.cookies_action_go),
-                                    )
-                                }
-                            },
-                            keyboardOptions = KeyboardOptions(
-                                autoCorrectEnabled = false,
-                                capitalization = KeyboardCapitalization.None,
-                                imeAction = ImeAction.Go,
-                            ),
-                            keyboardActions = KeyboardActions(onGo = { loadAddress() }),
-                        )
+                                ),
+                        ) {
+                            CookieLoginWarning()
+                            OutlinedTextField(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = refineryDimens.spacingSmall)
+                                    .focusRequester(focusRequester),
+                                value = addressText,
+                                onValueChange = { addressText = it },
+                                label = {
+                                    Text(text = stringResource(R.string.cookies_label_login_url))
+                                },
+                                singleLine = true,
+                                trailingIcon = {
+                                    IconButton(onClick = ::loadAddress) {
+                                        Icon(
+                                            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                                            contentDescription = stringResource(R.string.cookies_action_go),
+                                        )
+                                    }
+                                },
+                                keyboardOptions = KeyboardOptions(
+                                    autoCorrectEnabled = false,
+                                    capitalization = KeyboardCapitalization.None,
+                                    imeAction = ImeAction.Go,
+                                ),
+                                keyboardActions = KeyboardActions(onGo = { loadAddress() }),
+                            )
+                        }
                     }
                 }
             }
         },
     )
+}
+
+@Composable
+private fun CookieLoginWarning(
+    modifier: Modifier = Modifier,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+    ) {
+        Text(
+            modifier = Modifier.padding(refineryDimens.spacingMedium),
+            style = MaterialTheme.typography.bodySmall,
+            text = stringResource(R.string.cookies_webview_warning),
+        )
+    }
 }
 
 private data class CookieOverwritePrompt(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="cookies_action_replace">Replace</string>
     <string name="cookies_label_login_url">URL</string>
     <string name="cookies_webview_start_description">Enter a site, log in, then Save.</string>
+    <string name="cookies_webview_warning">Some sites may lock, restrict, or ban accounts after login attempts from embedded browsers. Use cookies.txt import when possible.</string>
     <string name="cookies_source_imported_file">Imported file</string>
     <string name="cookies_source_webview">WebView</string>
     <string name="cookies_no_domains">No domains</string>


### PR DESCRIPTION
- Add `CookieLoginWarning` above the `GetCookiesScreen` URL field
- Add `cookies_webview_warning` copy for embedded browser account risk
- Keep cookie login guidance visible before loading a site