### PR TITLE
fix: Preserve download selection during pager reorder

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPager.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPager.kt
@@ -10,7 +10,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,21 +64,44 @@ internal fun DownloadPager(
         val resolvedPage = remember(downloadIds, selectedId) {
             downloadIds.indexOfFirst { it == selectedId }
         }
+        val synchronizedIds = remember { mutableStateOf(downloadIds) }
+        val synchronizedSelectedId = remember { mutableStateOf(selectedId) }
+        val isReanchoring = rememberUpdatedState(
+            downloadIds != synchronizedIds.value || selectedId != synchronizedSelectedId.value,
+        )
+        val currentDownloadIds = rememberUpdatedState(downloadIds)
+        val currentSelectedId = rememberUpdatedState(selectedId)
+        val currentOnDownloadPageSelected = rememberUpdatedState(onDownloadPageSelected)
 
         LaunchedEffect(downloadIds) {
             onEnsureDefaults(downloadIds)
         }
-        LaunchedEffect(resolvedPage) {
-            if (resolvedPage >= 0 && pagerState.currentPage != resolvedPage) {
-                pagerState.scrollToPage(resolvedPage)
+        LaunchedEffect(downloadIds, selectedId) {
+            if (resolvedPage >= 0) {
+                try {
+                    if (pagerState.currentPage != resolvedPage) {
+                        pagerState.scrollToPage(resolvedPage)
+                    }
+                } finally {
+                    synchronizedIds.value = downloadIds
+                    synchronizedSelectedId.value = selectedId
+                }
             }
         }
-        LaunchedEffect(pagerState, downloadIds) {
-            snapshotFlow { pagerState.currentPage }
-                .mapNotNull { pageIndex -> downloadIds.getOrNull(pageIndex) }
+        LaunchedEffect(pagerState) {
+            snapshotFlow {
+                if (isReanchoring.value) {
+                    null
+                } else {
+                    currentDownloadIds.value.getOrNull(pagerState.settledPage)
+                }
+            }
+                .mapNotNull { it }
                 .distinctUntilChanged()
                 .collect { downloadId ->
-                    onDownloadPageSelected(downloadId)
+                    if (downloadId != currentSelectedId.value) {
+                        currentOnDownloadPageSelected.value(downloadId)
+                    }
                 }
         }
 

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -69,6 +69,7 @@ class DownloadViewModel @Inject constructor(
                 .map { it.id }
                 .toList()
         }
+        .distinctUntilChanged()
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -329,6 +329,54 @@ class DownloadViewModelTest {
     }
 
     @Test
+    fun uiState_publishesLiveOrder_whenRetriedDownloadMovesToActivePrefix() =
+        runTest(testDispatcher) {
+            val downloadIdsFlow = MutableStateFlow(listOf(10L, 20L))
+            val viewModel = createViewModel(
+                initialId = 20L,
+                downloadIdsFlow = downloadIdsFlow,
+            )
+            val collector = collectUiState(backgroundScope, viewModel)
+
+            waitForUiState(viewModel) { state ->
+                val data = state as? DownloadUiState.Data ?: return@waitForUiState false
+                data.data.downloadIds == listOf(10L, 20L) && data.data.id == 20L
+            }
+            downloadIdsFlow.value = listOf(20L, 10L)
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value as DownloadUiState.Data
+            assertEquals(listOf(20L, 10L), state.data.downloadIds)
+            assertEquals(20L, state.data.id)
+            assertEquals(20L, viewModel.selectedId.value)
+
+            collector.cancel()
+        }
+
+    @Test
+    fun uiState_publishesUpdatedOrder_whenDownloadsAreAddedAndRemoved() = runTest(testDispatcher) {
+        val downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 30L))
+        val viewModel = createViewModel(
+            initialId = 10L,
+            downloadIdsFlow = downloadIdsFlow,
+        )
+        val collector = collectUiState(backgroundScope, viewModel)
+
+        waitForUiState(viewModel) { state ->
+            val data = state as? DownloadUiState.Data ?: return@waitForUiState false
+            data.data.downloadIds == listOf(10L, 20L, 30L) && data.data.id == 10L
+        }
+        downloadIdsFlow.value = listOf(40L, 30L, 10L)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value as DownloadUiState.Data
+        assertEquals(listOf(40L, 30L, 10L), state.data.downloadIds)
+        assertEquals(10L, state.data.id)
+
+        collector.cancel()
+    }
+
+    @Test
     fun selectDownload_updatesSelectedId_andDefaultsMediaToVideo() = runTest(testDispatcher) {
         val viewModel = createViewModel(
             downloadIdsFlow = MutableStateFlow(listOf(10L, 20L, 44L)),


### PR DESCRIPTION
- Re-anchor `DownloadPager` after source order changes
- Ignore transient page indexes while re-anchoring
- Publish changed `downloadIds` order
- Cover live reorder state in `DownloadViewModelTest`