### PR TITLE
refactor: Extract download screen components

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
@@ -13,10 +13,10 @@ import androidx.navigation.navArgument
 import org.strigate.ferrot.presentation.screen.AboutScreen
 import org.strigate.ferrot.presentation.screen.ArchivedScreen
 import org.strigate.ferrot.presentation.screen.CookiesScreen
-import org.strigate.ferrot.presentation.screen.DownloadScreen
 import org.strigate.ferrot.presentation.screen.GetCookiesScreen
 import org.strigate.ferrot.presentation.screen.SettingsScreen
 import org.strigate.ferrot.presentation.screen.UpdatesScreen
+import org.strigate.ferrot.presentation.screen.download.DownloadScreen
 import org.strigate.ferrot.presentation.screen.downloads.DownloadsScreen
 
 @Composable

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPageContent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPageContent.kt
@@ -1,8 +1,5 @@
-package org.strigate.ferrot.presentation.screen
+package org.strigate.ferrot.presentation.screen.download
 
-import android.view.HapticFeedbackConstants
-import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -10,7 +7,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,492 +14,57 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.ImageNotSupported
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Unarchive
-import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.map
 import org.strigate.ferrot.R
 import org.strigate.ferrot.domain.model.DownloadMediaType
-import org.strigate.ferrot.extensions.copyToClipboard
-import org.strigate.ferrot.helper.PlayHelper
-import org.strigate.ferrot.helper.SaveHelper
-import org.strigate.ferrot.helper.ShareHelper
-import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.component.ActionIconButton
-import org.strigate.ferrot.presentation.component.ConfirmDialog
 import org.strigate.ferrot.presentation.component.DownloadProgressSection
-import org.strigate.ferrot.presentation.component.state.ErrorState
-import org.strigate.ferrot.presentation.component.state.LoadingState
-import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.model.DownloadStatusUiData
-import org.strigate.ferrot.presentation.model.DownloadUiData
-import org.strigate.ferrot.presentation.state.DownloadUiState
 import org.strigate.ferrot.presentation.theme.LocalDimens
 import org.strigate.ferrot.presentation.util.UiFormatter
-import org.strigate.ferrot.presentation.viewmodel.DownloadViewModel
 import org.strigate.refinery.theme.LocalRefineryDimens
-import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 import java.io.File
 
 @Composable
-fun DownloadScreen(
-    navController: NavController,
-    modifier: Modifier = Modifier,
-    viewModel: DownloadViewModel = hiltViewModel(),
-) {
-    val view = LocalView.current
-    val context = LocalContext.current
-    val uriHandler = LocalUriHandler.current
-
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val selectedId by viewModel.selectedId.collectAsStateWithLifecycle()
-    val selectedMedia by viewModel.selectedMedia.collectAsStateWithLifecycle(
-        initialValue = DownloadMediaType.VIDEO,
-    )
-    val selectedPageData by viewModel.selectedPageData.collectAsStateWithLifecycle()
-
-    val showConfirmDeleteDialog = remember { mutableStateOf(false) }
-    val onNavigateBack = {
-        navigateBackToParent(
-            navController = navController,
-            archived = selectedPageData?.archived == true,
-        )
-    }
-
-    BackHandler(enabled = !showConfirmDeleteDialog.value) {
-        onNavigateBack()
-    }
-
-    LaunchedEffect(Unit) {
-        viewModel.logShown()
-    }
-    LaunchedEffect(Unit) {
-        viewModel.events.collect { event ->
-            when (event) {
-                DownloadEvent.NavigateBack -> {
-                    onNavigateBack()
-                }
-
-                is DownloadEvent.Play -> {
-                    PlayHelper.playFileIfExists(context, event.path)
-                }
-
-                is DownloadEvent.Share -> {
-                    ShareHelper.shareFileIfExists(context, event.path)
-                }
-
-                is DownloadEvent.Save -> {
-                    SaveHelper.saveToDownloads(context, event.path)
-                }
-            }
-        }
-    }
-
-    DownloadScreenContent(
-        state = DownloadScreenContentState(
-            uiState = uiState,
-            selectedId = selectedId,
-            selectedMedia = selectedMedia,
-            selectedPageData = selectedPageData,
-            showConfirmDeleteDialog = showConfirmDeleteDialog.value,
-        ),
-        pageDataForId = { downloadId ->
-            val pageData by remember(downloadId) {
-                viewModel.getDownloadPageUiData(downloadId)
-            }.collectAsStateWithLifecycle(initialValue = null)
-            pageData
-        },
-        onBackClick = onNavigateBack,
-        onMarkUnseen = viewModel::markUnseenAndNavigateBack,
-        onUpdateArchived = viewModel::updateArchived,
-        onShowDeleteConfirmation = { showConfirmDeleteDialog.value = true },
-        onDeleteConfirmed = {
-            viewModel.deleteDownload()
-            showConfirmDeleteDialog.value = false
-        },
-        onDeleteDismissed = { showConfirmDeleteDialog.value = false },
-        onEnsureDefaults = viewModel::setDefaultsForIds,
-        onDownloadPageSelected = viewModel::selectDownload,
-        onVisibleCompletedUnseenDownload = viewModel::markSeenIfCompleted,
-        onSelectedMedia = { downloadId, mediaType ->
-            viewModel.setSelectedMedia(mediaType, downloadId)
-        },
-        onPlayClick = viewModel::playDownload,
-        onSaveClick = viewModel::saveDownload,
-        onShareClick = viewModel::shareDownload,
-        onRetryClick = { downloadId ->
-            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-            viewModel.retryDownload(downloadId)
-        },
-        onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
-        onUrlClick = uriHandler::openUri,
-        onCopyText = context::copyToClipboard,
-        modifier = modifier,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun DownloadScreenContent(
-    state: DownloadScreenContentState,
-    pageDataForId: @Composable (Long) -> DownloadPageUiData?,
-    onBackClick: () -> Unit,
-    onMarkUnseen: () -> Unit,
-    onUpdateArchived: (Boolean) -> Unit,
-    onShowDeleteConfirmation: () -> Unit,
-    onDeleteConfirmed: () -> Unit,
-    onDeleteDismissed: () -> Unit,
-    onEnsureDefaults: (List<Long>) -> Unit,
-    onDownloadPageSelected: (Long) -> Unit,
-    onVisibleCompletedUnseenDownload: (Long) -> Unit,
-    onSelectedMedia: (Long, DownloadMediaType) -> Unit,
-    onPlayClick: (Long) -> Unit,
-    onSaveClick: (Long) -> Unit,
-    onShareClick: (Long) -> Unit,
-    onRetryClick: (Long) -> Unit,
-    onRefreshMetadataClick: (Long) -> Unit,
-    onUrlClick: (String) -> Unit,
-    onCopyText: (String, String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    if (state.showConfirmDeleteDialog) {
-        ConfirmDialog(
-            title = stringResource(R.string.confirm_dialog_delete_download_title),
-            message = stringResource(R.string.confirm_dialog_delete_download_description),
-            positiveButtonText = stringResource(R.string.yes),
-            isDestructive = true,
-            onPositiveClick = onDeleteConfirmed,
-            negativeButtonText = stringResource(R.string.no),
-            onNegativeClick = onDeleteDismissed,
-            onDismissRequest = onDeleteDismissed,
-        )
-    }
-
-    Scaffold(
-        containerColor = MaterialTheme.colorScheme.background,
-        topBar = {
-            TopAppBar(
-                colors = RefineryTopAppBarDefaults.colors(),
-                navigationIcon = {
-                    IconButton(
-                        onClick = {
-                            onBackClick()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_description_back),
-                        )
-                    }
-                },
-                title = {
-                    Text(
-                        text = if (state.selectedPageData?.archived == true) {
-                            stringResource(R.string.screen_title_archived_download)
-                        } else {
-                            stringResource(R.string.screen_title_download)
-                        },
-                    )
-                },
-                actions = {
-                    IconButton(
-                        onClick = {
-                            onMarkUnseen()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.VisibilityOff,
-                            contentDescription = stringResource(R.string.content_description_mark_unseen),
-                        )
-                    }
-                    IconButton(
-                        onClick = {
-                            val archived = state.selectedPageData?.archived ?: false
-                            onUpdateArchived(!archived)
-                        },
-                    ) {
-                        Icon(
-                            imageVector = if (state.selectedPageData?.archived == true) {
-                                Icons.Filled.Unarchive
-                            } else {
-                                Icons.Filled.Archive
-                            },
-                            contentDescription = if (state.selectedPageData?.archived == true) {
-                                stringResource(R.string.content_description_unarchive)
-                            } else {
-                                stringResource(R.string.content_description_archive)
-                            },
-                        )
-                    }
-                    IconButton(
-                        onClick = {
-                            onShowDeleteConfirmation()
-                        },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Delete,
-                            contentDescription = stringResource(R.string.content_description_delete_download),
-                        )
-                    }
-                },
-            )
-        },
-        content = { contentPadding ->
-            val dimens = LocalDimens.current
-            when (val uiState = state.uiState) {
-                is DownloadUiState.Loading -> {
-                    LoadingState(
-                        modifier = modifier
-                            .padding(contentPadding)
-                            .fillMaxSize(),
-                        alignment = Alignment.Center,
-                    )
-                }
-
-                is DownloadUiState.Data -> {
-                    val peekPadding = dimens.spacingMediumAlt
-                    val pageSpacing = dimens.spacingSmall
-                    DownloadPager(
-                        modifier = modifier
-                            .padding(contentPadding)
-                            .fillMaxSize(),
-                        data = uiState.data,
-                        pageDataForId = pageDataForId,
-                        selectedId = state.selectedId,
-                        selectedMedia = state.selectedMedia,
-                        onEnsureDefaults = onEnsureDefaults,
-                        onDownloadPageSelected = onDownloadPageSelected,
-                        onVisibleCompletedUnseenDownload = onVisibleCompletedUnseenDownload,
-                        onSelectedMedia = onSelectedMedia,
-                        onPlayClick = onPlayClick,
-                        onSaveClick = onSaveClick,
-                        onShareClick = onShareClick,
-                        onRetryClick = onRetryClick,
-                        onRefreshMetadataClick = onRefreshMetadataClick,
-                        onUrlClick = onUrlClick,
-                        onCopyText = onCopyText,
-                        pagePadding = PaddingValues(
-                            horizontal = peekPadding,
-                            vertical = dimens.zero,
-                        ),
-                        pageSpacing = pageSpacing,
-                    )
-                }
-
-                is DownloadUiState.Error -> DownloadError()
-            }
-        },
-    )
-}
-
-private fun navigateBackToParent(
-    navController: NavController,
-    archived: Boolean,
-) {
-    val parentRoute = if (archived) {
-        Screen.Archived.route
-    } else {
-        Screen.Downloads.route
-    }
-    val previousRoute = navController.previousBackStackEntry?.destination?.route
-    if (previousRoute == parentRoute) {
-        navController.popBackStack()
-        return
-    }
-    if (navController.popBackStack(parentRoute, false)) {
-        return
-    }
-    navController.navigate(parentRoute) {
-        popUpTo(Screen.Downloads.route) {
-            inclusive = false
-            saveState = false
-        }
-        launchSingleTop = true
-        restoreState = false
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun DownloadPager(
-    modifier: Modifier = Modifier,
-    data: DownloadUiData,
-    pageDataForId: @Composable (Long) -> DownloadPageUiData?,
-    selectedId: Long?,
-    selectedMedia: DownloadMediaType,
-    onEnsureDefaults: (List<Long>) -> Unit,
-    onDownloadPageSelected: (Long) -> Unit,
-    onVisibleCompletedUnseenDownload: (Long) -> Unit,
-    onSelectedMedia: (Long, DownloadMediaType) -> Unit,
-    onPlayClick: (Long) -> Unit,
-    onSaveClick: (Long) -> Unit,
-    onShareClick: (Long) -> Unit,
-    onRetryClick: (Long) -> Unit,
-    onRefreshMetadataClick: (Long) -> Unit,
-    onUrlClick: (String) -> Unit,
-    onCopyText: (String, String) -> Unit,
-    pagePadding: PaddingValues,
-    pageSpacing: Dp,
-) {
-    val dimens = LocalDimens.current
-    val downloadIds = data.downloadIds
-    if (downloadIds.isEmpty()) {
-        DownloadError()
-    } else {
-        val initialIndex = downloadIds
-            .indexOfFirst { it == data.id }
-            .coerceAtLeast(0)
-
-        val pagerState = rememberPagerState(
-            initialPage = initialIndex,
-            pageCount = { downloadIds.size },
-        )
-        val resolvedPage = remember(downloadIds, selectedId) {
-            downloadIds.indexOfFirst { it == selectedId }
-        }
-
-        LaunchedEffect(downloadIds) {
-            onEnsureDefaults(downloadIds)
-        }
-        LaunchedEffect(resolvedPage) {
-            if (resolvedPage >= 0 && pagerState.currentPage != resolvedPage) {
-                pagerState.scrollToPage(resolvedPage)
-            }
-        }
-        LaunchedEffect(pagerState, downloadIds) {
-            snapshotFlow { pagerState.currentPage }
-                .map { pageIndex ->
-                    downloadIds.getOrNull(pageIndex)
-                }
-                .filterNotNull()
-                .distinctUntilChanged()
-                .collect { downloadId ->
-                    onDownloadPageSelected(downloadId)
-                }
-        }
-
-        HorizontalPager(
-            modifier = modifier
-                .fillMaxSize(),
-            state = pagerState,
-            contentPadding = pagePadding,
-            pageSpacing = pageSpacing,
-            beyondViewportPageCount = 0,
-            key = { page -> downloadIds[page] },
-        ) { page ->
-            val downloadId = downloadIds[page]
-            val isCurrentPage = pagerState.currentPage == page
-            val pageData = pageDataForId(downloadId)
-
-            Surface(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = dimens.spacingSmall),
-                shape = MaterialTheme.shapes.medium,
-                color = MaterialTheme.colorScheme.surface,
-                tonalElevation = dimens.tonalElevationLow,
-                shadowElevation = dimens.shadowElevationLow,
-            ) {
-                pageData?.let { download ->
-                    DownloadPageContent(
-                        data = download,
-                        isCurrentPage = isCurrentPage,
-                        selectedMedia = selectedMedia,
-                        onCompletedUnseenVisible = onVisibleCompletedUnseenDownload,
-                        onMediaChange = { mediaType ->
-                            onSelectedMedia(download.id, mediaType)
-                        },
-                        onEnsureValidSelection = { mediaType ->
-                            onSelectedMedia(download.id, mediaType)
-                        },
-                        onPlayClick = {
-                            onPlayClick(download.id)
-                        },
-                        onSaveClick = {
-                            onSaveClick(download.id)
-                        },
-                        onShareClick = {
-                            onShareClick(download.id)
-                        },
-                        onRetryClick = {
-                            onRetryClick(download.id)
-                        },
-                        onRefreshMetadataClick = {
-                            onRefreshMetadataClick(download.id)
-                        },
-                        onUrlClick = onUrlClick,
-                        onCopyText = onCopyText,
-                    )
-                } ?: LoadingState(
-                    modifier = Modifier
-                        .fillMaxSize(),
-                    alignment = Alignment.Center,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun DownloadPageContent(
+internal fun DownloadPageContent(
     data: DownloadPageUiData,
     isCurrentPage: Boolean,
     selectedMedia: DownloadMediaType,
@@ -520,6 +81,7 @@ private fun DownloadPageContent(
 ) {
     val refineryDimens = LocalRefineryDimens.current
     val dimens = LocalDimens.current
+
     with(data) {
         LaunchedEffect(id, status, seen, isCurrentPage) {
             if (isCurrentPage && status == DownloadStatusUiData.COMPLETED && !seen) {
@@ -563,8 +125,7 @@ private fun DownloadPageContent(
             )
             Spacer(modifier = Modifier.height(dimens.spacingXSmall))
             MediaSwitcherSegmentedButtonRow(
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 selected = selectedMedia,
                 enableVideo = video?.filePath?.isNotBlank() == true,
                 enableAudio = audio?.filePath?.isNotBlank() == true,
@@ -605,8 +166,7 @@ private fun DownloadPageContent(
             )
             Spacer(modifier = Modifier.height(dimens.spacingSmall))
             Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(dimens.spacingSmall),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -661,13 +221,12 @@ private fun DownloadPageContent(
                     DownloadMediaType.VIDEO -> video?.fileName
                     DownloadMediaType.AUDIO -> audio?.fileName
                 }
-                selectedName
-                    ?.let {
-                        MetaItem(
-                            label = stringResource(R.string.download_filename),
-                            value = it,
-                        )
-                    }
+                selectedName?.let {
+                    MetaItem(
+                        label = stringResource(R.string.download_filename),
+                        value = it,
+                    )
+                }
 
                 metadata?.durationSeconds
                     ?.let(UiFormatter::formatDuration)
@@ -690,13 +249,12 @@ private fun DownloadPageContent(
                         )
                     }
 
-                errorMessage
-                    ?.let {
-                        MetaItem(
-                            label = stringResource(R.string.download_error_message),
-                            value = it,
-                        )
-                    }
+                errorMessage?.let {
+                    MetaItem(
+                        label = stringResource(R.string.download_error_message),
+                        value = it,
+                    )
+                }
             }
         }
     }
@@ -810,21 +368,18 @@ private fun ThumbnailCard(
                     .build()
 
                 AsyncImage(
-                    modifier = Modifier
-                        .fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                     contentDescription = thumbnailContentDescription,
                     model = request,
                 )
             } else if (!showRetry) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
-                        modifier = Modifier
-                            .size(dimens.overlayIcon),
+                        modifier = Modifier.size(dimens.overlayIcon),
                         imageVector = if (isCompleted) {
                             Icons.Filled.ImageNotSupported
                         } else {
@@ -896,11 +451,10 @@ private fun FileExtensionPill(
         tonalElevation = dimens.tonalElevationHigh,
     ) {
         Text(
-            modifier = Modifier
-                .padding(
-                    horizontal = dimens.spacingSmall,
-                    vertical = dimens.spacingXXSmall,
-                ),
+            modifier = Modifier.padding(
+                horizontal = dimens.spacingSmall,
+                vertical = dimens.spacingXXSmall,
+            ),
             color = MaterialTheme.colorScheme.onSecondaryContainer,
             style = MaterialTheme.typography.titleMedium,
             text = text,
@@ -920,8 +474,7 @@ private fun MetaItem(
 ) {
     val dimens = LocalDimens.current
     Row(
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
@@ -938,13 +491,12 @@ private fun MetaItem(
             Spacer(modifier = Modifier.height(dimens.spacingXXSmall))
             if (isUrl) {
                 Text(
-                    modifier = Modifier
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = LocalIndication.current,
-                        ) {
-                            onUrlClick(value)
-                        },
+                    modifier = Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = LocalIndication.current,
+                    ) {
+                        onUrlClick(value)
+                    },
                     style = MaterialTheme.typography.bodySmall.copy(
                         textDecoration = TextDecoration.Underline,
                     ),
@@ -973,23 +525,3 @@ private fun MetaItem(
         }
     }
 }
-
-@Composable
-private fun DownloadError(
-    modifier: Modifier = Modifier,
-) {
-    ErrorState(
-        modifier = modifier
-            .fillMaxSize(),
-        alignment = Alignment.Center,
-        text = stringResource(R.string.error_failed_to_load_download),
-    )
-}
-
-internal data class DownloadScreenContentState(
-    val uiState: DownloadUiState,
-    val selectedId: Long?,
-    val selectedMedia: DownloadMediaType,
-    val selectedPageData: DownloadPageUiData?,
-    val showConfirmDeleteDialog: Boolean,
-)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPager.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPager.kt
@@ -1,0 +1,141 @@
+package org.strigate.ferrot.presentation.screen.download
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
+import org.strigate.ferrot.domain.model.DownloadMediaType
+import org.strigate.ferrot.presentation.component.state.LoadingState
+import org.strigate.ferrot.presentation.model.DownloadPageUiData
+import org.strigate.ferrot.presentation.model.DownloadUiData
+import org.strigate.ferrot.presentation.theme.LocalDimens
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun DownloadPager(
+    modifier: Modifier = Modifier,
+    data: DownloadUiData,
+    pageDataForId: @Composable (Long) -> DownloadPageUiData?,
+    selectedId: Long?,
+    selectedMedia: DownloadMediaType,
+    onEnsureDefaults: (List<Long>) -> Unit,
+    onDownloadPageSelected: (Long) -> Unit,
+    onVisibleCompletedUnseenDownload: (Long) -> Unit,
+    onSelectedMedia: (Long, DownloadMediaType) -> Unit,
+    onPlayClick: (Long) -> Unit,
+    onSaveClick: (Long) -> Unit,
+    onShareClick: (Long) -> Unit,
+    onRetryClick: (Long) -> Unit,
+    onRefreshMetadataClick: (Long) -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String, String) -> Unit,
+    pagePadding: PaddingValues,
+    pageSpacing: Dp,
+) {
+    val dimens = LocalDimens.current
+
+    val downloadIds = data.downloadIds
+    if (downloadIds.isEmpty()) {
+        DownloadError()
+    } else {
+        val initialIndex = downloadIds
+            .indexOfFirst { it == data.id }
+            .coerceAtLeast(0)
+
+        val pagerState = rememberPagerState(
+            initialPage = initialIndex,
+            pageCount = { downloadIds.size },
+        )
+        val resolvedPage = remember(downloadIds, selectedId) {
+            downloadIds.indexOfFirst { it == selectedId }
+        }
+
+        LaunchedEffect(downloadIds) {
+            onEnsureDefaults(downloadIds)
+        }
+        LaunchedEffect(resolvedPage) {
+            if (resolvedPage >= 0 && pagerState.currentPage != resolvedPage) {
+                pagerState.scrollToPage(resolvedPage)
+            }
+        }
+        LaunchedEffect(pagerState, downloadIds) {
+            snapshotFlow { pagerState.currentPage }
+                .mapNotNull { pageIndex -> downloadIds.getOrNull(pageIndex) }
+                .distinctUntilChanged()
+                .collect { downloadId ->
+                    onDownloadPageSelected(downloadId)
+                }
+        }
+
+        HorizontalPager(
+            modifier = modifier.fillMaxSize(),
+            state = pagerState,
+            contentPadding = pagePadding,
+            pageSpacing = pageSpacing,
+            beyondViewportPageCount = 0,
+            key = { page -> downloadIds[page] },
+        ) { page ->
+            val downloadId = downloadIds[page]
+            val isCurrentPage = pagerState.currentPage == page
+            val pageData = pageDataForId(downloadId)
+
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = dimens.spacingSmall),
+                shape = MaterialTheme.shapes.medium,
+                color = MaterialTheme.colorScheme.surface,
+                tonalElevation = dimens.tonalElevationLow,
+                shadowElevation = dimens.shadowElevationLow,
+            ) {
+                pageData?.let { download ->
+                    DownloadPageContent(
+                        data = download,
+                        isCurrentPage = isCurrentPage,
+                        selectedMedia = selectedMedia,
+                        onCompletedUnseenVisible = onVisibleCompletedUnseenDownload,
+                        onMediaChange = { mediaType ->
+                            onSelectedMedia(download.id, mediaType)
+                        },
+                        onEnsureValidSelection = { mediaType ->
+                            onSelectedMedia(download.id, mediaType)
+                        },
+                        onPlayClick = {
+                            onPlayClick(download.id)
+                        },
+                        onSaveClick = {
+                            onSaveClick(download.id)
+                        },
+                        onShareClick = {
+                            onShareClick(download.id)
+                        },
+                        onRetryClick = {
+                            onRetryClick(download.id)
+                        },
+                        onRefreshMetadataClick = {
+                            onRefreshMetadataClick(download.id)
+                        },
+                        onUrlClick = onUrlClick,
+                        onCopyText = onCopyText,
+                    )
+                } ?: LoadingState(
+                    modifier = Modifier.fillMaxSize(),
+                    alignment = Alignment.Center,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadScreen.kt
@@ -1,0 +1,347 @@
+package org.strigate.ferrot.presentation.screen.download
+
+import android.view.HapticFeedbackConstants
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Unarchive
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import org.strigate.ferrot.R
+import org.strigate.ferrot.domain.model.DownloadMediaType
+import org.strigate.ferrot.extensions.copyToClipboard
+import org.strigate.ferrot.helper.PlayHelper
+import org.strigate.ferrot.helper.SaveHelper
+import org.strigate.ferrot.helper.ShareHelper
+import org.strigate.ferrot.presentation.Screen
+import org.strigate.ferrot.presentation.component.ConfirmDialog
+import org.strigate.ferrot.presentation.component.state.ErrorState
+import org.strigate.ferrot.presentation.component.state.LoadingState
+import org.strigate.ferrot.presentation.event.DownloadEvent
+import org.strigate.ferrot.presentation.model.DownloadPageUiData
+import org.strigate.ferrot.presentation.state.DownloadUiState
+import org.strigate.ferrot.presentation.theme.LocalDimens
+import org.strigate.ferrot.presentation.viewmodel.DownloadViewModel
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
+
+@Composable
+fun DownloadScreen(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    viewModel: DownloadViewModel = hiltViewModel(),
+) {
+    val view = LocalView.current
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val selectedId by viewModel.selectedId.collectAsStateWithLifecycle()
+    val selectedMedia by viewModel.selectedMedia.collectAsStateWithLifecycle(
+        initialValue = DownloadMediaType.VIDEO,
+    )
+    val selectedPageData by viewModel.selectedPageData.collectAsStateWithLifecycle()
+
+    val showConfirmDeleteDialog = remember { mutableStateOf(false) }
+    val onNavigateBack = {
+        navigateBackToParent(
+            navController = navController,
+            archived = selectedPageData?.archived == true,
+        )
+    }
+
+    BackHandler(enabled = !showConfirmDeleteDialog.value) {
+        onNavigateBack()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.logShown()
+    }
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                DownloadEvent.NavigateBack -> {
+                    onNavigateBack()
+                }
+
+                is DownloadEvent.Play -> {
+                    PlayHelper.playFileIfExists(context, event.path)
+                }
+
+                is DownloadEvent.Share -> {
+                    ShareHelper.shareFileIfExists(context, event.path)
+                }
+
+                is DownloadEvent.Save -> {
+                    SaveHelper.saveToDownloads(context, event.path)
+                }
+            }
+        }
+    }
+
+    DownloadScreenContent(
+        state = DownloadScreenContentState(
+            uiState = uiState,
+            selectedId = selectedId,
+            selectedMedia = selectedMedia,
+            selectedPageData = selectedPageData,
+            showConfirmDeleteDialog = showConfirmDeleteDialog.value,
+        ),
+        pageDataForId = { downloadId ->
+            val pageData by remember(downloadId) {
+                viewModel.getDownloadPageUiData(downloadId)
+            }.collectAsStateWithLifecycle(initialValue = null)
+            pageData
+        },
+        onBackClick = onNavigateBack,
+        onMarkUnseen = viewModel::markUnseenAndNavigateBack,
+        onUpdateArchived = viewModel::updateArchived,
+        onShowDeleteConfirmation = { showConfirmDeleteDialog.value = true },
+        onDeleteConfirmed = {
+            viewModel.deleteDownload()
+            showConfirmDeleteDialog.value = false
+        },
+        onDeleteDismissed = { showConfirmDeleteDialog.value = false },
+        onEnsureDefaults = viewModel::setDefaultsForIds,
+        onDownloadPageSelected = viewModel::selectDownload,
+        onVisibleCompletedUnseenDownload = viewModel::markSeenIfCompleted,
+        onSelectedMedia = { downloadId, mediaType ->
+            viewModel.setSelectedMedia(mediaType, downloadId)
+        },
+        onPlayClick = viewModel::playDownload,
+        onSaveClick = viewModel::saveDownload,
+        onShareClick = viewModel::shareDownload,
+        onRetryClick = { downloadId ->
+            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+            viewModel.retryDownload(downloadId)
+        },
+        onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
+        onUrlClick = uriHandler::openUri,
+        onCopyText = context::copyToClipboard,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DownloadScreenContent(
+    state: DownloadScreenContentState,
+    pageDataForId: @Composable (Long) -> DownloadPageUiData?,
+    onBackClick: () -> Unit,
+    onMarkUnseen: () -> Unit,
+    onUpdateArchived: (Boolean) -> Unit,
+    onShowDeleteConfirmation: () -> Unit,
+    onDeleteConfirmed: () -> Unit,
+    onDeleteDismissed: () -> Unit,
+    onEnsureDefaults: (List<Long>) -> Unit,
+    onDownloadPageSelected: (Long) -> Unit,
+    onVisibleCompletedUnseenDownload: (Long) -> Unit,
+    onSelectedMedia: (Long, DownloadMediaType) -> Unit,
+    onPlayClick: (Long) -> Unit,
+    onSaveClick: (Long) -> Unit,
+    onShareClick: (Long) -> Unit,
+    onRetryClick: (Long) -> Unit,
+    onRefreshMetadataClick: (Long) -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (state.showConfirmDeleteDialog) {
+        ConfirmDialog(
+            title = stringResource(R.string.confirm_dialog_delete_download_title),
+            message = stringResource(R.string.confirm_dialog_delete_download_description),
+            positiveButtonText = stringResource(R.string.yes),
+            isDestructive = true,
+            onPositiveClick = onDeleteConfirmed,
+            negativeButtonText = stringResource(R.string.no),
+            onNegativeClick = onDeleteDismissed,
+            onDismissRequest = onDeleteDismissed,
+        )
+    }
+
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            TopAppBar(
+                colors = RefineryTopAppBarDefaults.colors(),
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            onBackClick()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.content_description_back),
+                        )
+                    }
+                },
+                title = {
+                    Text(
+                        text = if (state.selectedPageData?.archived == true) {
+                            stringResource(R.string.screen_title_archived_download)
+                        } else {
+                            stringResource(R.string.screen_title_download)
+                        },
+                    )
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            onMarkUnseen()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.VisibilityOff,
+                            contentDescription = stringResource(R.string.content_description_mark_unseen),
+                        )
+                    }
+                    IconButton(
+                        onClick = {
+                            val archived = state.selectedPageData?.archived ?: false
+                            onUpdateArchived(!archived)
+                        },
+                    ) {
+                        Icon(
+                            imageVector = if (state.selectedPageData?.archived == true) {
+                                Icons.Filled.Unarchive
+                            } else {
+                                Icons.Filled.Archive
+                            },
+                            contentDescription = if (state.selectedPageData?.archived == true) {
+                                stringResource(R.string.content_description_unarchive)
+                            } else {
+                                stringResource(R.string.content_description_archive)
+                            },
+                        )
+                    }
+                    IconButton(
+                        onClick = {
+                            onShowDeleteConfirmation()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = stringResource(R.string.content_description_delete_download),
+                        )
+                    }
+                },
+            )
+        },
+        content = { contentPadding ->
+            val dimens = LocalDimens.current
+            when (val uiState = state.uiState) {
+                is DownloadUiState.Loading -> {
+                    LoadingState(
+                        modifier = modifier
+                            .padding(contentPadding)
+                            .fillMaxSize(),
+                        alignment = Alignment.Center,
+                    )
+                }
+
+                is DownloadUiState.Data -> {
+                    val peekPadding = dimens.spacingMediumAlt
+                    val pageSpacing = dimens.spacingSmall
+                    DownloadPager(
+                        modifier = modifier
+                            .padding(contentPadding)
+                            .fillMaxSize(),
+                        data = uiState.data,
+                        pageDataForId = pageDataForId,
+                        selectedId = state.selectedId,
+                        selectedMedia = state.selectedMedia,
+                        onEnsureDefaults = onEnsureDefaults,
+                        onDownloadPageSelected = onDownloadPageSelected,
+                        onVisibleCompletedUnseenDownload = onVisibleCompletedUnseenDownload,
+                        onSelectedMedia = onSelectedMedia,
+                        onPlayClick = onPlayClick,
+                        onSaveClick = onSaveClick,
+                        onShareClick = onShareClick,
+                        onRetryClick = onRetryClick,
+                        onRefreshMetadataClick = onRefreshMetadataClick,
+                        onUrlClick = onUrlClick,
+                        onCopyText = onCopyText,
+                        pagePadding = PaddingValues(
+                            horizontal = peekPadding,
+                            vertical = dimens.zero,
+                        ),
+                        pageSpacing = pageSpacing,
+                    )
+                }
+
+                is DownloadUiState.Error -> DownloadError()
+            }
+        },
+    )
+}
+
+private fun navigateBackToParent(
+    navController: NavController,
+    archived: Boolean,
+) {
+    val parentRoute = if (archived) {
+        Screen.Archived.route
+    } else {
+        Screen.Downloads.route
+    }
+    val previousRoute = navController.previousBackStackEntry?.destination?.route
+    if (previousRoute == parentRoute) {
+        navController.popBackStack()
+        return
+    }
+    if (navController.popBackStack(parentRoute, false)) {
+        return
+    }
+    navController.navigate(parentRoute) {
+        popUpTo(Screen.Downloads.route) {
+            inclusive = false
+            saveState = false
+        }
+        launchSingleTop = true
+        restoreState = false
+    }
+}
+
+@Composable
+internal fun DownloadError(
+    modifier: Modifier = Modifier,
+) {
+    ErrorState(
+        modifier = modifier.fillMaxSize(),
+        alignment = Alignment.Center,
+        text = stringResource(R.string.error_failed_to_load_download),
+    )
+}
+
+internal data class DownloadScreenContentState(
+    val uiState: DownloadUiState,
+    val selectedId: Long?,
+    val selectedMedia: DownloadMediaType,
+    val selectedPageData: DownloadPageUiData?,
+    val showConfirmDeleteDialog: Boolean,
+)


### PR DESCRIPTION
- Extract `DownloadPager` and `DownloadPageContent` from `DownloadScreen`
- Isolate `DownloadScreen` navigation and `DownloadViewModel` interactions
- Simplify `DownloadPager` page ID mapping