### PR TITLE
fix: Handle nullable cookie and download inputs

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/cookies/CookieHeaderFileBuilder.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/cookies/CookieHeaderFileBuilder.kt
@@ -3,10 +3,11 @@ package org.strigate.ferrot.cookies
 import javax.inject.Inject
 
 class CookieHeaderFileBuilder @Inject constructor() {
-    fun build(domains: List<ParsedCookieDomain>, rawCookieHeader: String): String {
+    fun build(domains: List<ParsedCookieDomain>, rawCookieHeader: String): String? {
         val cookies = parseCookieHeader(rawCookieHeader)
-        require(domains.isNotEmpty()) { "At least one domain is required" }
-        require(cookies.isNotEmpty()) { "At least one cookie is required" }
+        if (domains.isEmpty() || cookies.isEmpty()) {
+            return null
+        }
 
         return buildString {
             appendLine("# Netscape HTTP Cookie File")

--- a/app/src/main/kotlin/org/strigate/ferrot/cookies/WebViewCookieDomainResolver.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/cookies/WebViewCookieDomainResolver.kt
@@ -6,12 +6,11 @@ import javax.inject.Inject
 class WebViewCookieDomainResolver @Inject constructor(
     private val cookieSetDomainParser: CookieSetDomainParser,
 ) {
-    operator fun invoke(url: String): String {
+    operator fun invoke(url: String): String? {
         val host = runCatching { URI(url).host }
             .getOrNull()
-        val normalizedHost = requireNotNull(cookieSetDomainParser.normalizeDomain(host.orEmpty())) {
-            "Could not determine cookie domain"
-        }
+        val normalizedHost = cookieSetDomainParser.normalizeDomain(host.orEmpty())
+            ?: return null
         return normalizedHost.withoutCommonSitePrefix()
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromFileUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromFileUseCase.kt
@@ -29,7 +29,7 @@ class CreateCookieSetFromFileUseCase @Inject constructor(
         uri: Uri,
         rawDomains: String,
         includeSubdomains: Boolean,
-    ): CookieSetWithDomains {
+    ): CookieSetWithDomains? {
         val cookieSetName = name.trim().ifBlank {
             displayNameFromUri(uri) ?: DEFAULT_PROFILE_NAME
         }
@@ -42,14 +42,16 @@ class CreateCookieSetFromFileUseCase @Inject constructor(
         )
 
         return runCatching {
-            val tempFile = copyUriToTempFile(uri)
+            val tempFile = copyUriToTempFile(uri) ?: return@runCatching null
             try {
                 val cookieFile = cookieFileStore.copyCookies(cookieSetId, tempFile)
                 val parsedDomains = cookieSetDomainParser
                     .parseDomainList(rawDomains, includeSubdomains)
                     .ifEmpty { cookieSetDomainParser.parseNetscapeDomains(cookieFile) }
 
-                require(parsedDomains.isNotEmpty()) { "No cookie domains were found" }
+                if (parsedDomains.isEmpty()) {
+                    return@runCatching null
+                }
 
                 cookieSetRepository.updateCookieFilePath(cookieSetId, cookieFile.absolutePath)
                 cookieSetRepository.saveDomains(
@@ -62,13 +64,17 @@ class CreateCookieSetFromFileUseCase @Inject constructor(
                     }
                 )
                 deleteCookieSetsWithMatchingDomains(cookieSetId, parsedDomains)
-                requireNotNull(cookieSetRepository.getByIdWithDomains(cookieSetId))
+                cookieSetRepository.getByIdWithDomains(cookieSetId)
             } finally {
                 tempFile.delete()
             }
         }.getOrElse { throwable ->
             deleteCookieSetUseCase(cookieSetId)
             throw throwable
+        }.also { cookieSetWithDomains ->
+            if (cookieSetWithDomains == null) {
+                deleteCookieSetUseCase(cookieSetId)
+            }
         }
     }
 
@@ -84,16 +90,25 @@ class CreateCookieSetFromFileUseCase @Inject constructor(
             }
     }
 
-    private suspend fun copyUriToTempFile(uri: Uri): File {
+    private suspend fun copyUriToTempFile(uri: Uri): File? {
         return withContext(Dispatchers.IO) {
             val tempFile = File.createTempFile("cookie-import", ".txt", appContext.cacheDir)
-            appContext.contentResolver.openInputStream(uri).use { inputStream ->
-                requireNotNull(inputStream) { "Could not open cookie file" }
-                tempFile.outputStream().use { outputStream ->
-                    inputStream.copyTo(outputStream)
+            try {
+                val inputStream = appContext.contentResolver.openInputStream(uri)
+                if (inputStream == null) {
+                    tempFile.delete()
+                    return@withContext null
                 }
+                inputStream.use {
+                    tempFile.outputStream().use { outputStream ->
+                        it.copyTo(outputStream)
+                    }
+                }
+                tempFile
+            } catch (throwable: Throwable) {
+                tempFile.delete()
+                throw throwable
             }
-            tempFile
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromWebViewUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromWebViewUseCase.kt
@@ -21,8 +21,8 @@ class CreateCookieSetFromWebViewUseCase @Inject constructor(
     suspend operator fun invoke(
         url: String,
         rawCookieHeader: String,
-    ): CookieSetWithDomains {
-        val domain = webViewCookieDomainResolver(url)
+    ): CookieSetWithDomains? {
+        val domain = webViewCookieDomainResolver(url) ?: return null
         val domains = listOf(
             ParsedCookieDomain(
                 domain = domain,
@@ -30,6 +30,8 @@ class CreateCookieSetFromWebViewUseCase @Inject constructor(
             )
         )
         val cookieFileContent = cookieHeaderFileBuilder.build(domains, rawCookieHeader)
+            ?: return null
+
         val cookieSetId = cookieSetRepository.saveCookieSet(
             CookieSet(
                 name = domain,
@@ -51,10 +53,14 @@ class CreateCookieSetFromWebViewUseCase @Inject constructor(
                 }
             )
             deleteCookieSetsWithMatchingDomains(cookieSetId, domains)
-            requireNotNull(cookieSetRepository.getByIdWithDomains(cookieSetId))
+            cookieSetRepository.getByIdWithDomains(cookieSetId)
         }.getOrElse { throwable ->
             deleteCookieSetUseCase(cookieSetId)
             throw throwable
+        }.also { cookieSetWithDomains ->
+            if (cookieSetWithDomains == null) {
+                deleteCookieSetUseCase(cookieSetId)
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/cookieset/GetExistingCookieSetDomainForWebViewUrlUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/cookieset/GetExistingCookieSetDomainForWebViewUrlUseCase.kt
@@ -9,7 +9,7 @@ class GetExistingCookieSetDomainForWebViewUrlUseCase @Inject constructor(
     private val webViewCookieDomainResolver: WebViewCookieDomainResolver,
 ) {
     suspend operator fun invoke(url: String): String? {
-        val domain = webViewCookieDomainResolver(url)
+        val domain = webViewCookieDomainResolver(url) ?: return null
         val cookieSetIds = cookieSetRepository.getCookieSetIdsByDomains(listOf(domain))
         return domain.takeIf { cookieSetIds.isNotEmpty() }
     }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -330,7 +330,7 @@ private fun DownloadPager(
     modifier: Modifier = Modifier,
     data: DownloadUiData,
     pageDataForId: (Long) -> Flow<DownloadPageUiData?>,
-    selectedId: Long,
+    selectedId: Long?,
     selectedMedia: DownloadMediaType,
     onEnsureDefaults: (List<Long>) -> Unit,
     onDownloadPageSelected: (Long) -> Unit,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/CookiesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/CookiesViewModel.kt
@@ -52,16 +52,17 @@ class CookiesViewModel @Inject constructor(
 
     fun importCookieFile(uri: Uri) {
         viewModelScope.launch {
-            runCatching {
+            val saved = runCatching {
                 cookieSetUseCase.createCookieSetFromFileUseCase(
                     name = "",
                     uri = uri,
                     rawDomains = "",
                     includeSubdomains = true,
-                )
-            }.onSuccess {
+                ) != null
+            }.getOrDefault(false)
+            if (saved) {
                 _event.emit(CookiesEvent.ShowToast(R.string.toast_cookie_set_saved))
-            }.onFailure {
+            } else {
                 _event.emit(CookiesEvent.ShowToast(R.string.toast_cookie_set_failed))
             }
         }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -56,7 +57,7 @@ class DownloadViewModel @Inject constructor(
     private val requestRefreshDownloadMetadataUseCase: RequestRefreshDownloadMetadataUseCase,
     downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
 ) : ViewModel() {
-    private val initialId: Long = checkNotNull(savedStateHandle[Screen.Download.ARG_DOWNLOAD_ID])
+    private val initialId: Long? = savedStateHandle[Screen.Download.ARG_DOWNLOAD_ID]
     private val archived: Boolean = savedStateHandle[Screen.ARG_ARCHIVED] ?: false
 
     private val downloadIds = downloadWithMetadataUseCase
@@ -75,7 +76,7 @@ class DownloadViewModel @Inject constructor(
         )
 
     private val _selectedId = MutableStateFlow(initialId)
-    val selectedId: StateFlow<Long> = _selectedId
+    val selectedId: StateFlow<Long?> = _selectedId
 
     val uiState = getUiState().stateIn(
         scope = viewModelScope,
@@ -88,7 +89,7 @@ class DownloadViewModel @Inject constructor(
         selectedId,
         _selectedMediaById,
     ) { id, map ->
-        map[id] ?: DownloadMediaType.VIDEO
+        id?.let { map[it] } ?: DownloadMediaType.VIDEO
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
@@ -97,7 +98,11 @@ class DownloadViewModel @Inject constructor(
 
     val selectedPageData: StateFlow<DownloadPageUiData?> = selectedId
         .flatMapLatest { downloadId ->
-            getDownloadPageUiData(downloadId)
+            if (downloadId == null) {
+                flowOf(null)
+            } else {
+                getDownloadPageUiData(downloadId)
+            }
         }
         .stateIn(
             scope = viewModelScope,
@@ -112,15 +117,17 @@ class DownloadViewModel @Inject constructor(
     val events = _events.asSharedFlow()
 
     init {
-        viewModelScope.launch {
-            clearNotificationsByDownloadIdUseCase(initialId)
+        initialId?.let { downloadId ->
+            viewModelScope.launch {
+                clearNotificationsByDownloadIdUseCase(downloadId)
+            }
         }
         viewModelScope.launch {
             var previousIds = emptyList<Long>()
             downloadIds.collect { ids ->
                 val currentSelectedId = _selectedId.value
-                if (ids.isNotEmpty() && currentSelectedId !in ids) {
-                    val previousIndex = previousIds.indexOf(currentSelectedId)
+                if (ids.isNotEmpty() && (currentSelectedId == null || currentSelectedId !in ids)) {
+                    val previousIndex = currentSelectedId?.let(previousIds::indexOf) ?: -1
                     _selectedId.value = if (previousIndex >= 0 && previousIndex < ids.size) {
                         ids[previousIndex]
                     } else {
@@ -136,8 +143,8 @@ class DownloadViewModel @Inject constructor(
         return combine(downloadIds, selectedId) { ids, currentSelectedId ->
             val selectedOrDefaultId = when {
                 ids.isEmpty() -> null
-                currentSelectedId in ids -> currentSelectedId
-                initialId in ids -> initialId
+                currentSelectedId != null && currentSelectedId in ids -> currentSelectedId
+                initialId != null && initialId in ids -> initialId
                 else -> ids.firstOrNull()
             }
             DownloadUiState.Data(
@@ -202,13 +209,13 @@ class DownloadViewModel @Inject constructor(
     }
 
     fun markUnseenAndNavigateBack(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         downloadUseCase.updateDownloadsSeenUseCase(setOf(downloadId), seen = false)
         _events.emit(DownloadEvent.NavigateBack)
     }
 
     fun setSelectedMedia(type: DownloadMediaType, forDownloadId: Long? = null) {
-        val downloadId = resolveDownloadId(forDownloadId)
+        val downloadId = resolveDownloadId(forDownloadId) ?: return
         _selectedMediaById.value = _selectedMediaById
             .value
             .toMutableMap()
@@ -232,7 +239,7 @@ class DownloadViewModel @Inject constructor(
     }
 
     fun deleteDownload(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         val isLastDownload = downloadIds.value.count { it != downloadId } == 0
         downloadUseCase.requestDeleteDownloadsUseCase(
             downloadIds = listOf(downloadId),
@@ -243,7 +250,7 @@ class DownloadViewModel @Inject constructor(
     }
 
     fun updateArchived(archived: Boolean, id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         val isLastDownload = downloadIds.value.count { it != downloadId } == 0
         val removesFromCurrentList = this@DownloadViewModel.archived != archived
         downloadUseCase.updateDownloadsArchivedUseCase(setOf(downloadId), archived = archived)
@@ -256,34 +263,34 @@ class DownloadViewModel @Inject constructor(
     }
 
     fun shareDownload(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         val download = getDownloadPageUiData(downloadId).first() ?: return@launch
         val path = getSelectedMediaFilePath(downloadId, download) ?: return@launch
         _events.emit(DownloadEvent.Share(path))
     }
 
     fun saveDownload(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         val download = getDownloadPageUiData(downloadId).first() ?: return@launch
         val path = getSelectedMediaFilePath(downloadId, download) ?: return@launch
         _events.emit(DownloadEvent.Save(path))
     }
 
     fun playDownload(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         val download = getDownloadPageUiData(downloadId).first() ?: return@launch
         val path = getSelectedMediaFilePath(downloadId, download) ?: return@launch
         _events.emit(DownloadEvent.Play(path))
     }
 
     fun retryDownload(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         analyticsLogger.logEvent(AnalyticsEvents.DOWNLOAD_RETRY)
         startDownloadUseCase(downloadId)
     }
 
     fun refreshDownloadMetadata(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id)
+        val downloadId = resolveDownloadId(id) ?: return@launch
         requestRefreshDownloadMetadataUseCase(downloadId)
     }
 
@@ -299,7 +306,7 @@ class DownloadViewModel @Inject constructor(
         }
     }
 
-    private fun resolveDownloadId(id: Long?): Long {
+    private fun resolveDownloadId(id: Long?): Long? {
         return id ?: _selectedId.value
     }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/GetCookiesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/GetCookiesViewModel.kt
@@ -29,7 +29,7 @@ class GetCookiesViewModel @Inject constructor(
         confirmOverwrite: Boolean = true,
     ) {
         viewModelScope.launch {
-            runCatching {
+            val saved = runCatching {
                 if (confirmOverwrite) {
                     val existingDomain =
                         cookieSetUseCase.getExistingCookieSetDomainForWebViewUrlUseCase(url)
@@ -46,11 +46,12 @@ class GetCookiesViewModel @Inject constructor(
                 cookieSetUseCase.createCookieSetFromWebViewUseCase(
                     url = url,
                     rawCookieHeader = cookieHeader,
-                )
-            }.onSuccess {
+                ) != null
+            }.getOrDefault(false)
+            if (saved) {
                 _event.emit(GetCookiesEvent.ShowToast(R.string.toast_cookie_set_saved))
                 _event.emit(GetCookiesEvent.Saved)
-            }.onFailure {
+            } else {
                 _event.emit(GetCookiesEvent.ShowToast(R.string.toast_cookie_set_failed))
             }
         }

--- a/app/src/test/kotlin/org/strigate/ferrot/cookies/CookieHeaderFileBuilderTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/cookies/CookieHeaderFileBuilderTest.kt
@@ -1,6 +1,7 @@
 package org.strigate.ferrot.cookies
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -17,9 +18,19 @@ class CookieHeaderFileBuilderTest {
             rawCookieHeader = "Cookie: auth=one; ct0=two",
         )
 
-        assertTrue(result.contains("# Netscape HTTP Cookie File"))
-        assertTrue(result.contains(".x.com\tTRUE\t/\tTRUE\t\tauth\tone"))
-        assertTrue(result.contains("twitter.com\tFALSE\t/\tTRUE\t\tct0\ttwo"))
+        assertTrue(result?.contains("# Netscape HTTP Cookie File") == true)
+        assertTrue(result?.contains(".x.com\tTRUE\t/\tTRUE\t\tauth\tone") == true)
+        assertTrue(result?.contains("twitter.com\tFALSE\t/\tTRUE\t\tct0\ttwo") == true)
+    }
+
+    @Test
+    fun build_returnsNull_whenCookieHeaderHasNoCookies() {
+        val result = builder.build(
+            domains = listOf(ParsedCookieDomain("x.com", includeSubdomains = true)),
+            rawCookieHeader = "Path=/; Secure; SameSite=Lax",
+        )
+
+        assertNull(result)
     }
 
     @Test

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromFileUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromFileUseCaseTest.kt
@@ -1,0 +1,202 @@
+package org.strigate.ferrot.domain.usecase.cookieset
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.strigate.ferrot.app.integration.CookieFileStore
+import org.strigate.ferrot.app.provider.CookieSetPathProvider
+import org.strigate.ferrot.cookies.CookieSetDomainParser
+import org.strigate.ferrot.domain.model.CookieSet
+import org.strigate.ferrot.domain.model.CookieSetDomain
+import org.strigate.ferrot.domain.model.CookieSetWithDomains
+import org.strigate.ferrot.domain.repository.CookieSetRepository
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.nio.file.Files
+
+class CreateCookieSetFromFileUseCaseTest {
+    @Test
+    fun invoke_returnsNullAndDeletesCookieSet_whenFileCannotBeOpened() = runTest {
+        val rootDir = Files.createTempDirectory("cookie-file-import").toFile()
+        val cacheDir = File(rootDir, "cache").apply { mkdirs() }
+        val repository = SavingCookieSetRepository()
+        val pathProvider = TempCookieSetPathProvider(rootDir)
+        val cookieFileStore = CookieFileStore(pathProvider)
+        val uri = mock(Uri::class.java)
+        val contentResolver = mock(ContentResolver::class.java)
+        val appContext = mock(Context::class.java)
+        `when`(appContext.cacheDir).thenReturn(cacheDir)
+        `when`(appContext.contentResolver).thenReturn(contentResolver)
+        `when`(contentResolver.openInputStream(uri)).thenReturn(null)
+        val useCase = createUseCase(
+            appContext = appContext,
+            repository = repository,
+            cookieFileStore = cookieFileStore,
+        )
+
+        try {
+            val result = useCase(
+                name = "",
+                uri = uri,
+                rawDomains = "",
+                includeSubdomains = true,
+            )
+
+            assertNull(result)
+            assertTrue(repository.getAllWithDomains().isEmpty())
+            assertFalse(pathProvider.cookieSetDirectory(1L).exists())
+            assertTrue(cacheDir.listFiles().orEmpty().isEmpty())
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun invoke_returnsNullAndDeletesCookieSet_whenNoDomainsAreFound() = runTest {
+        val rootDir = Files.createTempDirectory("cookie-file-import").toFile()
+        val cacheDir = File(rootDir, "cache").apply { mkdirs() }
+        val repository = SavingCookieSetRepository()
+        val pathProvider = TempCookieSetPathProvider(rootDir)
+        val cookieFileStore = CookieFileStore(pathProvider)
+        val uri = mock(Uri::class.java)
+        val contentResolver = mock(ContentResolver::class.java)
+        val appContext = mock(Context::class.java)
+        `when`(appContext.cacheDir).thenReturn(cacheDir)
+        `when`(appContext.contentResolver).thenReturn(contentResolver)
+        `when`(contentResolver.openInputStream(uri))
+            .thenReturn(ByteArrayInputStream("not a netscape cookie file".toByteArray()))
+        val useCase = createUseCase(
+            appContext = appContext,
+            repository = repository,
+            cookieFileStore = cookieFileStore,
+        )
+
+        try {
+            val result = useCase(
+                name = "",
+                uri = uri,
+                rawDomains = "",
+                includeSubdomains = true,
+            )
+
+            assertNull(result)
+            assertTrue(repository.getAllWithDomains().isEmpty())
+            assertFalse(pathProvider.cookieSetDirectory(1L).exists())
+            assertTrue(cacheDir.listFiles().orEmpty().isEmpty())
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    private fun createUseCase(
+        appContext: Context,
+        repository: CookieSetRepository,
+        cookieFileStore: CookieFileStore,
+    ): CreateCookieSetFromFileUseCase {
+        return CreateCookieSetFromFileUseCase(
+            appContext = appContext,
+            cookieSetRepository = repository,
+            cookieSetDomainParser = CookieSetDomainParser(),
+            cookieFileStore = cookieFileStore,
+            deleteCookieSetUseCase = DeleteCookieSetUseCase(
+                cookieSetRepository = repository,
+                cookieFileStore = cookieFileStore,
+            ),
+        )
+    }
+
+    private class SavingCookieSetRepository : CookieSetRepository {
+        private val cookieSets = mutableMapOf<Long, CookieSet>()
+        private val cookieSetDomains = mutableMapOf<Long, List<CookieSetDomain>>()
+        private var nextId = 1L
+
+        override suspend fun saveCookieSet(cookieSet: CookieSet): Long {
+            val id = nextId++
+            cookieSets[id] = cookieSet.copy(id = id)
+            return id
+        }
+
+        override suspend fun saveDomains(domains: List<CookieSetDomain>) {
+            domains.groupBy { it.cookieSetId }.forEach { (cookieSetId, cookieSetDomains) ->
+                this.cookieSetDomains[cookieSetId] = cookieSetDomains
+            }
+        }
+
+        override fun getAllWithDomainsAsFlow(): Flow<List<CookieSetWithDomains>> {
+            return flowOf(emptyList())
+        }
+
+        override suspend fun getAllWithDomains(): List<CookieSetWithDomains> {
+            return cookieSets.values.map { cookieSet ->
+                CookieSetWithDomains(
+                    cookieSet = cookieSet,
+                    domains = cookieSetDomains[cookieSet.id].orEmpty(),
+                )
+            }
+        }
+
+        override suspend fun getCookieSetIdsByDomains(domains: Collection<String>): List<Long> {
+            return cookieSetDomains
+                .filterValues { savedDomains -> savedDomains.any { it.domain in domains } }
+                .keys
+                .toList()
+        }
+
+        override suspend fun getByIdWithDomains(id: Long): CookieSetWithDomains? {
+            val cookieSet = cookieSets[id] ?: return null
+            return CookieSetWithDomains(
+                cookieSet = cookieSet,
+                domains = cookieSetDomains[id].orEmpty(),
+            )
+        }
+
+        override suspend fun updateCookieFilePath(id: Long, cookieFilePath: String): Int {
+            cookieSets[id] = cookieSets.getValue(id).copy(cookieFilePath = cookieFilePath)
+            return 1
+        }
+
+        override suspend fun updateLastUsedAt(id: Long, lastUsedAtMillis: Long): Int =
+            error("unused")
+
+        override suspend fun deleteCookieSetById(id: Long): Int {
+            cookieSets.remove(id)
+            cookieSetDomains.remove(id)
+            return 1
+        }
+    }
+
+    private class TempCookieSetPathProvider(
+        private val rootDir: File,
+    ) : CookieSetPathProvider {
+        override fun cookiesDir(): File = rootDir.apply { mkdirs() }
+
+        override fun cookieSetDir(cookieSetId: Long): File {
+            return cookieSetDirectory(cookieSetId).apply { mkdirs() }
+        }
+
+        override fun cookieFile(cookieSetId: Long): File {
+            return File(cookieSetDir(cookieSetId), "cookies.txt")
+        }
+
+        override fun tempDir(): File {
+            return File(cookiesDir(), "temp").apply { mkdirs() }
+        }
+
+        override fun tempCookieFile(cookieSetId: Long, fileName: String): File {
+            return File(tempDir(), "${cookieSetId}_$fileName")
+        }
+
+        fun cookieSetDirectory(cookieSetId: Long): File {
+            return File(rootDir, cookieSetId.toString())
+        }
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromWebViewUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/cookieset/CreateCookieSetFromWebViewUseCaseTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.strigate.ferrot.app.integration.CookieFileStore
@@ -41,7 +42,7 @@ class CreateCookieSetFromWebViewUseCaseTest {
             val result = useCase(
                 url = "https://mobile.x.com/home",
                 rawCookieHeader = "auth=one; ct0=two",
-            )
+            ) ?: throw AssertionError("Expected cookie set")
 
             assertEquals("x.com", result.cookieSet.name)
             assertEquals(CookieSetSource.WEBVIEW, result.cookieSet.source)
@@ -51,6 +52,35 @@ class CreateCookieSetFromWebViewUseCaseTest {
                 File(result.cookieSet.cookieFilePath).readText()
                     .contains(".x.com\tTRUE\t/\tTRUE\t\tauth\tone")
             )
+        } finally {
+            rootDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun invoke_returnsNull_whenCookieHeaderIsEmpty() = runTest {
+        val rootDir = Files.createTempDirectory("cookie-webview").toFile()
+        val repository = SavingCookieSetRepository()
+        val cookieFileStore = CookieFileStore(TempCookieSetPathProvider(rootDir))
+        val useCase = CreateCookieSetFromWebViewUseCase(
+            cookieSetRepository = repository,
+            webViewCookieDomainResolver = WebViewCookieDomainResolver(CookieSetDomainParser()),
+            cookieHeaderFileBuilder = CookieHeaderFileBuilder(),
+            cookieFileStore = cookieFileStore,
+            deleteCookieSetUseCase = DeleteCookieSetUseCase(
+                cookieSetRepository = repository,
+                cookieFileStore = cookieFileStore,
+            ),
+        )
+
+        try {
+            val result = useCase(
+                url = "https://x.com/home",
+                rawCookieHeader = "",
+            )
+
+            assertNull(result)
+            assertTrue(repository.getAllWithDomains().isEmpty())
         } finally {
             rootDir.deleteRecursively()
         }
@@ -93,7 +123,7 @@ class CreateCookieSetFromWebViewUseCaseTest {
             val result = useCase(
                 url = "https://x.com/home",
                 rawCookieHeader = "auth=new",
-            )
+            ) ?: throw AssertionError("Expected cookie set")
 
             assertFalse(repository.containsCookieSet(99L))
             assertEquals(

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/cookieset/GetExistingCookieSetDomainForWebViewUrlUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/cookieset/GetExistingCookieSetDomainForWebViewUrlUseCaseTest.kt
@@ -41,6 +41,19 @@ class GetExistingCookieSetDomainForWebViewUrlUseCaseTest {
         assertNull(result)
     }
 
+    @Test
+    fun invoke_returnsNullWhenUrlHasNoValidDomain() = runTest {
+        val repository = DomainMatchingCookieSetRepository(existingDomains = setOf("x.com"))
+        val useCase = GetExistingCookieSetDomainForWebViewUrlUseCase(
+            cookieSetRepository = repository,
+            webViewCookieDomainResolver = WebViewCookieDomainResolver(CookieSetDomainParser()),
+        )
+
+        val result = useCase("not a url")
+
+        assertNull(result)
+    }
+
     private class DomainMatchingCookieSetRepository(
         private val existingDomains: Set<String>,
     ) : CookieSetRepository {

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -27,6 +26,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.strigate.ferrot.test.MainDispatcherRule
@@ -154,25 +154,62 @@ class DownloadViewModelTest {
     }
 
     @Test
-    fun constructor_requiresDownloadIdArgument() {
-        try {
-            DownloadViewModel(
-                savedStateHandle = SavedStateHandle(),
-                analyticsLogger = analyticsLogger,
-                downloadUseCase = downloadUseCase,
-                downloadVideoUseCase = downloadVideoUseCase,
-                downloadAudioUseCase = downloadAudioUseCase,
-                downloadProgressUseCase = downloadProgressUseCase,
-                downloadMetadataUseCase = downloadMetadataUseCase,
-                clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
-                startDownloadUseCase = startDownloadUseCase,
-                requestRefreshDownloadMetadataUseCase = requestRefreshDownloadMetadataUseCase,
-                downloadWithMetadataUseCase = downloadWithMetadataUseCase,
-            )
-            fail("Expected IllegalStateException")
-        } catch (_: IllegalStateException) {
+    fun constructor_fallsBackWhenDownloadIdArgumentIsMissing() = runTest(testDispatcher) {
+        val viewModel = createViewModel(initialId = null)
+        val collector = collectUiState(backgroundScope, viewModel)
+
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadUiState.Data ?: return@waitForUiState false
+            data.data.id in listOf(10L, 20L, 30L)
         }
+
+        val state = viewModel.uiState.value as DownloadUiState.Data
+        assertEquals(true, state.data.id in listOf(10L, 20L, 30L))
+
+        collector.cancel()
     }
+
+    @Test
+    fun noArgActionsDoNothing_whenDownloadIdIsMissingAndNoDownloadsExist() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                initialId = null,
+                downloadIdsFlow = MutableStateFlow(emptyList()),
+            )
+            val mediaCollector = collectSelectedMedia(backgroundScope, viewModel)
+            val eventDeferred = backgroundScope.async {
+                runCatching {
+                    withTimeout(250L) {
+                        viewModel.events.first()
+                    }
+                }
+            }
+
+            viewModel.markUnseenAndNavigateBack()
+            viewModel.setSelectedMedia(DownloadMediaType.AUDIO)
+            viewModel.deleteDownload()
+            viewModel.updateArchived(archived = true)
+            viewModel.shareDownload()
+            viewModel.saveDownload()
+            viewModel.playDownload()
+            viewModel.retryDownload()
+            viewModel.refreshDownloadMetadata()
+            advanceUntilIdle()
+
+            assertEquals(DownloadMediaType.VIDEO, viewModel.selectedMedia.value)
+            assertNull(eventDeferred.await().getOrNull())
+            verifyNoInteractions(
+                updateDownloadsSeenUseCase,
+                requestDeleteDownloadsUseCase,
+                startDownloadUseCase,
+                requestRefreshDownloadMetadataUseCase,
+                getDownloadByIdAsFlowUseCase,
+            )
+            verify(analyticsLogger, never())
+                .logEvent(AnalyticsEvents.DOWNLOAD_RETRY)
+
+            mediaCollector.cancel()
+        }
 
     @Test
     fun uiState_returnsNullId_whenDownloadIdsAreEmpty() = runTest(testDispatcher) {
@@ -773,7 +810,7 @@ class DownloadViewModelTest {
     }
 
     private fun createViewModel(
-        initialId: Long = 20L,
+        initialId: Long? = 20L,
         downloadIdsFlow: MutableStateFlow<List<Long>> = MutableStateFlow(listOf(10L, 20L, 30L)),
         downloadsWithMetadataFlow: MutableStateFlow<List<DownloadWithMetadata>>? = null,
     ): DownloadViewModel {
@@ -806,10 +843,14 @@ class DownloadViewModelTest {
         `when`(downloadProgressUseCase.getDownloadProgressByDownloadIdAsFlowUseCase)
             .thenReturn(getDownloadProgressByDownloadIdAsFlowUseCase)
 
+        val savedStateHandle = if (initialId == null) {
+            SavedStateHandle()
+        } else {
+            SavedStateHandle(mapOf(Screen.Download.ARG_DOWNLOAD_ID to initialId))
+        }
+
         return DownloadViewModel(
-            savedStateHandle = SavedStateHandle(
-                mapOf(Screen.Download.ARG_DOWNLOAD_ID to initialId)
-            ),
+            savedStateHandle = savedStateHandle,
             analyticsLogger = analyticsLogger,
             downloadUseCase = downloadUseCase,
             downloadVideoUseCase = downloadVideoUseCase,


### PR DESCRIPTION
- Return `null` from `CookieHeaderFileBuilder` when cookies or domains are unavailable
- Return `null` from `WebViewCookieDomainResolver` for invalid domains
- Treat failed `CreateCookieSetFromFileUseCase` and `CreateCookieSetFromWebViewUseCase` results as failed UI operations
- Allow `DownloadViewModel` to operate without `ARG_DOWNLOAD_ID`
- Add coverage for cookie save failures and missing download selection