### PR TITLE
refactor: Make settings dropdowns type-safe

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -40,7 +40,6 @@ import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import org.strigate.ferrot.presentation.viewmodel.SettingsViewModel
 import org.strigate.refinery.component.settings.DropdownSetting
-import org.strigate.refinery.component.settings.DropdownSettingOption
 import org.strigate.refinery.component.settings.ExpandableSettingsSection
 import org.strigate.refinery.component.settings.SwitchSetting
 import org.strigate.refinery.component.settings.TextNavigateSetting
@@ -70,25 +69,6 @@ fun SettingsScreen(
             DownloadSwipeActionUiData.DELETE -> deleteSwipeActionLabel
         }
     }
-
-    val swipeActionOptions = listOf(
-        DropdownSettingOption(
-            id = DownloadSwipeActionUiData.NONE.name,
-            text = noneSwipeActionLabel,
-        ),
-        DropdownSettingOption(
-            id = DownloadSwipeActionUiData.ARCHIVE.name,
-            text = archiveSwipeActionLabel,
-        ),
-        DropdownSettingOption(
-            id = DownloadSwipeActionUiData.SEEN.name,
-            text = seenSwipeActionLabel,
-        ),
-        DropdownSettingOption(
-            id = DownloadSwipeActionUiData.DELETE.name,
-            text = deleteSwipeActionLabel,
-        ),
-    )
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -192,24 +172,18 @@ fun SettingsScreen(
                                     DropdownSetting(
                                         text = stringResource(R.string.settings_title_swipe_left),
                                         description = stringResource(R.string.settings_description_swipe_left),
-                                        selectedText = swipeActionLabel(leftSwipeAction),
-                                        options = swipeActionOptions,
-                                        onOptionSelected = { option ->
-                                            viewModel.setLeftSwipeAction(
-                                                DownloadSwipeActionUiData.valueOf(option.id),
-                                            )
-                                        },
+                                        selectedOption = leftSwipeAction,
+                                        options = DownloadSwipeActionUiData.entries,
+                                        optionText = { option -> swipeActionLabel(option) },
+                                        onOptionSelected = viewModel::setLeftSwipeAction,
                                     )
                                     DropdownSetting(
                                         text = stringResource(R.string.settings_title_swipe_right),
                                         description = stringResource(R.string.settings_description_swipe_right),
-                                        selectedText = swipeActionLabel(rightSwipeAction),
-                                        options = swipeActionOptions,
-                                        onOptionSelected = { option ->
-                                            viewModel.setRightSwipeAction(
-                                                DownloadSwipeActionUiData.valueOf(option.id),
-                                            )
-                                        },
+                                        selectedOption = rightSwipeAction,
+                                        options = DownloadSwipeActionUiData.entries,
+                                        optionText = { option -> swipeActionLabel(option) },
+                                        onOptionSelected = viewModel::setRightSwipeAction,
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
@@ -39,79 +39,83 @@ fun ColorPickerSetting(
     val chipColor = MaterialTheme.colorScheme.surface
     val chipTextColor = MaterialTheme.colorScheme.onSurface
     val clickableModifier = if (onClick != null) {
+        Modifier.combinedClickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = ripple(),
+            onClick = onClick,
+        )
+    } else {
         Modifier
-            .combinedClickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = ripple(),
-                onClick = {
-                    onClick()
-                },
-            )
-    } else Modifier
+    }
 
-    Column(
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .then(clickableModifier)
-            .padding(
-                horizontal = refineryDimens.spacingMedium,
-                vertical = refineryDimens.spacingMediumAlt,
-            ),
     ) {
-        Row(
+        Column(
             modifier = Modifier
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+                .fillMaxWidth()
+                .then(clickableModifier)
+                .padding(
+                    horizontal = refineryDimens.spacingMedium,
+                    vertical = refineryDimens.spacingMediumAlt,
+                ),
         ) {
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(end = refineryDimens.spacingLarge),
-            ) {
-                Text(
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    text = text,
-                )
-                description?.let { currentDescription ->
-                    Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
-                    Text(
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        text = currentDescription,
-                    )
-                }
-            }
             Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Box(
+                Column(
                     modifier = Modifier
-                        .clip(RoundedCornerShape(refineryDimens.radiusPill))
-                        .background(chipColor)
-                        .padding(
-                            start = refineryDimens.spacingSmall,
-                            end = refineryDimens.spacingMediumAlt,
-                            top = refineryDimens.spacingXSmallAlt,
-                            bottom = refineryDimens.spacingXSmallAlt,
-                        ),
+                        .weight(1f)
+                        .padding(end = refineryDimens.spacingLarge),
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(refineryDimens.spacingSmallAlt),
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(refineryDimens.iconXSmall)
-                                .clip(RoundedCornerShape(refineryDimens.radiusMedium))
-                                .background(color),
-                        )
+                    Text(
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        text = text,
+                    )
+                    description?.let { currentDescription ->
+                        Spacer(modifier = Modifier.height(refineryDimens.spacingXSmall))
                         Text(
-                            text = color.toHexString(),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = chipTextColor,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            text = currentDescription,
                         )
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(refineryDimens.radiusPill))
+                            .background(chipColor)
+                            .padding(
+                                start = refineryDimens.spacingSmall,
+                                end = refineryDimens.spacingMediumAlt,
+                                top = refineryDimens.spacingXSmallAlt,
+                                bottom = refineryDimens.spacingXSmallAlt,
+                            ),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(refineryDimens.spacingSmallAlt),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(refineryDimens.iconXSmall)
+                                    .clip(RoundedCornerShape(refineryDimens.radiusMedium))
+                                    .background(color),
+                            )
+                            Text(
+                                text = color.toHexString(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = chipTextColor,
+                            )
+                        }
                     }
                 }
             }

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/DropdownSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/DropdownSetting.kt
@@ -30,19 +30,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.DpOffset
 import org.strigate.refinery.theme.LocalRefineryDimens
 
-data class DropdownSettingOption(
-    val id: String,
-    val text: String,
-)
-
 @Composable
-fun DropdownSetting(
+fun <T> DropdownSetting(
     text: String,
-    selectedText: String,
-    options: List<DropdownSettingOption>,
+    selectedOption: T,
+    options: List<T>,
+    optionText: @Composable (T) -> String,
     modifier: Modifier = Modifier,
     description: String? = null,
-    onOptionSelected: (DropdownSettingOption) -> Unit,
+    onOptionSelected: (T) -> Unit,
 ) {
     val refineryDimens = LocalRefineryDimens.current
 
@@ -115,7 +111,7 @@ fun DropdownSetting(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
-                                text = selectedText,
+                                text = optionText(selectedOption),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = chipTextColor,
                             )
@@ -136,8 +132,7 @@ fun DropdownSetting(
                             },
                             items = options.map { option ->
                                 SettingsDropdownMenuItem(
-                                    id = option.id,
-                                    text = option.text,
+                                    text = optionText(option),
                                     onClick = {
                                         onOptionSelected(option)
                                     },

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsDropdownMenu.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsDropdownMenu.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.unit.DpOffset
 import org.strigate.refinery.theme.LocalRefineryDimens
 
 internal data class SettingsDropdownMenuItem(
-    val id: String,
     val text: String,
     val enabled: Boolean = true,
     val leadingIcon: (@Composable (() -> Unit))? = null,


### PR DESCRIPTION
- Preserve typed options in `DropdownSetting`
- Simplify swipe action selection
- Align `ColorPickerSetting` with shared source