### PR TITLE
refactor: Decouple screen content dependencies

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -47,16 +47,13 @@ import org.strigate.refinery.component.settings.TextSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AboutScreen(
     modifier: Modifier = Modifier,
     viewModel: AboutViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-    val refineryDimens = LocalRefineryDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-    val urlStrigate = stringResource(R.string.url_strigate)
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -89,15 +86,34 @@ fun AboutScreen(
         }
     }
 
+    AboutScreenContent(
+        onBackClick = { backDispatcher?.onBackPressed() },
+        onBuildClick = viewModel::onBuildClicked,
+        onUrlClick = viewModel::onUrlClicked,
+        onCopyText = context::copyToClipboard,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AboutScreenContent(
+    onBackClick: () -> Unit,
+    onBuildClick: () -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+    val urlStrigate = stringResource(R.string.url_strigate)
+
     Scaffold(
         topBar = {
             TopAppBar(
                 colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
-                        onClick = {
-                            backDispatcher?.onBackPressed()
-                        },
+                        onClick = onBackClick,
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -133,10 +149,10 @@ fun AboutScreen(
                             text = stringResource(R.string.settings_title_build),
                             description = BuildConfig.VERSION_NAME,
                             onLongClick = {
-                                context.copyToClipboard(BuildConfig.VERSION_NAME)
+                                onCopyText(BuildConfig.VERSION_NAME)
                             },
                         ) {
-                            viewModel.onBuildClicked()
+                            onBuildClick()
                         }
                     }
                     Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
@@ -152,37 +168,37 @@ fun AboutScreen(
                             text = stringResource(R.string.settings_title_website),
                             description = stringResource(R.string.settings_description_website),
                             onLongClick = {
-                                context.copyToClipboard(urlWebsite)
+                                onCopyText(urlWebsite)
                             },
                         ) {
-                            viewModel.onUrlClicked(urlWebsite)
+                            onUrlClick(urlWebsite)
                         }
                         TextSetting(
                             text = stringResource(R.string.settings_title_github),
                             description = stringResource(R.string.settings_description_github),
                             onLongClick = {
-                                context.copyToClipboard(urlGitHub)
+                                onCopyText(urlGitHub)
                             },
                         ) {
-                            viewModel.onUrlClicked(urlGitHub)
+                            onUrlClick(urlGitHub)
                         }
                         TextSetting(
                             text = stringResource(R.string.settings_title_privacy),
                             description = stringResource(R.string.settings_description_privacy),
                             onLongClick = {
-                                context.copyToClipboard(urlPrivacy)
+                                onCopyText(urlPrivacy)
                             },
                         ) {
-                            viewModel.onUrlClicked(urlPrivacy)
+                            onUrlClick(urlPrivacy)
                         }
                         TextSetting(
                             text = stringResource(R.string.settings_title_license),
                             description = stringResource(R.string.settings_description_license),
                             onLongClick = {
-                                context.copyToClipboard(urlLicense)
+                                onCopyText(urlLicense)
                             },
                         ) {
-                            viewModel.onUrlClicked(urlLicense)
+                            onUrlClick(urlLicense)
                         }
                     }
                     Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
@@ -195,14 +211,14 @@ fun AboutScreen(
                                     painter = painterResource(R.drawable.ic_github),
                                     contentDescription = stringResource(R.string.content_description_github),
                                     onClick = {
-                                        viewModel.onUrlClicked(urlGitHubStrigate)
+                                        onUrlClick(urlGitHubStrigate)
                                     },
                                 ),
                                 SettingsIconRowItem(
                                     painter = painterResource(R.drawable.ic_x),
                                     contentDescription = stringResource(R.string.content_description_x),
                                     onClick = {
-                                        viewModel.onUrlClicked(urlX)
+                                        onUrlClick(urlX)
                                     },
                                 ),
                             ),
@@ -212,7 +228,7 @@ fun AboutScreen(
                         modifier = Modifier
                             .fillMaxWidth(),
                         onLogoClick = {
-                            viewModel.onUrlClicked(urlStrigate)
+                            onUrlClick(urlStrigate)
                         },
                     )
                 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/CookiesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/CookiesScreen.kt
@@ -60,20 +60,15 @@ import org.strigate.refinery.component.settings.TextSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CookiesScreen(
     navController: NavController,
     modifier: Modifier = Modifier,
     viewModel: CookiesViewModel = hiltViewModel(),
 ) {
-    val refineryDimens = LocalRefineryDimens.current
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-
     val uiState by viewModel.uiState.collectAsState()
-
-    var cookieSetPendingDelete by remember { mutableStateOf<CookieSetUiData?>(null) }
 
     val importLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
@@ -94,6 +89,35 @@ fun CookiesScreen(
         }
     }
 
+    CookiesScreenContent(
+        uiState = uiState,
+        onBackClick = { backDispatcher?.onBackPressed() ?: navController.popBackStack() },
+        onNavigateToGetCookies = { navController.navigate(Screen.GetCookies.route) },
+        onImportFile = { importLauncher.launch(COOKIE_FILE_MIME_TYPES) },
+        onDeleteCookieSet = { cookieSet ->
+            if (cookieSet.source == CookieSetSourceUiData.WEBVIEW) {
+                clearWebViewData()
+            }
+            viewModel.deleteCookieSet(cookieSet.id)
+        },
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun CookiesScreenContent(
+    uiState: CookiesUiState,
+    onBackClick: () -> Unit,
+    onNavigateToGetCookies: () -> Unit,
+    onImportFile: () -> Unit,
+    onDeleteCookieSet: (CookieSetUiData) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+
+    var cookieSetPendingDelete by remember { mutableStateOf<CookieSetUiData?>(null) }
+
     cookieSetPendingDelete?.let { cookieSet ->
         ConfirmDialog(
             title = stringResource(R.string.confirm_dialog_delete_cookie_set_title),
@@ -105,10 +129,7 @@ fun CookiesScreen(
             negativeButtonText = stringResource(R.string.cancel),
             isDestructive = true,
             onPositiveClick = {
-                if (cookieSet.source == CookieSetSourceUiData.WEBVIEW) {
-                    clearWebViewData()
-                }
-                viewModel.deleteCookieSet(cookieSet.id)
+                onDeleteCookieSet(cookieSet)
                 cookieSetPendingDelete = null
             },
             onNegativeClick = {
@@ -125,9 +146,7 @@ fun CookiesScreen(
                 colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
-                        onClick = {
-                            backDispatcher?.onBackPressed() ?: navController.popBackStack()
-                        },
+                        onClick = onBackClick,
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -169,12 +188,12 @@ fun CookiesScreen(
                                 TextSetting(
                                     text = stringResource(R.string.cookies_title_get_cookies),
                                     description = stringResource(R.string.cookies_description_get_cookies),
-                                    onClick = { navController.navigate(Screen.GetCookies.route) },
+                                    onClick = onNavigateToGetCookies,
                                 )
                                 TextSetting(
                                     text = stringResource(R.string.cookies_title_import_file),
                                     description = stringResource(R.string.cookies_description_import_file),
-                                    onClick = { importLauncher.launch(COOKIE_FILE_MIME_TYPES) },
+                                    onClick = onImportFile,
                                 )
                             }
                             Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadScreen.kt
@@ -76,7 +76,6 @@ import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
@@ -104,7 +103,6 @@ import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 import java.io.File
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadScreen(
     navController: NavController,
@@ -113,6 +111,7 @@ fun DownloadScreen(
 ) {
     val view = LocalView.current
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val selectedId by viewModel.selectedId.collectAsStateWithLifecycle()
@@ -158,23 +157,83 @@ fun DownloadScreen(
         }
     }
 
-    if (showConfirmDeleteDialog.value) {
+    DownloadScreenContent(
+        state = DownloadScreenContentState(
+            uiState = uiState,
+            selectedId = selectedId,
+            selectedMedia = selectedMedia,
+            selectedPageData = selectedPageData,
+            showConfirmDeleteDialog = showConfirmDeleteDialog.value,
+        ),
+        pageDataForId = { downloadId ->
+            val pageData by remember(downloadId) {
+                viewModel.getDownloadPageUiData(downloadId)
+            }.collectAsStateWithLifecycle(initialValue = null)
+            pageData
+        },
+        onBackClick = onNavigateBack,
+        onMarkUnseen = viewModel::markUnseenAndNavigateBack,
+        onUpdateArchived = viewModel::updateArchived,
+        onShowDeleteConfirmation = { showConfirmDeleteDialog.value = true },
+        onDeleteConfirmed = {
+            viewModel.deleteDownload()
+            showConfirmDeleteDialog.value = false
+        },
+        onDeleteDismissed = { showConfirmDeleteDialog.value = false },
+        onEnsureDefaults = viewModel::setDefaultsForIds,
+        onDownloadPageSelected = viewModel::selectDownload,
+        onVisibleCompletedUnseenDownload = viewModel::markSeenIfCompleted,
+        onSelectedMedia = { downloadId, mediaType ->
+            viewModel.setSelectedMedia(mediaType, downloadId)
+        },
+        onPlayClick = viewModel::playDownload,
+        onSaveClick = viewModel::saveDownload,
+        onShareClick = viewModel::shareDownload,
+        onRetryClick = { downloadId ->
+            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+            viewModel.retryDownload(downloadId)
+        },
+        onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
+        onUrlClick = uriHandler::openUri,
+        onCopyText = context::copyToClipboard,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DownloadScreenContent(
+    state: DownloadScreenContentState,
+    pageDataForId: @Composable (Long) -> DownloadPageUiData?,
+    onBackClick: () -> Unit,
+    onMarkUnseen: () -> Unit,
+    onUpdateArchived: (Boolean) -> Unit,
+    onShowDeleteConfirmation: () -> Unit,
+    onDeleteConfirmed: () -> Unit,
+    onDeleteDismissed: () -> Unit,
+    onEnsureDefaults: (List<Long>) -> Unit,
+    onDownloadPageSelected: (Long) -> Unit,
+    onVisibleCompletedUnseenDownload: (Long) -> Unit,
+    onSelectedMedia: (Long, DownloadMediaType) -> Unit,
+    onPlayClick: (Long) -> Unit,
+    onSaveClick: (Long) -> Unit,
+    onShareClick: (Long) -> Unit,
+    onRetryClick: (Long) -> Unit,
+    onRefreshMetadataClick: (Long) -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state.showConfirmDeleteDialog) {
         ConfirmDialog(
             title = stringResource(R.string.confirm_dialog_delete_download_title),
             message = stringResource(R.string.confirm_dialog_delete_download_description),
             positiveButtonText = stringResource(R.string.yes),
             isDestructive = true,
-            onPositiveClick = {
-                viewModel.deleteDownload()
-                showConfirmDeleteDialog.value = false
-            },
+            onPositiveClick = onDeleteConfirmed,
             negativeButtonText = stringResource(R.string.no),
-            onNegativeClick = {
-                showConfirmDeleteDialog.value = false
-            },
-            onDismissRequest = {
-                showConfirmDeleteDialog.value = false
-            },
+            onNegativeClick = onDeleteDismissed,
+            onDismissRequest = onDeleteDismissed,
         )
     }
 
@@ -186,7 +245,7 @@ fun DownloadScreen(
                 navigationIcon = {
                     IconButton(
                         onClick = {
-                            onNavigateBack()
+                            onBackClick()
                         },
                     ) {
                         Icon(
@@ -197,7 +256,7 @@ fun DownloadScreen(
                 },
                 title = {
                     Text(
-                        text = if (selectedPageData?.archived == true) {
+                        text = if (state.selectedPageData?.archived == true) {
                             stringResource(R.string.screen_title_archived_download)
                         } else {
                             stringResource(R.string.screen_title_download)
@@ -207,7 +266,7 @@ fun DownloadScreen(
                 actions = {
                     IconButton(
                         onClick = {
-                            viewModel.markUnseenAndNavigateBack()
+                            onMarkUnseen()
                         },
                     ) {
                         Icon(
@@ -217,17 +276,17 @@ fun DownloadScreen(
                     }
                     IconButton(
                         onClick = {
-                            val archived = selectedPageData?.archived ?: false
-                            viewModel.updateArchived(archived = !archived)
+                            val archived = state.selectedPageData?.archived ?: false
+                            onUpdateArchived(!archived)
                         },
                     ) {
                         Icon(
-                            imageVector = if (selectedPageData?.archived == true) {
+                            imageVector = if (state.selectedPageData?.archived == true) {
                                 Icons.Filled.Unarchive
                             } else {
                                 Icons.Filled.Archive
                             },
-                            contentDescription = if (selectedPageData?.archived == true) {
+                            contentDescription = if (state.selectedPageData?.archived == true) {
                                 stringResource(R.string.content_description_unarchive)
                             } else {
                                 stringResource(R.string.content_description_archive)
@@ -236,7 +295,7 @@ fun DownloadScreen(
                     }
                     IconButton(
                         onClick = {
-                            showConfirmDeleteDialog.value = true
+                            onShowDeleteConfirmation()
                         },
                     ) {
                         Icon(
@@ -249,7 +308,7 @@ fun DownloadScreen(
         },
         content = { contentPadding ->
             val dimens = LocalDimens.current
-            when (val state = uiState) {
+            when (val uiState = state.uiState) {
                 is DownloadUiState.Loading -> {
                     LoadingState(
                         modifier = modifier
@@ -266,24 +325,21 @@ fun DownloadScreen(
                         modifier = modifier
                             .padding(contentPadding)
                             .fillMaxSize(),
-                        data = state.data,
-                        pageDataForId = viewModel::getDownloadPageUiData,
-                        selectedId = selectedId,
-                        selectedMedia = selectedMedia,
-                        onEnsureDefaults = viewModel::setDefaultsForIds,
-                        onDownloadPageSelected = viewModel::selectDownload,
-                        onVisibleCompletedUnseenDownload = viewModel::markSeenIfCompleted,
-                        onSelectedMedia = { downloadId, type ->
-                            viewModel.setSelectedMedia(type, downloadId)
-                        },
-                        onPlayClick = viewModel::playDownload,
-                        onSaveClick = viewModel::saveDownload,
-                        onShareClick = viewModel::shareDownload,
-                        onRetryClick = { downloadId ->
-                            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                            viewModel.retryDownload(downloadId)
-                        },
-                        onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
+                        data = uiState.data,
+                        pageDataForId = pageDataForId,
+                        selectedId = state.selectedId,
+                        selectedMedia = state.selectedMedia,
+                        onEnsureDefaults = onEnsureDefaults,
+                        onDownloadPageSelected = onDownloadPageSelected,
+                        onVisibleCompletedUnseenDownload = onVisibleCompletedUnseenDownload,
+                        onSelectedMedia = onSelectedMedia,
+                        onPlayClick = onPlayClick,
+                        onSaveClick = onSaveClick,
+                        onShareClick = onShareClick,
+                        onRetryClick = onRetryClick,
+                        onRefreshMetadataClick = onRefreshMetadataClick,
+                        onUrlClick = onUrlClick,
+                        onCopyText = onCopyText,
                         pagePadding = PaddingValues(
                             horizontal = peekPadding,
                             vertical = dimens.zero,
@@ -330,7 +386,7 @@ private fun navigateBackToParent(
 private fun DownloadPager(
     modifier: Modifier = Modifier,
     data: DownloadUiData,
-    pageDataForId: (Long) -> Flow<DownloadPageUiData?>,
+    pageDataForId: @Composable (Long) -> DownloadPageUiData?,
     selectedId: Long?,
     selectedMedia: DownloadMediaType,
     onEnsureDefaults: (List<Long>) -> Unit,
@@ -342,6 +398,8 @@ private fun DownloadPager(
     onShareClick: (Long) -> Unit,
     onRetryClick: (Long) -> Unit,
     onRefreshMetadataClick: (Long) -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String, String) -> Unit,
     pagePadding: PaddingValues,
     pageSpacing: Dp,
 ) {
@@ -393,9 +451,7 @@ private fun DownloadPager(
         ) { page ->
             val downloadId = downloadIds[page]
             val isCurrentPage = pagerState.currentPage == page
-            val pageData by remember(downloadId) {
-                pageDataForId(downloadId)
-            }.collectAsStateWithLifecycle(initialValue = null)
+            val pageData = pageDataForId(downloadId)
 
             Surface(
                 modifier = Modifier
@@ -433,6 +489,8 @@ private fun DownloadPager(
                         onRefreshMetadataClick = {
                             onRefreshMetadataClick(download.id)
                         },
+                        onUrlClick = onUrlClick,
+                        onCopyText = onCopyText,
                     )
                 } ?: LoadingState(
                     modifier = Modifier
@@ -457,6 +515,8 @@ private fun DownloadPageContent(
     onShareClick: () -> Unit,
     onRetryClick: () -> Unit,
     onRefreshMetadataClick: () -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String, String) -> Unit,
 ) {
     val refineryDimens = LocalRefineryDimens.current
     val dimens = LocalDimens.current
@@ -594,6 +654,8 @@ private fun DownloadPageContent(
                     isCopyable = true,
                     isUrl = true,
                     value = url,
+                    onUrlClick = onUrlClick,
+                    onCopyText = onCopyText,
                 )
                 val selectedName = when (selectedMedia) {
                     DownloadMediaType.VIDEO -> video?.fileName
@@ -853,10 +915,10 @@ private fun MetaItem(
     modifier: Modifier = Modifier,
     isCopyable: Boolean = false,
     isUrl: Boolean = false,
+    onUrlClick: (String) -> Unit = {},
+    onCopyText: (String, String) -> Unit = { _, _ -> },
 ) {
     val dimens = LocalDimens.current
-    val context = LocalContext.current
-    val uriHandler = LocalUriHandler.current
     Row(
         modifier = modifier
             .fillMaxWidth(),
@@ -881,7 +943,7 @@ private fun MetaItem(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = LocalIndication.current,
                         ) {
-                            uriHandler.openUri(value)
+                            onUrlClick(value)
                         },
                     style = MaterialTheme.typography.bodySmall.copy(
                         textDecoration = TextDecoration.Underline,
@@ -904,7 +966,7 @@ private fun MetaItem(
                 enabled = true,
                 imageVector = Icons.Filled.ContentCopy,
                 onClick = {
-                    context.copyToClipboard(value, label)
+                    onCopyText(value, label)
                 },
                 contentDescription = stringResource(R.string.content_description_copy_to_clipboard),
             )
@@ -923,3 +985,11 @@ private fun DownloadError(
         text = stringResource(R.string.error_failed_to_load_download),
     )
 }
+
+internal data class DownloadScreenContentState(
+    val uiState: DownloadUiState,
+    val selectedId: Long?,
+    val selectedMedia: DownloadMediaType,
+    val selectedPageData: DownloadPageUiData?,
+    val showConfirmDeleteDialog: Boolean,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/DownloadsScreen.kt
@@ -126,7 +126,6 @@ private const val RETRY_FAILED_SCROLL_DELAY_MILLIS = 357L
 private const val SNAP_BACK_SWIPE_THRESHOLD_RATIO = 0.3f
 private const val DISMISS_SWIPE_THRESHOLD_RATIO = 0.5f
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadsScreen(
     navController: NavController,
@@ -134,15 +133,88 @@ fun DownloadsScreen(
     modifier: Modifier = Modifier,
     viewModel: DownloadsViewModel = hiltViewModel(),
 ) {
-    val view = LocalView.current
     val context = LocalContext.current
-    val keyboardController = LocalSoftwareKeyboardController.current
-
-    val lazyListState = rememberLazyListState()
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val isArchived by viewModel.isArchived.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.logShown()
+    }
+    LaunchedEffect(archived) {
+        viewModel.setArchived(archived)
+    }
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is DownloadsEvent.InstallUpdate -> {
+                    InstallHelper.requestInstallApkIfExists(context, event.path)
+                }
+            }
+        }
+    }
+    LifecycleEffect {
+        on(Lifecycle.Event.ON_START) {
+            viewModel.requestDeletePendingDownloadsImmediate()
+        }
+    }
+
+    DownloadsScreenContent(
+        uiState = uiState,
+        searchQuery = searchQuery,
+        isArchived = isArchived,
+        onUpdateSearchQuery = viewModel::updateSearchQuery,
+        onNavigateBack = navController::navigateUp,
+        onNavigateToDownload = { item ->
+            navController.navigate(
+                Screen.Download.route(
+                    id = item.id,
+                    archived = isArchived,
+                )
+            )
+        },
+        onNavigateToArchived = { navController.navigate(Screen.Archived.route) },
+        onNavigateToSettings = { navController.navigate(Screen.Settings.route) },
+        onInstallAvailableUpdate = viewModel::installAvailableUpdate,
+        onStopDownload = viewModel::stopDownload,
+        onRetryDownload = viewModel::retryDownload,
+        onMarkDownloadsPendingDelete = viewModel::markDownloadsPendingDelete,
+        onRequestDeletePendingDownloadsImmediate = viewModel::requestDeletePendingDownloadsImmediate,
+        onUpdateDownloadsArchived = viewModel::updateDownloadsArchived,
+        onToggleDownloadsSeen = viewModel::toggleDownloadsSeen,
+        onRetryFailedDownloads = viewModel::retryFailedDownloads,
+        onStopAllDownloads = viewModel::stopAllDownloads,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DownloadsScreenContent(
+    uiState: DownloadsUiState,
+    searchQuery: TextFieldValue,
+    isArchived: Boolean,
+    onUpdateSearchQuery: (TextFieldValue) -> Unit,
+    onNavigateBack: () -> Unit,
+    onNavigateToDownload: (DownloadItemUiData) -> Unit,
+    onNavigateToArchived: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onInstallAvailableUpdate: () -> Unit,
+    onStopDownload: (Long) -> Unit,
+    onRetryDownload: (Long) -> Unit,
+    onMarkDownloadsPendingDelete: (Set<Long>, Boolean) -> Unit,
+    onRequestDeletePendingDownloadsImmediate: () -> Unit,
+    onUpdateDownloadsArchived: (Set<Long>, Boolean) -> Unit,
+    onToggleDownloadsSeen: (Set<Long>) -> Unit,
+    onRetryFailedDownloads: () -> Unit,
+    onStopAllDownloads: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val view = LocalView.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    val lazyListState = rememberLazyListState()
 
     val searchFocusRequester = remember { FocusRequester() }
     val snackbarHostState = remember { SnackbarHostState() }
@@ -159,7 +231,7 @@ fun DownloadsScreen(
 
     BackHandler(enabled = searchActive) {
         searchActive = false
-        viewModel.updateSearchQuery(TextFieldValue(""))
+        onUpdateSearchQuery(TextFieldValue(""))
         keyboardController?.hide()
     }
     LaunchedEffect(searchActive) {
@@ -217,26 +289,6 @@ fun DownloadsScreen(
     BackHandler(enabled = selectionMode) {
         selectedIds = emptySet()
     }
-    LaunchedEffect(Unit) {
-        viewModel.logShown()
-    }
-    LaunchedEffect(archived) {
-        viewModel.setArchived(archived)
-    }
-    LaunchedEffect(Unit) {
-        viewModel.events.collect { event ->
-            when (event) {
-                is DownloadsEvent.InstallUpdate -> {
-                    InstallHelper.requestInstallApkIfExists(context, event.path)
-                }
-            }
-        }
-    }
-    LifecycleEffect {
-        on(Lifecycle.Event.ON_START) {
-            viewModel.requestDeletePendingDownloadsImmediate()
-        }
-    }
     PendingDeleteSnackbarEffect(
         pendingDeleteIds = pendingDeleteIds,
         hasPendingDeletes = hasPendingDeletes,
@@ -247,9 +299,9 @@ fun DownloadsScreen(
         snackbarBulkDeleteMessage = snackbarBulkDeleteMessage,
         snackbarUndoActionLabel = snackbarUndoActionLabel,
         onUndoPendingDelete = { ids ->
-            viewModel.markDownloadsPendingDelete(ids, pendingDelete = false)
+            onMarkDownloadsPendingDelete(ids, false)
         },
-        onConfirmPendingDelete = viewModel::requestDeletePendingDownloadsImmediate,
+        onConfirmPendingDelete = onRequestDeletePendingDownloadsImmediate,
     )
 
     Scaffold(
@@ -258,8 +310,6 @@ fun DownloadsScreen(
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             DownloadsTopBar(
-                navController = navController,
-                viewModel = viewModel,
                 selectionMode = selectionMode,
                 selectedIds = selectedIds,
                 dismissingIds = dismissingIds,
@@ -281,6 +331,15 @@ fun DownloadsScreen(
                 onDismissingIdsChange = { dismissingIds = it },
                 onArchivingIdsChange = { archivingIds = it },
                 onSearchActiveChange = { searchActive = it },
+                onSearchQueryChange = onUpdateSearchQuery,
+                onNavigateBack = onNavigateBack,
+                onNavigateToArchived = onNavigateToArchived,
+                onNavigateToSettings = onNavigateToSettings,
+                onToggleDownloadsSeen = onToggleDownloadsSeen,
+                onMarkDownloadsPendingDelete = onMarkDownloadsPendingDelete,
+                onUpdateDownloadsArchived = onUpdateDownloadsArchived,
+                onRetryFailedDownloads = onRetryFailedDownloads,
+                onStopAllDownloads = onStopAllDownloads,
             )
         },
         snackbarHost = {
@@ -322,9 +381,7 @@ fun DownloadsScreen(
                                         .fillMaxWidth(),
                                     tag = it.tag,
                                     localFilePath = it.localFilePath,
-                                    onClick = {
-                                        viewModel.installAvailableUpdate()
-                                    },
+                                    onClick = { onInstallAvailableUpdate() },
                                 )
                             }
                             DownloadsList(
@@ -341,15 +398,10 @@ fun DownloadsScreen(
                                 lazyListState = lazyListState,
                                 onItemClick = { item ->
                                     if (pendingDeleteIds.isNotEmpty()) {
-                                        viewModel.requestDeletePendingDownloadsImmediate()
+                                        onRequestDeletePendingDownloadsImmediate()
                                     }
                                     keyboardController?.hide()
-                                    navController.navigate(
-                                        Screen.Download.route(
-                                            id = item.id,
-                                            archived = isArchived,
-                                        )
-                                    )
+                                    onNavigateToDownload(item)
                                 },
                                 onPauseResume = { item ->
                                     when (item.status) {
@@ -359,12 +411,12 @@ fun DownloadsScreen(
                                         DownloadStatusUiData.DOWNLOADING,
                                         DownloadStatusUiData.METADATA -> {
                                             view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                                            viewModel.stopDownload(item.id)
+                                            onStopDownload(item.id)
                                         }
 
                                         else -> {
                                             view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                                            viewModel.retryDownload(item.id)
+                                            onRetryDownload(item.id)
                                         }
                                     }
                                 },
@@ -373,19 +425,18 @@ fun DownloadsScreen(
                                 },
                                 onBulkDismissAnimationFinished = { itemId ->
                                     dismissingIds = dismissingIds - itemId
-                                    viewModel.markDownloadsPendingDelete(setOf(itemId))
+                                    onMarkDownloadsPendingDelete(setOf(itemId), true)
                                 },
                                 onBulkArchiveAnimationFinished = { itemId ->
                                     archivingIds = archivingIds - itemId
-                                    viewModel.updateDownloadsArchived(
-                                        downloadIds = setOf(itemId),
-                                        archived = !isArchived,
-                                    )
+                                    onUpdateDownloadsArchived(setOf(itemId), !isArchived)
                                 },
                                 onToggleSeen = { itemId ->
-                                    viewModel.toggleDownloadsSeen(setOf(itemId))
+                                    onToggleDownloadsSeen(setOf(itemId))
                                 },
-                                onMarkPendingDelete = viewModel::markDownloadsPendingDelete,
+                                onMarkPendingDelete = { ids ->
+                                    onMarkDownloadsPendingDelete(ids, true)
+                                },
                             )
                         }
                     }
@@ -400,8 +451,6 @@ fun DownloadsScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DownloadsTopBar(
-    navController: NavController,
-    viewModel: DownloadsViewModel,
     selectionMode: Boolean,
     selectedIds: Set<Long>,
     dismissingIds: Set<Long>,
@@ -423,6 +472,15 @@ private fun DownloadsTopBar(
     onDismissingIdsChange: (Set<Long>) -> Unit,
     onArchivingIdsChange: (Set<Long>) -> Unit,
     onSearchActiveChange: (Boolean) -> Unit,
+    onSearchQueryChange: (TextFieldValue) -> Unit,
+    onNavigateBack: () -> Unit,
+    onNavigateToArchived: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onToggleDownloadsSeen: (Set<Long>) -> Unit,
+    onMarkDownloadsPendingDelete: (Set<Long>, Boolean) -> Unit,
+    onUpdateDownloadsArchived: (Set<Long>, Boolean) -> Unit,
+    onRetryFailedDownloads: () -> Unit,
+    onStopAllDownloads: () -> Unit,
 ) {
     val view = LocalView.current
     val dimens = LocalDimens.current
@@ -480,7 +538,7 @@ private fun DownloadsTopBar(
                 }
                 IconButton(
                     onClick = {
-                        viewModel.toggleDownloadsSeen(selectedIds)
+                        onToggleDownloadsSeen(selectedIds)
                     },
                 ) {
                     Icon(
@@ -505,10 +563,7 @@ private fun DownloadsTopBar(
                         val hiddenSelectedIds = selectedIds - visibleSelectedIds
                         onArchivingIdsChange(archivingIds + visibleSelectedIds)
                         if (hiddenSelectedIds.isNotEmpty()) {
-                            viewModel.updateDownloadsArchived(
-                                downloadIds = hiddenSelectedIds,
-                                archived = !isArchived,
-                            )
+                            onUpdateDownloadsArchived(hiddenSelectedIds, !isArchived)
                         }
                         onSelectionChange(emptySet())
                     },
@@ -535,7 +590,7 @@ private fun DownloadsTopBar(
                         val hiddenSelectedIds = selectedIds - visibleSelectedIds
                         onDismissingIdsChange(dismissingIds + visibleSelectedIds)
                         if (hiddenSelectedIds.isNotEmpty()) {
-                            viewModel.markDownloadsPendingDelete(hiddenSelectedIds)
+                            onMarkDownloadsPendingDelete(hiddenSelectedIds, true)
                         }
                         onSelectionChange(emptySet())
                     },
@@ -553,9 +608,7 @@ private fun DownloadsTopBar(
             navigationIcon = {
                 if (isArchived) {
                     IconButton(
-                        onClick = {
-                            navController.navigateUp()
-                        },
+                        onClick = onNavigateBack,
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -609,7 +662,7 @@ private fun DownloadsTopBar(
                     ) {
                         TextField(
                             value = searchQuery,
-                            onValueChange = viewModel::updateSearchQuery,
+                            onValueChange = onSearchQueryChange,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(end = dimens.spacingSmall)
@@ -642,7 +695,7 @@ private fun DownloadsTopBar(
                     onClick = {
                         onSearchActiveChange(!searchActive)
                         if (searchActive) {
-                            viewModel.updateSearchQuery(TextFieldValue(""))
+                            onSearchQueryChange(TextFieldValue(""))
                             keyboardController?.hide()
                         }
                     }
@@ -709,7 +762,7 @@ private fun DownloadsTopBar(
                             },
                             onClick = {
                                 view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                                viewModel.retryFailedDownloads()
+                                onRetryFailedDownloads()
                                 coroutineScope.launch {
                                     delay(RETRY_FAILED_SCROLL_DELAY_MILLIS.milliseconds)
                                     lazyListState.animateScrollToItem(0)
@@ -732,7 +785,7 @@ private fun DownloadsTopBar(
                                 )
                             },
                             onClick = {
-                                viewModel.stopAllDownloads()
+                                onStopAllDownloads()
                                 menuExpanded = false
                             },
                         )
@@ -751,7 +804,7 @@ private fun DownloadsTopBar(
                                 )
                             },
                             onClick = {
-                                navController.navigate(Screen.Archived.route)
+                                onNavigateToArchived()
                                 menuExpanded = false
                             },
                         )
@@ -769,7 +822,7 @@ private fun DownloadsTopBar(
                             )
                         },
                         onClick = {
-                            navController.navigate(Screen.Settings.route)
+                            onNavigateToSettings()
                             menuExpanded = false
                         },
                     )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/GetCookiesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/GetCookiesScreen.kt
@@ -68,7 +68,6 @@ import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 import java.net.URI
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GetCookiesScreen(
     navController: NavController,
@@ -78,7 +77,6 @@ fun GetCookiesScreen(
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
-    val refineryDimens = LocalRefineryDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     val focusRequester = remember { FocusRequester() }
@@ -152,7 +150,62 @@ fun GetCookiesScreen(
         }
     }
 
-    overwritePrompt?.let { prompt ->
+    GetCookiesScreenContent(
+        state = GetCookiesScreenState(
+            addressText = addressText,
+            requestedUrl = requestedUrl,
+            titleText = titleText,
+            saveUrl = saveUrl,
+            overwritePrompt = overwritePrompt,
+        ),
+        focusRequester = focusRequester,
+        onAddressTextChange = { addressText = it },
+        onLoadAddress = ::loadAddress,
+        onSaveCookies = { saveCookies(saveUrl) },
+        onConfirmOverwrite = { prompt ->
+            overwritePrompt = null
+            saveCookies(
+                url = prompt.url,
+                confirmOverwrite = false,
+            )
+        },
+        onDismissOverwrite = { overwritePrompt = null },
+        onClose = {
+            backDispatcher?.onBackPressed() ?: navController.popBackStack()
+        },
+        webViewContent = { webViewModifier ->
+            GetCookiesWebView(
+                modifier = webViewModifier,
+                requestedUrl = requestedUrl,
+                onWebViewCreated = { webView = it },
+                onCurrentUrlChanged = { url ->
+                    currentUrl = url
+                    addressText = url.toTextFieldValue()
+                },
+                onTitleChanged = { title -> pageTitle = title },
+            )
+        },
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun GetCookiesScreenContent(
+    state: GetCookiesScreenState,
+    focusRequester: FocusRequester,
+    onAddressTextChange: (TextFieldValue) -> Unit,
+    onLoadAddress: () -> Unit,
+    onSaveCookies: () -> Unit,
+    onConfirmOverwrite: (CookieOverwritePrompt) -> Unit,
+    onDismissOverwrite: () -> Unit,
+    onClose: () -> Unit,
+    webViewContent: @Composable (Modifier) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+
+    state.overwritePrompt?.let { prompt ->
         ConfirmDialog(
             title = stringResource(R.string.confirm_dialog_replace_cookie_set_title),
             message = stringResource(
@@ -161,19 +214,9 @@ fun GetCookiesScreen(
             ),
             positiveButtonText = stringResource(R.string.cookies_action_replace),
             negativeButtonText = stringResource(R.string.cancel),
-            onPositiveClick = {
-                overwritePrompt = null
-                saveCookies(
-                    url = prompt.url,
-                    confirmOverwrite = false,
-                )
-            },
-            onNegativeClick = {
-                overwritePrompt = null
-            },
-            onDismissRequest = {
-                overwritePrompt = null
-            },
+            onPositiveClick = { onConfirmOverwrite(prompt) },
+            onNegativeClick = onDismissOverwrite,
+            onDismissRequest = onDismissOverwrite,
         )
     }
 
@@ -183,9 +226,7 @@ fun GetCookiesScreen(
                 colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
-                        onClick = {
-                            backDispatcher?.onBackPressed() ?: navController.popBackStack()
-                        },
+                        onClick = onClose,
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Close,
@@ -194,12 +235,12 @@ fun GetCookiesScreen(
                     }
                 },
                 title = {
-                    Text(text = titleText)
+                    Text(text = state.titleText)
                 },
                 actions = {
                     IconButton(
-                        enabled = !saveUrl.isNullOrBlank(),
-                        onClick = { saveCookies(saveUrl) },
+                        enabled = !state.saveUrl.isNullOrBlank(),
+                        onClick = onSaveCookies,
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Save,
@@ -220,7 +261,7 @@ fun GetCookiesScreen(
                     modifier = Modifier
                         .fillMaxSize(),
                 ) {
-                    if (requestedUrl == null) {
+                    if (state.requestedUrl == null) {
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -233,20 +274,12 @@ fun GetCookiesScreen(
                             )
                         }
                     } else {
-                        GetCookiesWebView(
-                            modifier = Modifier
-                                .requiredSize(maxWidth, maxHeight),
-                            requestedUrl = requestedUrl,
-                            onWebViewCreated = { webView = it },
-                            onCurrentUrlChanged = { url ->
-                                currentUrl = url
-                                addressText = url.toTextFieldValue()
-                            },
-                            onTitleChanged = { title -> pageTitle = title },
+                        webViewContent(
+                            Modifier.requiredSize(maxWidth, maxHeight),
                         )
                     }
                     AnimatedVisibility(
-                        visible = requestedUrl == null,
+                        visible = state.requestedUrl == null,
                         modifier = Modifier
                             .align(Alignment.TopCenter)
                             .fillMaxWidth(),
@@ -267,14 +300,14 @@ fun GetCookiesScreen(
                                     .fillMaxWidth()
                                     .padding(top = refineryDimens.spacingSmall)
                                     .focusRequester(focusRequester),
-                                value = addressText,
-                                onValueChange = { addressText = it },
+                                value = state.addressText,
+                                onValueChange = onAddressTextChange,
                                 label = {
                                     Text(text = stringResource(R.string.cookies_label_login_url))
                                 },
                                 singleLine = true,
                                 trailingIcon = {
-                                    IconButton(onClick = ::loadAddress) {
+                                    IconButton(onClick = onLoadAddress) {
                                         Icon(
                                             imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                                             contentDescription = stringResource(R.string.cookies_action_go),
@@ -286,7 +319,7 @@ fun GetCookiesScreen(
                                     capitalization = KeyboardCapitalization.None,
                                     imeAction = ImeAction.Go,
                                 ),
-                                keyboardActions = KeyboardActions(onGo = { loadAddress() }),
+                                keyboardActions = KeyboardActions(onGo = { onLoadAddress() }),
                             )
                         }
                     }
@@ -315,11 +348,6 @@ private fun CookieLoginWarning(
         )
     }
 }
-
-private data class CookieOverwritePrompt(
-    val url: String,
-    val domain: String,
-)
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -439,3 +467,16 @@ private fun String.toTextFieldValue(): TextFieldValue {
 }
 
 private const val DEFAULT_URL_PREFIX = "https://"
+
+internal data class GetCookiesScreenState(
+    val addressText: TextFieldValue,
+    val requestedUrl: String?,
+    val titleText: String,
+    val saveUrl: String?,
+    val overwritePrompt: CookieOverwritePrompt?,
+)
+
+internal data class CookieOverwritePrompt(
+    val url: String,
+    val domain: String,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -46,17 +46,50 @@ import org.strigate.refinery.component.settings.TextNavigateSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     navController: NavController,
     modifier: Modifier = Modifier,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
-    val refineryDimens = LocalRefineryDimens.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
 
+    LaunchedEffect(Unit) {
+        viewModel.logShown()
+    }
+
+    SettingsScreenContent(
+        uiState = uiState,
+        onBackClick = { backDispatcher?.onBackPressed() },
+        onSetWifiOnlyDownloadsEnabled = viewModel::setWifiOnlyDownloadsEnabled,
+        onSetAutomaticDuplicateDownloadDeletionEnabled = viewModel::setAutomaticDuplicateDownloadDeletionEnabled,
+        onSetCookiesEnabled = viewModel::setCookiesEnabled,
+        onSetLeftSwipeAction = viewModel::setLeftSwipeAction,
+        onSetRightSwipeAction = viewModel::setRightSwipeAction,
+        onNavigateToCookies = { navController.navigate(Screen.Cookies.route) },
+        onNavigateToUpdates = { navController.navigate(Screen.Updates.route) },
+        onNavigateToAbout = { navController.navigate(Screen.About.route) },
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingsScreenContent(
+    uiState: SettingsUiState,
+    onBackClick: () -> Unit,
+    onSetWifiOnlyDownloadsEnabled: (Boolean) -> Unit,
+    onSetAutomaticDuplicateDownloadDeletionEnabled: (Boolean) -> Unit,
+    onSetCookiesEnabled: (Boolean) -> Unit,
+    onSetLeftSwipeAction: (DownloadSwipeActionUiData) -> Unit,
+    onSetRightSwipeAction: (DownloadSwipeActionUiData) -> Unit,
+    onNavigateToCookies: () -> Unit,
+    onNavigateToUpdates: () -> Unit,
+    onNavigateToAbout: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val refineryDimens = LocalRefineryDimens.current
     val noneSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_none)
     val archiveSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_archive)
     val seenSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_seen)
@@ -70,19 +103,13 @@ fun SettingsScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.logShown()
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
                 colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
-                        onClick = {
-                            backDispatcher?.onBackPressed()
-                        },
+                        onClick = onBackClick,
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -128,20 +155,14 @@ fun SettingsScreen(
                                         text = stringResource(id = R.string.settings_title_download_wifi_only),
                                         description = stringResource(id = R.string.settings_description_download_wifi_only),
                                         checked = wifiOnlyDownloadsEnabled,
-                                        onCheckedChange = { checked ->
-                                            viewModel.setWifiOnlyDownloadsEnabled(checked)
-                                        },
+                                        onCheckedChange = onSetWifiOnlyDownloadsEnabled,
                                     )
                                     Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                     SwitchSetting(
                                         text = stringResource(id = R.string.settings_title_automatic_duplicate_deletion),
                                         description = stringResource(id = R.string.settings_description_automatic_duplicate_deletion),
                                         checked = automaticDuplicateDownloadDeletionEnabled,
-                                        onCheckedChange = { checked ->
-                                            viewModel.setAutomaticDuplicateDownloadDeletionEnabled(
-                                                checked,
-                                            )
-                                        },
+                                        onCheckedChange = onSetAutomaticDuplicateDownloadDeletionEnabled,
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
@@ -154,15 +175,13 @@ fun SettingsScreen(
                                         text = stringResource(id = R.string.settings_title_use_cookies),
                                         description = stringResource(id = R.string.settings_description_use_cookies),
                                         checked = cookiesEnabled,
-                                        onCheckedChange = { checked ->
-                                            viewModel.setCookiesEnabled(checked)
-                                        },
+                                        onCheckedChange = onSetCookiesEnabled,
                                     )
                                     TextNavigateSetting(
                                         text = stringResource(R.string.settings_navigate_title_manage_cookies),
                                         description = stringResource(R.string.settings_description_manage_cookies),
                                     ) {
-                                        navController.navigate(Screen.Cookies.route)
+                                        onNavigateToCookies()
                                     }
                                 }
                                 Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
@@ -177,7 +196,7 @@ fun SettingsScreen(
                                         selectedOption = leftSwipeAction,
                                         options = DownloadSwipeActionUiData.entries,
                                         optionText = { option -> swipeActionLabel(option) },
-                                        onOptionSelected = viewModel::setLeftSwipeAction,
+                                        onOptionSelected = onSetLeftSwipeAction,
                                     )
                                     DropdownSetting(
                                         text = stringResource(R.string.settings_title_swipe_right),
@@ -185,7 +204,7 @@ fun SettingsScreen(
                                         selectedOption = rightSwipeAction,
                                         options = DownloadSwipeActionUiData.entries,
                                         optionText = { option -> swipeActionLabel(option) },
-                                        onOptionSelected = viewModel::setRightSwipeAction,
+                                        onOptionSelected = onSetRightSwipeAction,
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
@@ -193,14 +212,14 @@ fun SettingsScreen(
                                     icon = Icons.Outlined.SystemUpdate,
                                     text = stringResource(R.string.settings_navigate_title_updates),
                                 ) {
-                                    navController.navigate(Screen.Updates.route)
+                                    onNavigateToUpdates()
                                 }
                                 Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
                                 TextNavigateSetting(
                                     icon = Icons.Outlined.Info,
                                     text = stringResource(R.string.settings_navigate_title_about),
                                 ) {
-                                    navController.navigate(Screen.About.route)
+                                    onNavigateToAbout()
                                 }
                                 Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
                             }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -43,13 +43,11 @@ import org.strigate.refinery.component.settings.TextSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
 import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UpdatesScreen(
     modifier: Modifier = Modifier,
     viewModel: UpdatesViewModel = hiltViewModel(),
 ) {
-    val refineryDimens = LocalRefineryDimens.current
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
     val uiState by viewModel.uiState.collectAsState()
@@ -67,13 +65,38 @@ fun UpdatesScreen(
         }
     }
 
+    UpdatesScreenContent(
+        uiState = uiState,
+        onBackClick = { backDispatcher?.onBackPressed() },
+        onSetAutomaticAppUpdatesEnabled = viewModel::setAutomaticAppUpdatesEnabled,
+        onCheckForAvailableUpdate = viewModel::checkForAvailableUpdate,
+        onSetAutomaticDependencyUpdatesEnabled = viewModel::setAutomaticDependencyUpdatesEnabled,
+        onCheckForDependencyUpdates = viewModel::checkForDependencyUpdates,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun UpdatesScreenContent(
+    uiState: UpdatesUiState,
+    onBackClick: () -> Unit,
+    onSetAutomaticAppUpdatesEnabled: (Boolean) -> Unit,
+    onCheckForAvailableUpdate: () -> Unit,
+    onSetAutomaticDependencyUpdatesEnabled: (Boolean) -> Unit,
+    onCheckForDependencyUpdates: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+    val context = LocalContext.current
+
     Scaffold(
         topBar = {
             TopAppBar(
                 colors = RefineryTopAppBarDefaults.colors(),
                 navigationIcon = {
                     IconButton(
-                        onClick = { backDispatcher?.onBackPressed() },
+                        onClick = onBackClick,
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -118,15 +141,13 @@ fun UpdatesScreen(
                                         text = stringResource(R.string.settings_title_automatic_updates),
                                         description = stringResource(R.string.settings_description_automatic_updates),
                                         checked = settings.automaticAppUpdatesEnabled,
-                                        onCheckedChange = { checked ->
-                                            viewModel.setAutomaticAppUpdatesEnabled(checked)
-                                        },
+                                        onCheckedChange = onSetAutomaticAppUpdatesEnabled,
                                     )
                                     TextSetting(
                                         text = stringResource(R.string.settings_title_check_now),
                                         description = stringResource(R.string.settings_description_check_for_app_updates),
                                     ) {
-                                        viewModel.checkForAvailableUpdate()
+                                        onCheckForAvailableUpdate()
                                     }
                                     TextSetting(
                                         text = stringResource(R.string.settings_title_last_checked),
@@ -145,15 +166,13 @@ fun UpdatesScreen(
                                         text = stringResource(R.string.settings_title_automatic_updates),
                                         description = stringResource(R.string.settings_description_automatic_dependency_updates),
                                         checked = settings.automaticDependencyUpdatesEnabled,
-                                        onCheckedChange = { checked ->
-                                            viewModel.setAutomaticDependencyUpdatesEnabled(checked)
-                                        },
+                                        onCheckedChange = onSetAutomaticDependencyUpdatesEnabled,
                                     )
                                     TextSetting(
                                         text = stringResource(R.string.settings_title_check_now),
                                         description = stringResource(R.string.settings_description_check_dependencies_now),
                                     ) {
-                                        viewModel.checkForDependencyUpdates()
+                                        onCheckForDependencyUpdates()
                                     }
                                     TextSetting(
                                         text = stringResource(R.string.settings_title_last_checked),


### PR DESCRIPTION
- Extract content composables from screen entry points
- Hoist navigation, `ViewModel` and platform callbacks
- Group content state for `DownloadScreenContent` and `GetCookiesScreenContent`