### PR TITLE
fix: Harden shared link handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,24 +114,20 @@
         <activity
             android:name=".app.ShareReceiveActivity"
             android:exported="true"
-            android:label="@string/activity_label_download"
-            android:launchMode="singleInstance">
+            android:label="@string/activity_label_download">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="text/plain" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND_MULTIPLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/uri-list" />
             </intent-filter>
         </activity>
 
         <activity
             android:name=".presentation.MainActivity"
             android:exported="true"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.Ferrot">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ShareDownloadActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ShareDownloadActivity.kt
@@ -2,14 +2,18 @@ package org.strigate.ferrot.app
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARE_FILE_PATH
+import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.helper.ShareHelper
 
 class ShareDownloadActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val filePath = intent?.getStringExtra(EXTRA_SHARE_FILE_PATH)
-        ShareHelper.shareFileIfExists(this, filePath)
+        if (!ShareHelper.shareFileIfExists(this, filePath)) {
+            toast(R.string.toast_share_failed, true)
+        }
         finish()
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ShareIntentParser.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ShareIntentParser.kt
@@ -1,0 +1,132 @@
+package org.strigate.ferrot.app
+
+import android.content.ClipData
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.IntentCompat
+import java.net.IDN
+import java.net.URI
+
+object ShareIntentParser {
+    private val HTTP_URL_REGEX = Regex(
+        pattern = """https?://[^\s<>"]+""",
+        option = RegexOption.IGNORE_CASE,
+    )
+
+    fun extractUrl(intent: Intent?): String? {
+        if (intent?.action != Intent.ACTION_SEND) {
+            return null
+        }
+        firstUrlFromTextExtra(intent)?.let { return it }
+        getStreamUri(intent)?.let { normalizeHttpUri(it)?.let { url -> return url } }
+        firstUrlFromClipData(intent.clipData)?.let { return it }
+        return normalizeHttpUri(intent.data)
+    }
+
+    fun findFirstHttpUrl(text: String): String? {
+        return findHttpUrls(text).firstOrNull()
+    }
+
+    fun normalizeHttpUrl(value: String): String? {
+        val candidate = value.trim()
+        return validateHttpUrl(candidate)
+    }
+
+    private fun normalizeTextHttpUrl(value: String): String? {
+        var candidate = value.trim()
+        while (candidate.isNotEmpty() && shouldTrimTrailingCharacter(candidate)) {
+            candidate = candidate.dropLast(1)
+        }
+        return validateHttpUrl(candidate)
+    }
+
+    private fun validateHttpUrl(candidate: String): String? {
+        if (candidate.isEmpty()) {
+            return null
+        }
+        val uri = runCatching { URI(candidate) }.getOrNull() ?: return null
+        if (!uri.scheme.equals("http", ignoreCase = true) &&
+            !uri.scheme.equals("https", ignoreCase = true)
+        ) {
+            return null
+        }
+        if (uri.port > 65535) {
+            return null
+        }
+        if (!hasValidHost(uri)) {
+            return null
+        }
+        return candidate
+    }
+
+    private fun firstUrlFromTextExtra(intent: Intent): String? {
+        val text = intent.extras?.getCharSequence(Intent.EXTRA_TEXT)?.toString()
+        return text?.let(::findFirstHttpUrl)
+    }
+
+    private fun getStreamUri(intent: Intent): Uri? {
+        return IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
+    }
+
+    private fun firstUrlFromClipData(clipData: ClipData?): String? {
+        if (clipData == null) {
+            return null
+        }
+        for (index in 0 until clipData.itemCount) {
+            val item = clipData.getItemAt(index)
+            item.text?.let { text ->
+                findFirstHttpUrl(text.toString())?.let { return it }
+            }
+            normalizeHttpUri(item.uri)?.let { return it }
+        }
+        return null
+    }
+
+    private fun findHttpUrls(text: String): List<String> {
+        return HTTP_URL_REGEX.findAll(text)
+            .mapNotNull { match -> normalizeTextHttpUrl(match.value) }
+            .toList()
+    }
+
+    private fun normalizeHttpUri(uri: Uri?): String? {
+        return uri?.let { normalizeHttpUrl(it.toString()) }
+    }
+
+    private fun hasValidHost(uri: URI): Boolean {
+        if (!uri.host.isNullOrBlank()) {
+            return true
+        }
+
+        val authority = uri.rawAuthority ?: return false
+        val hostAndPort = authority.substringAfterLast('@')
+        if (hostAndPort.startsWith('[')) {
+            return false
+        }
+        val portSeparator = hostAndPort.lastIndexOf(':')
+        val host = if (portSeparator >= 0) {
+            val port = hostAndPort.substring(portSeparator + 1)
+            if (port.isEmpty() || port.any { !it.isDigit() } || port.toIntOrNull() !in 0..65535) {
+                return false
+            }
+            hostAndPort.substring(0, portSeparator)
+        } else {
+            hostAndPort
+        }
+        if (host.isEmpty()) {
+            return false
+        }
+        return runCatching {
+            IDN.toASCII(host, IDN.USE_STD3_ASCII_RULES)
+        }.getOrNull()?.isNotEmpty() == true
+    }
+
+    private fun shouldTrimTrailingCharacter(value: String): Boolean {
+        return when (value.last()) {
+            '.', ',', '?', '#', '"' -> true
+            ')' -> value.count { it == ')' } > value.count { it == '(' }
+            ']' -> value.count { it == ']' } > value.count { it == '[' }
+            '}' -> value.count { it == '}' } > value.count { it == '{' }
+            else -> false
+        }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/app/ShareReceiveActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/app/ShareReceiveActivity.kt
@@ -1,14 +1,15 @@
 package org.strigate.ferrot.app
 
-import android.content.ClipData
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import dagger.hilt.android.AndroidEntryPoint
+import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.Action.ACTION_START_DOWNLOAD_FROM_SHARE
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_ACTION
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL_UID
+import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.presentation.MainActivity
 import org.strigate.ferrot.util.UidUtil
 
@@ -16,99 +17,32 @@ import org.strigate.ferrot.util.UidUtil
 class ShareReceiveActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val action = intent?.action
-        val sharedUrl = when (action) {
-            Intent.ACTION_SEND -> extractUrlFromActionSend(intent)
-            Intent.ACTION_SEND_MULTIPLE -> extractUrlFromActionSendMultiple(intent)
-            else -> null
+        if (savedInstanceState == null) {
+            handleIntent(intent)
+        } else {
+            finish()
         }
-        val intent = Intent(this, MainActivity::class.java).apply {
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(receivedIntent: Intent?) {
+        val sharedUrl = ShareIntentParser.extractUrl(receivedIntent)
+        if (sharedUrl == null) {
+            toast(R.string.toast_share_no_url, true)
+            finish()
+            return
+        }
+        val handoffIntent = Intent(this, MainActivity::class.java).apply {
             putExtra(EXTRA_ACTION, ACTION_START_DOWNLOAD_FROM_SHARE)
             putExtra(EXTRA_SHARED_URL_UID, UidUtil.generateUid())
             putExtra(EXTRA_SHARED_URL, sharedUrl)
         }
-        startActivity(intent)
+        startActivity(handoffIntent)
         finish()
-    }
-
-    private fun extractUrlFromActionSend(intent: Intent): String? {
-        val extraText = intent.getStringExtra(Intent.EXTRA_TEXT)
-        if (!extraText.isNullOrEmpty()) {
-            val urlFromText = findFirstHttpUrl(extraText)
-            if (!urlFromText.isNullOrEmpty()) {
-                return urlFromText
-            }
-        }
-        val clip: ClipData? = intent.clipData
-        if (clip != null) {
-            val count = clip.itemCount
-            for (index in 0 until count) {
-                val item = clip.getItemAt(index)
-                val itemText: CharSequence? = item.text
-                if (itemText != null) {
-                    val urlFromItemText: String? = findFirstHttpUrl(itemText.toString())
-                    if (!urlFromItemText.isNullOrEmpty()) {
-                        return urlFromItemText
-                    }
-                }
-                val itemUri = item.uri
-                if (itemUri != null) {
-                    val uriString = itemUri.toString()
-                    if (uriString.startsWith("http://") || uriString.startsWith("https://")) {
-                        return uriString
-                    }
-                }
-            }
-        }
-        val dataUri = intent.data
-        if (dataUri != null) {
-            val asString = dataUri.toString()
-            if (asString.startsWith("http://") || asString.startsWith("https://")) {
-                return asString
-            }
-        }
-        return null
-    }
-
-    private fun extractUrlFromActionSendMultiple(intent: Intent): String? {
-        val clip: ClipData? = intent.clipData
-        if (clip != null) {
-            val count = clip.itemCount
-            for (index in 0 until count) {
-                val item = clip.getItemAt(index)
-                val itemText: CharSequence? = item.text
-                if (itemText != null) {
-                    val urlFromItemText: String? = findFirstHttpUrl(itemText.toString())
-                    if (!urlFromItemText.isNullOrEmpty()) {
-                        return urlFromItemText
-                    }
-                }
-                val itemUri = item.uri
-                if (itemUri != null) {
-                    val uriString = itemUri.toString()
-                    if (uriString.startsWith("http://") || uriString.startsWith("https://")) {
-                        return uriString
-                    }
-                }
-            }
-        }
-        val extraText: String? = intent.getStringExtra(Intent.EXTRA_TEXT)
-        if (!extraText.isNullOrEmpty()) {
-            val urlFromText: String? = findFirstHttpUrl(extraText)
-            if (!urlFromText.isNullOrEmpty()) {
-                return urlFromText
-            }
-        }
-        return null
-    }
-
-    companion object {
-        private val URL_REGEX: Regex = Regex("""https?://\S+""", RegexOption.IGNORE_CASE)
-
-        fun findFirstHttpUrl(text: String): String? {
-            if (text.isEmpty()) return null
-            val match = URL_REGEX.find(text)
-            return match?.value
-        }
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
+import org.strigate.ferrot.R
 import org.strigate.ferrot.app.Constants.Action.ACTION_INSTALL_AVAILABLE_UPDATE
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOAD
 import org.strigate.ferrot.app.Constants.Action.ACTION_NAVIGATE_DOWNLOADS
@@ -31,6 +32,8 @@ import org.strigate.ferrot.app.Constants.Extras.EXTRA_DOWNLOAD_ID
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL
 import org.strigate.ferrot.app.Constants.Extras.EXTRA_SHARED_URL_UID
 import org.strigate.ferrot.app.Constants.LOG_TAG
+import org.strigate.ferrot.app.ShareIntentParser
+import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.helper.InstallHelper
 import org.strigate.ferrot.presentation.theme.Dimens
 import org.strigate.ferrot.presentation.theme.LocalDimens
@@ -47,6 +50,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
         handleIntent(intent)
     }
 
@@ -64,20 +68,21 @@ class MainActivity : ComponentActivity() {
         when (intent.getStringExtra(EXTRA_ACTION)) {
             ACTION_START_DOWNLOAD_FROM_SHARE -> {
                 val sharedUrlUid = intent.getStringExtra(EXTRA_SHARED_URL_UID)
-                if (!sharedUrlUid.isNullOrBlank() && handledUids.contains(sharedUrlUid)) {
+                val sharedUrl = intent.getStringExtra(EXTRA_SHARED_URL)
+                    ?.let(ShareIntentParser::normalizeHttpUrl)
+
+                if (sharedUrl == null || sharedUrlUid.isNullOrBlank()) {
+                    toast(R.string.toast_share_no_url, true)
                     return
                 }
-                val sharedUrl = intent.getStringExtra(EXTRA_SHARED_URL)
-                if (!sharedUrl.isNullOrBlank()) {
-                    sharedUrlUid?.let {
-                        handledUids.add(it)
-                        viewModel.startDownload(sharedUrl)
-                        viewModel.navigateTo(
-                            route = Screen.Downloads.route,
-                            popUpToRoute = Screen.Downloads.route,
-                        )
-                    }
+                if (!markShareHandled(sharedUrlUid)) {
+                    return
                 }
+                viewModel.startDownload(sharedUrl)
+                viewModel.navigateTo(
+                    route = Screen.Downloads.route,
+                    popUpToRoute = Screen.Downloads.route,
+                )
                 return
             }
 
@@ -196,7 +201,19 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun markShareHandled(uid: String): Boolean {
+        if (handledShareUids.contains(uid)) {
+            return false
+        }
+        if (handledShareUids.size >= MAX_HANDLED_SHARE_UIDS) {
+            handledShareUids.iterator().next().let(handledShareUids::remove)
+        }
+        handledShareUids.add(uid)
+        return true
+    }
+
     companion object {
-        private val handledUids = mutableListOf<String>()
+        private const val MAX_HANDLED_SHARE_UIDS = 64
+        private val handledShareUids = LinkedHashSet<String>()
     }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadScreen.kt
@@ -35,6 +35,7 @@ import androidx.navigation.NavController
 import org.strigate.ferrot.R
 import org.strigate.ferrot.domain.model.DownloadMediaType
 import org.strigate.ferrot.extensions.copyToClipboard
+import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.helper.PlayHelper
 import org.strigate.ferrot.helper.SaveHelper
 import org.strigate.ferrot.helper.ShareHelper
@@ -93,7 +94,9 @@ fun DownloadScreen(
                 }
 
                 is DownloadEvent.Share -> {
-                    ShareHelper.shareFileIfExists(context, event.path)
+                    if (!ShareHelper.shareFileIfExists(context, event.path)) {
+                        context.toast(R.string.toast_share_failed, true)
+                    }
                 }
 
                 is DownloadEvent.Save -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="toast_cookie_set_failed">Could not save cookies</string>
     <string name="toast_cookie_set_preview_failed">Could not load cookies</string>
     <string name="toast_cookie_webview_invalid_url">Enter a valid site URL</string>
+    <string name="toast_share_no_url">No link found in shared content</string>
+    <string name="toast_share_failed">Could not share the download</string>
     <string name="toast_unable_to_open_link">Unable to open link</string>
 
     <!-- Settings: sections -->

--- a/app/src/test/kotlin/org/strigate/ferrot/app/ShareIntentParserTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/app/ShareIntentParserTest.kt
@@ -1,0 +1,99 @@
+package org.strigate.ferrot.app
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class ShareIntentParserTest {
+    @Test
+    fun findFirstHttpUrl_extractsAndCleansUrlFromText() {
+        val result = ShareIntentParser.findFirstHttpUrl(
+            "Watch this (https://example.com/video).",
+        )
+
+        assertEquals("https://example.com/video", result)
+    }
+
+    @Test
+    fun findFirstHttpUrl_preservesValidPathPunctuation() {
+        listOf(
+            "https://example.com/file!",
+            "https://example.com/file;",
+            "https://example.com/file:",
+            "https://example.com/it's-here",
+        ).forEach { url ->
+            assertEquals(url, ShareIntentParser.findFirstHttpUrl("Shared link: $url"))
+        }
+    }
+
+    @Test
+    fun normalizeHttpUrl_rejectsInvalidSchemesAndHosts() {
+        assertNull(ShareIntentParser.normalizeHttpUrl("ftp://example.com/video"))
+        assertNull(ShareIntentParser.normalizeHttpUrl("https://"))
+        assertNull(ShareIntentParser.normalizeHttpUrl("https://_example.com/video"))
+        assertNull(ShareIntentParser.normalizeHttpUrl("https://example.com:65536/video"))
+        assertEquals(
+            "HTTPS://example.com/video",
+            ShareIntentParser.normalizeHttpUrl("HTTPS://example.com/video"),
+        )
+    }
+
+    @Test
+    fun normalizeHttpUrl_preservesPunctuationInUriPayloads() {
+        assertEquals(
+            "https://example.com/file!",
+            ShareIntentParser.normalizeHttpUrl("https://example.com/file!"),
+        )
+    }
+
+    @Test
+    fun normalizeHttpUrl_acceptsInternationalizedHostnames() {
+        assertEquals(
+            "https://例え.テスト/video",
+            ShareIntentParser.normalizeHttpUrl("https://例え.テスト/video"),
+        )
+    }
+
+    @Test
+    fun extractUrl_readsSingleCharSequenceText() {
+        val intent = mock(Intent::class.java)
+        val extras = mock(Bundle::class.java)
+        `when`(intent.action).thenReturn(Intent.ACTION_SEND)
+        `when`(intent.extras).thenReturn(extras)
+        `when`(extras.getCharSequence(Intent.EXTRA_TEXT))
+            .thenReturn("https://example.com/video")
+
+        assertEquals(
+            "https://example.com/video",
+            ShareIntentParser.extractUrl(intent),
+        )
+    }
+
+    @Test
+    fun extractUrl_readsSingleStreamUri() {
+        val intent = mock(Intent::class.java)
+        val uri = mock(Uri::class.java)
+        `when`(intent.action).thenReturn(Intent.ACTION_SEND)
+        `when`(uri.toString()).thenReturn("https://example.com/video")
+        @Suppress("DEPRECATION")
+        `when`(intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)).thenReturn(uri)
+
+        assertEquals(
+            "https://example.com/video",
+            ShareIntentParser.extractUrl(intent),
+        )
+    }
+
+    @Test
+    fun extractUrl_ignoresMultipleShareAction() {
+        val intent = mock(Intent::class.java)
+        `when`(intent.action).thenReturn(Intent.ACTION_SEND_MULTIPLE)
+
+        assertNull(ShareIntentParser.extractUrl(intent))
+    }
+}


### PR DESCRIPTION
- Validate shared URLs with `ShareIntentParser`
- Handle `MainActivity` intent delivery without duplicate downloads
- Report invalid shared links and failed file shares
- Limit sharing to single links and cover parser behavior