### PR TITLE
fix: Show progress while deleting downloads

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/work/DeletePendingDownloadsDelayedWorker.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/work/DeletePendingDownloadsDelayedWorker.kt
@@ -60,6 +60,7 @@ class DeletePendingDownloadsDelayedWorker(
                     R.plurals.notification_text_deleting_downloads,
                     pendingDeleteIds.size,
                 ),
+            indeterminate = true,
         )
         Log.d(LOG_TAG, "$tag Starting delete for ${pendingDeleteIds.size} pending download(s)")
 


### PR DESCRIPTION
- Display indeterminate progress in `DeletePendingDownloadsDelayedWorker` notification