### PR TITLE
chore: Standardize Compose modifier formatting

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
@@ -43,12 +43,13 @@ fun Copyright(
             ),
         ) {
             Column(
-                modifier = Modifier.padding(
-                    start = refineryDimens.spacingLarge,
-                    top = refineryDimens.spacingMedium,
-                    end = refineryDimens.spacingLarge,
-                    bottom = refineryDimens.spacingLarge,
-                ),
+                modifier = Modifier
+                    .padding(
+                        start = refineryDimens.spacingLarge,
+                        top = refineryDimens.spacingMedium,
+                        end = refineryDimens.spacingLarge,
+                        bottom = refineryDimens.spacingLarge,
+                    ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Icon(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/Copyright.kt
@@ -52,8 +52,7 @@ fun Copyright(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Icon(
-                    modifier = Modifier
-                        .height(refineryDimens.iconLarge),
+                    modifier = Modifier.height(refineryDimens.iconLarge),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
                         alpha = 0.8f,
                     ),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadPrimaryActionButton.kt
@@ -86,14 +86,12 @@ fun DownloadPrimaryActionButton(
         tonalElevation = refineryDimens.tonalElevationHigh,
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxSize(),
+            modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
             thumbnailFile?.let {
                 AsyncImage(
-                    modifier = Modifier
-                        .matchParentSize(),
+                    modifier = Modifier.matchParentSize(),
                     model = ImageRequest.Builder(context)
                         .data(it)
                         .crossfade(true)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/DownloadProgressSection.kt
@@ -61,8 +61,7 @@ fun DownloadProgressSection(
             Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
         }
         Box(
-            modifier = Modifier
-                .heightIn(min = refineryDimens.spacingLarge),
+            modifier = Modifier.heightIn(min = refineryDimens.spacingLarge),
         ) {
             StatusSizeEtaRow(
                 status = status,
@@ -139,8 +138,7 @@ private fun InfoLine(
     ) {
         if (!leftText.isNullOrBlank()) {
             Text(
-                modifier = Modifier
-                    .weight(1f),
+                modifier = Modifier.weight(1f),
                 style = MaterialTheme.typography.bodySmall,
                 color = if (isError) {
                     MaterialTheme.colorScheme.error

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/EmptyState.kt
@@ -39,8 +39,7 @@ fun EmptyState(
     ) {
         icon?.let {
             Icon(
-                modifier = Modifier
-                    .size(refineryDimens.iconXLarge),
+                modifier = Modifier.size(refineryDimens.iconXLarge),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 imageVector = it,
                 contentDescription = iconContentDescription,
@@ -48,8 +47,7 @@ fun EmptyState(
         }
         Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
         Column(
-            modifier = Modifier
-                .widthIn(max = dimens.contentMaxWidth),
+            modifier = Modifier.widthIn(max = dimens.contentMaxWidth),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/state/ErrorState.kt
@@ -36,8 +36,7 @@ fun ErrorState(
             verticalArrangement = Arrangement.Center,
         ) {
             Icon(
-                modifier = Modifier
-                    .size(refineryDimens.iconXLarge),
+                modifier = Modifier.size(refineryDimens.iconXLarge),
                 tint = MaterialTheme.colorScheme.error,
                 imageVector = Icons.Outlined.ErrorOutline,
                 contentDescription = null,
@@ -45,8 +44,7 @@ fun ErrorState(
             text?.let {
                 Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
                 Column(
-                    modifier = Modifier
-                        .widthIn(max = dimens.contentMaxWidth),
+                    modifier = Modifier.widthIn(max = dimens.contentMaxWidth),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Text(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -225,8 +225,7 @@ internal fun AboutScreenContent(
                         )
                     }
                     Copyright(
-                        modifier = Modifier
-                            .fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth(),
                         onLogoClick = {
                             onUrlClick(urlStrigate)
                         },

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/GetCookiesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/GetCookiesScreen.kt
@@ -258,8 +258,7 @@ internal fun GetCookiesScreenContent(
                 color = MaterialTheme.colorScheme.background,
             ) {
                 BoxWithConstraints(
-                    modifier = Modifier
-                        .fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                 ) {
                     if (state.requestedUrl == null) {
                         Box(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -126,15 +126,13 @@ internal fun SettingsScreenContent(
         },
         content = { contentPadding ->
             Surface(
-                modifier = modifier
-                    .padding(contentPadding),
+                modifier = modifier.padding(contentPadding),
                 color = MaterialTheme.colorScheme.background,
             ) {
                 when (val state = uiState) {
                     is SettingsUiState.Loading -> {
                         LoadingState(
-                            modifier = Modifier
-                                .fillMaxSize(),
+                            modifier = Modifier.fillMaxSize(),
                             alignment = Alignment.Center,
                         )
                     }
@@ -238,8 +236,7 @@ private fun SettingsError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
-        modifier = modifier
-            .fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_settings),
     )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -119,8 +119,7 @@ internal fun UpdatesScreenContent(
                 when (val state = uiState) {
                     is UpdatesUiState.Loading -> {
                         LoadingState(
-                            modifier = Modifier
-                                .fillMaxSize(),
+                            modifier = Modifier.fillMaxSize(),
                             alignment = Alignment.Center,
                         )
                     }
@@ -199,8 +198,7 @@ private fun UpdatesError(
     modifier: Modifier = Modifier,
 ) {
     ErrorState(
-        modifier = modifier
-            .fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_update_settings),
     )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPageContent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPageContent.kt
@@ -451,10 +451,11 @@ private fun FileExtensionPill(
         tonalElevation = dimens.tonalElevationHigh,
     ) {
         Text(
-            modifier = Modifier.padding(
-                horizontal = dimens.spacingSmall,
-                vertical = dimens.spacingXXSmall,
-            ),
+            modifier = Modifier
+                .padding(
+                    horizontal = dimens.spacingSmall,
+                    vertical = dimens.spacingXXSmall,
+                ),
             color = MaterialTheme.colorScheme.onSecondaryContainer,
             style = MaterialTheme.typography.titleMedium,
             text = text,
@@ -491,12 +492,13 @@ private fun MetaItem(
             Spacer(modifier = Modifier.height(dimens.spacingXXSmall))
             if (isUrl) {
                 Text(
-                    modifier = Modifier.clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = LocalIndication.current,
-                    ) {
-                        onUrlClick(value)
-                    },
+                    modifier = Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = LocalIndication.current,
+                        ) {
+                            onUrlClick(value)
+                        },
                     style = MaterialTheme.typography.bodySmall.copy(
                         textDecoration = TextDecoration.Underline,
                     ),

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsScreen.kt
@@ -317,8 +317,7 @@ internal fun DownloadsScreenContent(
     )
 
     Scaffold(
-        modifier = modifier
-            .fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             if (selectionMode) {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsScreen.kt
@@ -644,11 +644,12 @@ private fun DownloadsContent(
                     selectedIds = selectedIds,
                     isRestoring = item.id in restoringItemIds,
                     gridLayoutEnabled = gridLayoutEnabled,
-                    modifier = Modifier.animateItem(
-                        fadeInSpec = null,
-                        placementSpec = spring(),
-                        fadeOutSpec = null,
-                    ),
+                    modifier = Modifier
+                        .animateItem(
+                            fadeInSpec = null,
+                            placementSpec = spring(),
+                            fadeOutSpec = null,
+                        ),
                     onItemClick = onItemClick,
                     onPauseResume = { clickedItem ->
                         if (selectedIds.isNotEmpty()) {
@@ -1247,10 +1248,11 @@ private fun SwipeActionBackground(
             },
         ) {
             Icon(
-                modifier = Modifier.padding(
-                    start = if (isEndToStart) dimens.zero else dimens.spacingMedium,
-                    end = if (isEndToStart) dimens.spacingMedium else dimens.zero,
-                ),
+                modifier = Modifier
+                    .padding(
+                        start = if (isEndToStart) dimens.zero else dimens.spacingMedium,
+                        end = if (isEndToStart) dimens.spacingMedium else dimens.zero,
+                    ),
                 imageVector = getSwipeActionIcon(
                     action = swipeAction,
                     archived = archived,

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
@@ -39,11 +39,12 @@ fun ColorPickerSetting(
     val chipColor = MaterialTheme.colorScheme.surface
     val chipTextColor = MaterialTheme.colorScheme.onSurface
     val clickableModifier = if (onClick != null) {
-        Modifier.combinedClickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = ripple(),
-            onClick = onClick,
-        )
+        Modifier
+            .combinedClickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(),
+                onClick = onClick,
+            )
     } else {
         Modifier
     }

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ColorPickerSetting.kt
@@ -49,8 +49,7 @@ fun ColorPickerSetting(
     }
 
     Box(
-        modifier = modifier
-            .fillMaxWidth()
+        modifier = modifier.fillMaxWidth()
     ) {
         Column(
             modifier = Modifier
@@ -62,8 +61,7 @@ fun ColorPickerSetting(
                 ),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/DropdownSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/DropdownSetting.kt
@@ -48,8 +48,7 @@ fun <T> DropdownSetting(
     val chipTextColor = MaterialTheme.colorScheme.onSurface
 
     Box(
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Column(
             modifier = Modifier
@@ -67,8 +66,7 @@ fun <T> DropdownSetting(
                 ),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ExpandableSettingsSection.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/ExpandableSettingsSection.kt
@@ -63,8 +63,7 @@ fun ExpandableSettingsSection(
                 title = title,
             ) {
                 Icon(
-                    modifier = Modifier
-                        .size(refineryDimens.iconXSmallAlt),
+                    modifier = Modifier.size(refineryDimens.iconXSmallAlt),
                     imageVector = if (expanded) {
                         Icons.Filled.KeyboardArrowUp
                     } else {

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsDropdownMenu.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsDropdownMenu.kt
@@ -33,8 +33,7 @@ internal fun SettingsDropdownMenu(
     }
     val refineryDimens = LocalRefineryDimens.current
     DropdownMenu(
-        modifier = modifier
-            .padding(end = refineryDimens.spacingSmall),
+        modifier = modifier.padding(end = refineryDimens.spacingSmall),
         onDismissRequest = onDismissRequest,
         expanded = expanded,
         shape = MaterialTheme.shapes.medium,

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsIconRow.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsIconRow.kt
@@ -37,13 +37,11 @@ fun SettingsIconRow(
         ) {
             items.forEach { item ->
                 IconButton(
-                    modifier = Modifier
-                        .size(refineryDimens.iconSmall + refineryDimens.spacingXSmallAlt),
+                    modifier = Modifier.size(refineryDimens.iconSmall + refineryDimens.spacingXSmallAlt),
                     onClick = item.onClick,
                 ) {
                     Icon(
-                        modifier = Modifier
-                            .size(refineryDimens.iconXSmall),
+                        modifier = Modifier.size(refineryDimens.iconXSmall),
                         painter = item.painter,
                         contentDescription = item.contentDescription,
                     )

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsSectionHeader.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SettingsSectionHeader.kt
@@ -27,8 +27,7 @@ internal fun SettingsSectionHeader(
     ) {
         if (icon != null) {
             Icon(
-                modifier = Modifier
-                    .size(refineryDimens.iconXSmallAlt),
+                modifier = Modifier.size(refineryDimens.iconXSmallAlt),
                 imageVector = icon,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -39,8 +38,7 @@ internal fun SettingsSectionHeader(
         }
         if (title != null) {
             Text(
-                modifier = Modifier
-                    .weight(1f),
+                modifier = Modifier.weight(1f),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
                 text = title,

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SwitchSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/SwitchSetting.kt
@@ -44,8 +44,7 @@ fun SwitchSetting(
             ),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
@@ -69,8 +68,7 @@ fun SwitchSetting(
                 }
             }
             Switch(
-                modifier = Modifier
-                    .height(refineryDimens.iconXSmall),
+                modifier = Modifier.height(refineryDimens.iconXSmall),
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.primary,
                     checkedTrackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextNavigateSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextNavigateSetting.kt
@@ -53,15 +53,13 @@ fun TextNavigateSetting(
                 .padding(refineryDimens.spacingMedium),
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 if (icon != null) {
                     Icon(
-                        modifier = Modifier
-                            .size(refineryDimens.iconXSmallAlt),
+                        modifier = Modifier.size(refineryDimens.iconXSmallAlt),
                         imageVector = icon,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         contentDescription = null,
@@ -88,8 +86,7 @@ fun TextNavigateSetting(
                     }
                 }
                 Icon(
-                    modifier = Modifier
-                        .size(refineryDimens.iconXSmallAlt),
+                    modifier = Modifier.size(refineryDimens.iconXSmallAlt),
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     contentDescription = null,

--- a/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextSetting.kt
+++ b/refinery/src/main/kotlin/org/strigate/refinery/component/settings/TextSetting.kt
@@ -63,8 +63,7 @@ fun TextSetting(
             ),
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {


### PR DESCRIPTION
- Inline concise single-call `Modifier` expressions
- Preserve multiline formatting for chained and complex modifiers