### PR TITLE
fix: Handle external link launch failures

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -1,5 +1,6 @@
 package org.strigate.ferrot.presentation.screen
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
@@ -35,6 +36,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.copyToClipboard
+import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.presentation.component.Copyright
 import org.strigate.ferrot.presentation.event.AboutEvent
 import org.strigate.ferrot.presentation.viewmodel.AboutViewModel
@@ -73,9 +75,15 @@ fun AboutScreen(
                 }
 
                 is AboutEvent.OpenUrl -> {
-                    context.startActivity(
-                        Intent(Intent.ACTION_VIEW, event.url.toUri())
-                    )
+                    try {
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, event.url.toUri()),
+                        )
+                    } catch (_: ActivityNotFoundException) {
+                        context.toast(R.string.toast_unable_to_open_link)
+                    } catch (_: SecurityException) {
+                        context.toast(R.string.toast_unable_to_open_link)
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="toast_cookie_set_failed">Could not save cookies</string>
     <string name="toast_cookie_set_preview_failed">Could not load cookies</string>
     <string name="toast_cookie_webview_invalid_url">Enter a valid site URL</string>
+    <string name="toast_unable_to_open_link">Unable to open link</string>
 
     <!-- Settings: sections -->
     <string name="settings_section_general">General</string>


### PR DESCRIPTION
- Catch `ActivityNotFoundException` and `SecurityException` when opening links
- Display feedback when no permitted link handler is available