### PR TITLE
fix: Align confirmation dialog title styling

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/ConfirmDialog.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/ConfirmDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import org.strigate.ferrot.presentation.theme.TextStyles
 
 @Composable
 fun ConfirmDialog(
@@ -18,7 +19,10 @@ fun ConfirmDialog(
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = {
-            Text(text = title)
+            Text(
+                text = title,
+                style = TextStyles.dialogTitle(),
+            )
         },
         text = {
             Text(text = message)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/theme/Type.kt
@@ -3,8 +3,16 @@ package org.strigate.ferrot.presentation.theme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
 object TextStyles {
+    @Composable
+    fun dialogTitle() = MaterialTheme.typography.titleLarge
+        .copy(
+            fontSize = 22.sp,
+            lineHeight = 24.sp,
+        )
+
     @Composable
     fun downloadsTitle() = MaterialTheme.typography
         .titleLarge


### PR DESCRIPTION
- Add reusable `TextStyles.dialogTitle` typography
- Apply the dialog title style to `ConfirmDialog`