### PR TITLE
refactor: Encapsulate extended icon dependency

### DIFF
--- a/refinery/build.gradle.kts
+++ b/refinery/build.gradle.kts
@@ -32,6 +32,6 @@ dependencies {
     api(platform(libs.androidx.compose.bom))
     api(libs.androidx.compose.ui)
     api(libs.androidx.compose.ui.graphics)
-    api(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.compose.material.icons.extended)
     api(libs.androidx.compose.material3)
 }


### PR DESCRIPTION
- Change extended icon pack from `api` to `implementation`