### PR TITLE
fix: Harden screen state handling

### DIFF
--- a/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadmetadata/IsDownloadThumbnailAvailableUseCase.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/domain/usecase/downloadmetadata/IsDownloadThumbnailAvailableUseCase.kt
@@ -1,0 +1,12 @@
+package org.strigate.ferrot.domain.usecase.downloadmetadata
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+class IsDownloadThumbnailAvailableUseCase @Inject constructor() {
+    suspend operator fun invoke(path: String?): Boolean = withContext(Dispatchers.IO) {
+        !path.isNullOrBlank() && File(path).let { it.isFile && it.length() > 0L }
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/MainNavHost.kt
@@ -12,12 +12,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import org.strigate.ferrot.presentation.screen.AboutScreen
 import org.strigate.ferrot.presentation.screen.CookiesScreen
-import org.strigate.ferrot.presentation.screen.GetCookiesScreen
 import org.strigate.ferrot.presentation.screen.SettingsScreen
 import org.strigate.ferrot.presentation.screen.UpdatesScreen
 import org.strigate.ferrot.presentation.screen.download.DownloadScreen
 import org.strigate.ferrot.presentation.screen.downloads.ArchivedScreen
 import org.strigate.ferrot.presentation.screen.downloads.DownloadsScreen
+import org.strigate.ferrot.presentation.screen.getcookies.GetCookiesScreen
 
 @Composable
 fun MainNavHost(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/component/BackTopAppBar.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/component/BackTopAppBar.kt
@@ -1,0 +1,36 @@
+package org.strigate.ferrot.presentation.component
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.strigate.ferrot.R
+import org.strigate.refinery.theme.RefineryTopAppBarDefaults
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BackTopAppBar(
+    title: String,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TopAppBar(
+        modifier = modifier,
+        colors = RefineryTopAppBarDefaults.colors(),
+        title = { Text(text = title) },
+        navigationIcon = {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(R.string.content_description_back),
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadPageUiData.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/model/DownloadPageUiData.kt
@@ -12,4 +12,5 @@ data class DownloadPageUiData(
     val archived: Boolean,
     val errorMessage: String?,
     val completedAtMillis: Long?,
+    val thumbnailAvailable: Boolean = false,
 )

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/AboutScreen.kt
@@ -14,17 +14,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Link
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -37,6 +31,7 @@ import org.strigate.ferrot.BuildConfig
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.copyToClipboard
 import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.presentation.component.BackTopAppBar
 import org.strigate.ferrot.presentation.component.Copyright
 import org.strigate.ferrot.presentation.event.AboutEvent
 import org.strigate.ferrot.presentation.viewmodel.AboutViewModel
@@ -45,7 +40,6 @@ import org.strigate.refinery.component.settings.SettingsIconRowItem
 import org.strigate.refinery.component.settings.StaticSettingsSection
 import org.strigate.refinery.component.settings.TextSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
-import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @Composable
 fun AboutScreen(
@@ -95,7 +89,6 @@ fun AboutScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun AboutScreenContent(
     onBackClick: () -> Unit,
@@ -104,134 +97,134 @@ internal fun AboutScreenContent(
     onCopyText: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val refineryDimens = LocalRefineryDimens.current
-    val urlStrigate = stringResource(R.string.url_strigate)
-
     Scaffold(
+        modifier = modifier,
         topBar = {
-            TopAppBar(
-                colors = RefineryTopAppBarDefaults.colors(),
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBackClick,
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_description_back),
-                        )
-                    }
-                },
-                title = {
-                    Text(
-                        text = stringResource(R.string.screen_title_about),
-                    )
-                },
+            BackTopAppBar(
+                title = stringResource(R.string.screen_title_about),
+                onBackClick = onBackClick,
             )
         },
         content = { contentPadding ->
             Surface(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding),
                 color = MaterialTheme.colorScheme.background,
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = refineryDimens.spacingMediumAlt)
-                        .verticalScroll(rememberScrollState()),
-                ) {
-                    StaticSettingsSection(
-                        icon = Icons.Outlined.Info,
-                        title = stringResource(R.string.settings_section_app_info),
-                    ) {
-                        TextSetting(
-                            text = stringResource(R.string.settings_title_build),
-                            description = BuildConfig.VERSION_NAME,
-                            onLongClick = {
-                                onCopyText(BuildConfig.VERSION_NAME)
-                            },
-                        ) {
-                            onBuildClick()
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                    StaticSettingsSection(
-                        icon = Icons.Outlined.Link,
-                        title = stringResource(R.string.settings_section_links),
-                    ) {
-                        val urlWebsite = stringResource(R.string.url_website)
-                        val urlGitHub = stringResource(R.string.url_github)
-                        val urlPrivacy = stringResource(R.string.url_privacy)
-                        val urlLicense = stringResource(R.string.url_license)
-                        TextSetting(
-                            text = stringResource(R.string.settings_title_website),
-                            description = stringResource(R.string.settings_description_website),
-                            onLongClick = {
-                                onCopyText(urlWebsite)
-                            },
-                        ) {
-                            onUrlClick(urlWebsite)
-                        }
-                        TextSetting(
-                            text = stringResource(R.string.settings_title_github),
-                            description = stringResource(R.string.settings_description_github),
-                            onLongClick = {
-                                onCopyText(urlGitHub)
-                            },
-                        ) {
-                            onUrlClick(urlGitHub)
-                        }
-                        TextSetting(
-                            text = stringResource(R.string.settings_title_privacy),
-                            description = stringResource(R.string.settings_description_privacy),
-                            onLongClick = {
-                                onCopyText(urlPrivacy)
-                            },
-                        ) {
-                            onUrlClick(urlPrivacy)
-                        }
-                        TextSetting(
-                            text = stringResource(R.string.settings_title_license),
-                            description = stringResource(R.string.settings_description_license),
-                            onLongClick = {
-                                onCopyText(urlLicense)
-                            },
-                        ) {
-                            onUrlClick(urlLicense)
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                    StaticSettingsSection {
-                        val urlGitHubStrigate = stringResource(R.string.url_github_strigate)
-                        val urlX = stringResource(R.string.url_x)
-                        SettingsIconRow(
-                            items = listOf(
-                                SettingsIconRowItem(
-                                    painter = painterResource(R.drawable.ic_github),
-                                    contentDescription = stringResource(R.string.content_description_github),
-                                    onClick = {
-                                        onUrlClick(urlGitHubStrigate)
-                                    },
-                                ),
-                                SettingsIconRowItem(
-                                    painter = painterResource(R.drawable.ic_x),
-                                    contentDescription = stringResource(R.string.content_description_x),
-                                    onClick = {
-                                        onUrlClick(urlX)
-                                    },
-                                ),
-                            ),
-                        )
-                    }
-                    Copyright(
-                        modifier = Modifier.fillMaxWidth(),
-                        onLogoClick = {
-                            onUrlClick(urlStrigate)
-                        },
-                    )
-                }
+                AboutContent(
+                    onBuildClick = onBuildClick,
+                    onUrlClick = onUrlClick,
+                    onCopyText = onCopyText,
+                )
             }
         },
     )
+}
+
+@Composable
+private fun AboutContent(
+    onBuildClick: () -> Unit,
+    onUrlClick: (String) -> Unit,
+    onCopyText: (String) -> Unit,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+    val urlStrigate = stringResource(R.string.url_strigate)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = refineryDimens.spacingMediumAlt)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        StaticSettingsSection(
+            icon = Icons.Outlined.Info,
+            title = stringResource(R.string.settings_section_app_info),
+        ) {
+            TextSetting(
+                text = stringResource(R.string.settings_title_build),
+                description = BuildConfig.VERSION_NAME,
+                onLongClick = {
+                    onCopyText(BuildConfig.VERSION_NAME)
+                },
+            ) {
+                onBuildClick()
+            }
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        StaticSettingsSection(
+            icon = Icons.Outlined.Link,
+            title = stringResource(R.string.settings_section_links),
+        ) {
+            val urlWebsite = stringResource(R.string.url_website)
+            val urlGitHub = stringResource(R.string.url_github)
+            val urlPrivacy = stringResource(R.string.url_privacy)
+            val urlLicense = stringResource(R.string.url_license)
+            TextSetting(
+                text = stringResource(R.string.settings_title_website),
+                description = stringResource(R.string.settings_description_website),
+                onLongClick = {
+                    onCopyText(urlWebsite)
+                },
+            ) {
+                onUrlClick(urlWebsite)
+            }
+            TextSetting(
+                text = stringResource(R.string.settings_title_github),
+                description = stringResource(R.string.settings_description_github),
+                onLongClick = {
+                    onCopyText(urlGitHub)
+                },
+            ) {
+                onUrlClick(urlGitHub)
+            }
+            TextSetting(
+                text = stringResource(R.string.settings_title_privacy),
+                description = stringResource(R.string.settings_description_privacy),
+                onLongClick = {
+                    onCopyText(urlPrivacy)
+                },
+            ) {
+                onUrlClick(urlPrivacy)
+            }
+            TextSetting(
+                text = stringResource(R.string.settings_title_license),
+                description = stringResource(R.string.settings_description_license),
+                onLongClick = {
+                    onCopyText(urlLicense)
+                },
+            ) {
+                onUrlClick(urlLicense)
+            }
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        StaticSettingsSection {
+            val urlGitHubStrigate = stringResource(R.string.url_github_strigate)
+            val urlX = stringResource(R.string.url_x)
+            SettingsIconRow(
+                items = listOf(
+                    SettingsIconRowItem(
+                        painter = painterResource(R.drawable.ic_github),
+                        contentDescription = stringResource(R.string.content_description_github),
+                        onClick = {
+                            onUrlClick(urlGitHubStrigate)
+                        },
+                    ),
+                    SettingsIconRowItem(
+                        painter = painterResource(R.drawable.ic_x),
+                        contentDescription = stringResource(R.string.content_description_x),
+                        onClick = {
+                            onUrlClick(urlX)
+                        },
+                    ),
+                ),
+            )
+        }
+        Copyright(
+            modifier = Modifier.fillMaxWidth(),
+            onLogoClick = {
+                onUrlClick(urlStrigate)
+            },
+        )
+    }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/CookiesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/CookiesScreen.kt
@@ -18,10 +18,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.Cookie
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
@@ -29,11 +27,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,10 +39,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.toast
 import org.strigate.ferrot.presentation.Screen
+import org.strigate.ferrot.presentation.component.BackTopAppBar
 import org.strigate.ferrot.presentation.component.ConfirmDialog
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
@@ -58,7 +56,6 @@ import org.strigate.ferrot.presentation.viewmodel.CookiesViewModel
 import org.strigate.refinery.component.settings.StaticSettingsSection
 import org.strigate.refinery.component.settings.TextSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
-import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @Composable
 fun CookiesScreen(
@@ -68,7 +65,7 @@ fun CookiesScreen(
 ) {
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val importLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
@@ -104,7 +101,6 @@ fun CookiesScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun CookiesScreenContent(
     uiState: CookiesUiState,
@@ -114,8 +110,6 @@ internal fun CookiesScreenContent(
     onDeleteCookieSet: (CookieSetUiData) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val refineryDimens = LocalRefineryDimens.current
-
     var cookieSetPendingDelete by remember { mutableStateOf<CookieSetUiData?>(null) }
 
     cookieSetPendingDelete?.let { cookieSet ->
@@ -141,27 +135,16 @@ internal fun CookiesScreenContent(
         )
     }
     Scaffold(
+        modifier = modifier,
         topBar = {
-            TopAppBar(
-                colors = RefineryTopAppBarDefaults.colors(),
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBackClick,
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_description_back),
-                        )
-                    }
-                },
-                title = {
-                    Text(text = stringResource(R.string.screen_title_cookies))
-                },
+            BackTopAppBar(
+                title = stringResource(R.string.screen_title_cookies),
+                onBackClick = onBackClick,
             )
         },
         content = { contentPadding ->
             Surface(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding),
                 color = MaterialTheme.colorScheme.background,
@@ -175,50 +158,12 @@ internal fun CookiesScreenContent(
                     }
 
                     is CookiesUiState.Data -> {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = refineryDimens.spacingMediumAlt)
-                                .verticalScroll(rememberScrollState()),
-                        ) {
-                            StaticSettingsSection(
-                                icon = Icons.Outlined.Cookie,
-                                title = stringResource(R.string.cookies_section_add),
-                            ) {
-                                TextSetting(
-                                    text = stringResource(R.string.cookies_title_get_cookies),
-                                    description = stringResource(R.string.cookies_description_get_cookies),
-                                    onClick = onNavigateToGetCookies,
-                                )
-                                TextSetting(
-                                    text = stringResource(R.string.cookies_title_import_file),
-                                    description = stringResource(R.string.cookies_description_import_file),
-                                    onClick = onImportFile,
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                            StaticSettingsSection(
-                                icon = Icons.Outlined.Cookie,
-                                title = stringResource(R.string.cookies_section_saved),
-                            ) {
-                                if (state.cookieSets.isEmpty()) {
-                                    TextSetting(
-                                        text = stringResource(R.string.cookies_empty_title),
-                                        description = stringResource(R.string.cookies_empty_description),
-                                        enabled = false,
-                                    )
-                                } else {
-                                    state.cookieSets.forEach { cookieSet ->
-                                        CookieSetSetting(
-                                            cookieSet = cookieSet,
-                                            description = cookieSetDescription(cookieSet),
-                                            onDelete = { cookieSetPendingDelete = cookieSet },
-                                        )
-                                    }
-                                }
-                            }
-                            Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
-                        }
+                        CookiesContent(
+                            cookieSets = state.cookieSets,
+                            onNavigateToGetCookies = onNavigateToGetCookies,
+                            onImportFile = onImportFile,
+                            onRequestDelete = { cookieSetPendingDelete = it },
+                        )
                     }
 
                     is CookiesUiState.Error -> CookiesError()
@@ -324,4 +269,59 @@ private fun clearWebViewData() {
         cookieManager.flush()
     }
     WebStorage.getInstance().deleteAllData()
+}
+
+@Composable
+private fun CookiesContent(
+    cookieSets: List<CookieSetUiData>,
+    onNavigateToGetCookies: () -> Unit,
+    onImportFile: () -> Unit,
+    onRequestDelete: (CookieSetUiData) -> Unit,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = refineryDimens.spacingMediumAlt)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        StaticSettingsSection(
+            icon = Icons.Outlined.Cookie,
+            title = stringResource(R.string.cookies_section_add),
+        ) {
+            TextSetting(
+                text = stringResource(R.string.cookies_title_get_cookies),
+                description = stringResource(R.string.cookies_description_get_cookies),
+                onClick = onNavigateToGetCookies,
+            )
+            TextSetting(
+                text = stringResource(R.string.cookies_title_import_file),
+                description = stringResource(R.string.cookies_description_import_file),
+                onClick = onImportFile,
+            )
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        StaticSettingsSection(
+            icon = Icons.Outlined.Cookie,
+            title = stringResource(R.string.cookies_section_saved),
+        ) {
+            if (cookieSets.isEmpty()) {
+                TextSetting(
+                    text = stringResource(R.string.cookies_empty_title),
+                    description = stringResource(R.string.cookies_empty_description),
+                    enabled = false,
+                )
+            } else {
+                cookieSets.forEach { cookieSet ->
+                    CookieSetSetting(
+                        cookieSet = cookieSet,
+                        description = cookieSetDescription(cookieSet),
+                        onDelete = { onRequestDelete(cookieSet) },
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
+    }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/SettingsScreen.kt
@@ -9,34 +9,30 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Cookie
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.SwapHoriz
 import androidx.compose.material.icons.outlined.SystemUpdate
 import androidx.compose.material.icons.outlined.Tune
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import org.strigate.ferrot.R
 import org.strigate.ferrot.presentation.Screen
+import org.strigate.ferrot.presentation.component.BackTopAppBar
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
+import org.strigate.ferrot.presentation.model.SettingsUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import org.strigate.ferrot.presentation.viewmodel.SettingsViewModel
 import org.strigate.refinery.component.settings.DropdownSetting
@@ -44,7 +40,6 @@ import org.strigate.refinery.component.settings.ExpandableSettingsSection
 import org.strigate.refinery.component.settings.SwitchSetting
 import org.strigate.refinery.component.settings.TextNavigateSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
-import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @Composable
 fun SettingsScreen(
@@ -53,7 +48,7 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -74,7 +69,6 @@ fun SettingsScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SettingsScreenContent(
     uiState: SettingsUiState,
@@ -89,44 +83,17 @@ internal fun SettingsScreenContent(
     onNavigateToAbout: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val refineryDimens = LocalRefineryDimens.current
-    val noneSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_none)
-    val archiveSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_archive)
-    val seenSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_seen)
-    val deleteSwipeActionLabel = stringResource(R.string.settings_value_swipe_action_delete)
-    val swipeActionLabel: (DownloadSwipeActionUiData) -> String = { action ->
-        when (action) {
-            DownloadSwipeActionUiData.NONE -> noneSwipeActionLabel
-            DownloadSwipeActionUiData.ARCHIVE -> archiveSwipeActionLabel
-            DownloadSwipeActionUiData.SEEN -> seenSwipeActionLabel
-            DownloadSwipeActionUiData.DELETE -> deleteSwipeActionLabel
-        }
-    }
-
     Scaffold(
+        modifier = modifier,
         topBar = {
-            TopAppBar(
-                colors = RefineryTopAppBarDefaults.colors(),
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBackClick,
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_description_back),
-                        )
-                    }
-                },
-                title = {
-                    Text(
-                        text = stringResource(R.string.screen_title_settings),
-                    )
-                },
+            BackTopAppBar(
+                title = stringResource(R.string.screen_title_settings),
+                onBackClick = onBackClick,
             )
         },
         content = { contentPadding ->
             Surface(
-                modifier = modifier.padding(contentPadding),
+                modifier = Modifier.padding(contentPadding),
                 color = MaterialTheme.colorScheme.background,
             ) {
                 when (val state = uiState) {
@@ -138,90 +105,17 @@ internal fun SettingsScreenContent(
                     }
 
                     is SettingsUiState.Data -> {
-                        with(state.data) {
-                            Column(
-                                modifier = Modifier
-                                    .padding(horizontal = refineryDimens.spacingMediumAlt)
-                                    .verticalScroll(rememberScrollState()),
-                            ) {
-                                ExpandableSettingsSection(
-                                    icon = Icons.Outlined.Tune,
-                                    title = stringResource(id = R.string.settings_section_general),
-                                    initialExpanded = true,
-                                ) {
-                                    SwitchSetting(
-                                        text = stringResource(id = R.string.settings_title_download_wifi_only),
-                                        description = stringResource(id = R.string.settings_description_download_wifi_only),
-                                        checked = wifiOnlyDownloadsEnabled,
-                                        onCheckedChange = onSetWifiOnlyDownloadsEnabled,
-                                    )
-                                    Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                                    SwitchSetting(
-                                        text = stringResource(id = R.string.settings_title_automatic_duplicate_deletion),
-                                        description = stringResource(id = R.string.settings_description_automatic_duplicate_deletion),
-                                        checked = automaticDuplicateDownloadDeletionEnabled,
-                                        onCheckedChange = onSetAutomaticDuplicateDownloadDeletionEnabled,
-                                    )
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                                ExpandableSettingsSection(
-                                    icon = Icons.Outlined.Cookie,
-                                    title = stringResource(id = R.string.settings_section_cookies),
-                                    initialExpanded = true,
-                                ) {
-                                    SwitchSetting(
-                                        text = stringResource(id = R.string.settings_title_use_cookies),
-                                        description = stringResource(id = R.string.settings_description_use_cookies),
-                                        checked = cookiesEnabled,
-                                        onCheckedChange = onSetCookiesEnabled,
-                                    )
-                                    TextNavigateSetting(
-                                        text = stringResource(R.string.settings_navigate_title_manage_cookies),
-                                        description = stringResource(R.string.settings_description_manage_cookies),
-                                    ) {
-                                        onNavigateToCookies()
-                                    }
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                                ExpandableSettingsSection(
-                                    icon = Icons.Outlined.SwapHoriz,
-                                    title = stringResource(id = R.string.settings_section_swipe_actions),
-                                    initialExpanded = true,
-                                ) {
-                                    DropdownSetting(
-                                        text = stringResource(R.string.settings_title_swipe_left),
-                                        description = stringResource(R.string.settings_description_swipe_left),
-                                        selectedOption = leftSwipeAction,
-                                        options = DownloadSwipeActionUiData.entries,
-                                        optionText = { option -> swipeActionLabel(option) },
-                                        onOptionSelected = onSetLeftSwipeAction,
-                                    )
-                                    DropdownSetting(
-                                        text = stringResource(R.string.settings_title_swipe_right),
-                                        description = stringResource(R.string.settings_description_swipe_right),
-                                        selectedOption = rightSwipeAction,
-                                        options = DownloadSwipeActionUiData.entries,
-                                        optionText = { option -> swipeActionLabel(option) },
-                                        onOptionSelected = onSetRightSwipeAction,
-                                    )
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                                TextNavigateSetting(
-                                    icon = Icons.Outlined.SystemUpdate,
-                                    text = stringResource(R.string.settings_navigate_title_updates),
-                                ) {
-                                    onNavigateToUpdates()
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                                TextNavigateSetting(
-                                    icon = Icons.Outlined.Info,
-                                    text = stringResource(R.string.settings_navigate_title_about),
-                                ) {
-                                    onNavigateToAbout()
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
-                            }
-                        }
+                        SettingsContent(
+                            data = state.data,
+                            onSetWifiOnlyDownloadsEnabled = onSetWifiOnlyDownloadsEnabled,
+                            onSetAutomaticDuplicateDownloadDeletionEnabled = onSetAutomaticDuplicateDownloadDeletionEnabled,
+                            onSetCookiesEnabled = onSetCookiesEnabled,
+                            onSetLeftSwipeAction = onSetLeftSwipeAction,
+                            onSetRightSwipeAction = onSetRightSwipeAction,
+                            onNavigateToCookies = onNavigateToCookies,
+                            onNavigateToUpdates = onNavigateToUpdates,
+                            onNavigateToAbout = onNavigateToAbout,
+                        )
                     }
 
                     is SettingsUiState.Error -> SettingsError()
@@ -239,5 +133,130 @@ private fun SettingsError(
         modifier = modifier.fillMaxSize(),
         alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_settings),
+    )
+}
+
+@Composable
+private fun SettingsContent(
+    data: SettingsUiData,
+    onSetWifiOnlyDownloadsEnabled: (Boolean) -> Unit,
+    onSetAutomaticDuplicateDownloadDeletionEnabled: (Boolean) -> Unit,
+    onSetCookiesEnabled: (Boolean) -> Unit,
+    onSetLeftSwipeAction: (DownloadSwipeActionUiData) -> Unit,
+    onSetRightSwipeAction: (DownloadSwipeActionUiData) -> Unit,
+    onNavigateToCookies: () -> Unit,
+    onNavigateToUpdates: () -> Unit,
+    onNavigateToAbout: () -> Unit,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+
+    Column(
+        modifier = Modifier
+            .padding(horizontal = refineryDimens.spacingMediumAlt)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        ExpandableSettingsSection(
+            icon = Icons.Outlined.Tune,
+            title = stringResource(id = R.string.settings_section_general),
+            initialExpanded = true,
+        ) {
+            SwitchSetting(
+                text = stringResource(id = R.string.settings_title_download_wifi_only),
+                description = stringResource(id = R.string.settings_description_download_wifi_only),
+                checked = data.wifiOnlyDownloadsEnabled,
+                onCheckedChange = onSetWifiOnlyDownloadsEnabled,
+            )
+            Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+            SwitchSetting(
+                text = stringResource(id = R.string.settings_title_automatic_duplicate_deletion),
+                description = stringResource(id = R.string.settings_description_automatic_duplicate_deletion),
+                checked = data.automaticDuplicateDownloadDeletionEnabled,
+                onCheckedChange = onSetAutomaticDuplicateDownloadDeletionEnabled,
+            )
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        ExpandableSettingsSection(
+            icon = Icons.Outlined.Cookie,
+            title = stringResource(id = R.string.settings_section_cookies),
+            initialExpanded = true,
+        ) {
+            SwitchSetting(
+                text = stringResource(id = R.string.settings_title_use_cookies),
+                description = stringResource(id = R.string.settings_description_use_cookies),
+                checked = data.cookiesEnabled,
+                onCheckedChange = onSetCookiesEnabled,
+            )
+            TextNavigateSetting(
+                text = stringResource(R.string.settings_navigate_title_manage_cookies),
+                description = stringResource(R.string.settings_description_manage_cookies),
+            ) {
+                onNavigateToCookies()
+            }
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        SwipeActionSettings(
+            leftSwipeAction = data.leftSwipeAction,
+            rightSwipeAction = data.rightSwipeAction,
+            onSetLeftSwipeAction = onSetLeftSwipeAction,
+            onSetRightSwipeAction = onSetRightSwipeAction,
+        )
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        TextNavigateSetting(
+            icon = Icons.Outlined.SystemUpdate,
+            text = stringResource(R.string.settings_navigate_title_updates),
+        ) {
+            onNavigateToUpdates()
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        TextNavigateSetting(
+            icon = Icons.Outlined.Info,
+            text = stringResource(R.string.settings_navigate_title_about),
+        ) {
+            onNavigateToAbout()
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingMedium))
+    }
+}
+
+@Composable
+private fun SwipeActionSettings(
+    leftSwipeAction: DownloadSwipeActionUiData,
+    rightSwipeAction: DownloadSwipeActionUiData,
+    onSetLeftSwipeAction: (DownloadSwipeActionUiData) -> Unit,
+    onSetRightSwipeAction: (DownloadSwipeActionUiData) -> Unit,
+) {
+    ExpandableSettingsSection(
+        icon = Icons.Outlined.SwapHoriz,
+        title = stringResource(id = R.string.settings_section_swipe_actions),
+        initialExpanded = true,
+    ) {
+        DropdownSetting(
+            text = stringResource(R.string.settings_title_swipe_left),
+            description = stringResource(R.string.settings_description_swipe_left),
+            selectedOption = leftSwipeAction,
+            options = DownloadSwipeActionUiData.entries,
+            optionText = { option -> swipeActionLabel(option) },
+            onOptionSelected = onSetLeftSwipeAction,
+        )
+        DropdownSetting(
+            text = stringResource(R.string.settings_title_swipe_right),
+            description = stringResource(R.string.settings_description_swipe_right),
+            selectedOption = rightSwipeAction,
+            options = DownloadSwipeActionUiData.entries,
+            optionText = { option -> swipeActionLabel(option) },
+            onOptionSelected = onSetRightSwipeAction,
+        )
+    }
+}
+
+@Composable
+private fun swipeActionLabel(action: DownloadSwipeActionUiData): String {
+    return stringResource(
+        when (action) {
+            DownloadSwipeActionUiData.NONE -> R.string.settings_value_swipe_action_none
+            DownloadSwipeActionUiData.ARCHIVE -> R.string.settings_value_swipe_action_archive
+            DownloadSwipeActionUiData.SEEN -> R.string.settings_value_swipe_action_seen
+            DownloadSwipeActionUiData.DELETE -> R.string.settings_value_swipe_action_delete
+        },
     )
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/UpdatesScreen.kt
@@ -9,31 +9,27 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.SystemUpdate
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.strigate.ferrot.R
 import org.strigate.ferrot.extensions.toast
+import org.strigate.ferrot.presentation.component.BackTopAppBar
 import org.strigate.ferrot.presentation.component.state.ErrorState
 import org.strigate.ferrot.presentation.component.state.LoadingState
 import org.strigate.ferrot.presentation.event.UpdatesEvent
+import org.strigate.ferrot.presentation.model.UpdatesUiData
 import org.strigate.ferrot.presentation.state.UpdatesUiState
 import org.strigate.ferrot.presentation.util.UiFormatter
 import org.strigate.ferrot.presentation.viewmodel.UpdatesViewModel
@@ -41,7 +37,6 @@ import org.strigate.refinery.component.settings.StaticSettingsSection
 import org.strigate.refinery.component.settings.SwitchSetting
 import org.strigate.refinery.component.settings.TextSetting
 import org.strigate.refinery.theme.LocalRefineryDimens
-import org.strigate.refinery.theme.RefineryTopAppBarDefaults
 
 @Composable
 fun UpdatesScreen(
@@ -50,7 +45,7 @@ fun UpdatesScreen(
 ) {
     val context = LocalContext.current
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.logShown()
@@ -76,7 +71,6 @@ fun UpdatesScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun UpdatesScreenContent(
     uiState: UpdatesUiState,
@@ -87,31 +81,17 @@ internal fun UpdatesScreenContent(
     onCheckForDependencyUpdates: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val refineryDimens = LocalRefineryDimens.current
-    val context = LocalContext.current
-
     Scaffold(
+        modifier = modifier,
         topBar = {
-            TopAppBar(
-                colors = RefineryTopAppBarDefaults.colors(),
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBackClick,
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_description_back),
-                        )
-                    }
-                },
-                title = {
-                    Text(text = stringResource(R.string.screen_title_updates))
-                },
+            BackTopAppBar(
+                title = stringResource(R.string.screen_title_updates),
+                onBackClick = onBackClick,
             )
         },
         content = { contentPadding ->
             Surface(
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding),
                 color = MaterialTheme.colorScheme.background,
@@ -125,65 +105,13 @@ internal fun UpdatesScreenContent(
                     }
 
                     is UpdatesUiState.Data -> {
-                        with(state.data) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = refineryDimens.spacingMediumAlt)
-                                    .verticalScroll(rememberScrollState()),
-                            ) {
-                                StaticSettingsSection(
-                                    icon = Icons.Outlined.SystemUpdate,
-                                    title = stringResource(R.string.settings_section_app),
-                                ) {
-                                    SwitchSetting(
-                                        text = stringResource(R.string.settings_title_automatic_updates),
-                                        description = stringResource(R.string.settings_description_automatic_updates),
-                                        checked = settings.automaticAppUpdatesEnabled,
-                                        onCheckedChange = onSetAutomaticAppUpdatesEnabled,
-                                    )
-                                    TextSetting(
-                                        text = stringResource(R.string.settings_title_check_now),
-                                        description = stringResource(R.string.settings_description_check_for_app_updates),
-                                    ) {
-                                        onCheckForAvailableUpdate()
-                                    }
-                                    TextSetting(
-                                        text = stringResource(R.string.settings_title_last_checked),
-                                        description = UiFormatter.formatLastCheckedTime(
-                                            context,
-                                            info.lastAvailableUpdateCheckMillis,
-                                        ),
-                                    )
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                                StaticSettingsSection(
-                                    icon = Icons.Outlined.Extension,
-                                    title = stringResource(R.string.settings_section_dependencies),
-                                ) {
-                                    SwitchSetting(
-                                        text = stringResource(R.string.settings_title_automatic_updates),
-                                        description = stringResource(R.string.settings_description_automatic_dependency_updates),
-                                        checked = settings.automaticDependencyUpdatesEnabled,
-                                        onCheckedChange = onSetAutomaticDependencyUpdatesEnabled,
-                                    )
-                                    TextSetting(
-                                        text = stringResource(R.string.settings_title_check_now),
-                                        description = stringResource(R.string.settings_description_check_dependencies_now),
-                                    ) {
-                                        onCheckForDependencyUpdates()
-                                    }
-                                    TextSetting(
-                                        text = stringResource(R.string.settings_title_last_checked),
-                                        description = UiFormatter.formatLastCheckedTime(
-                                            context,
-                                            info.lastDependencyUpdateCheckMillis,
-                                        ),
-                                    )
-                                }
-                                Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
-                            }
-                        }
+                        UpdatesContent(
+                            data = state.data,
+                            onSetAutomaticAppUpdatesEnabled = onSetAutomaticAppUpdatesEnabled,
+                            onCheckForAvailableUpdate = onCheckForAvailableUpdate,
+                            onSetAutomaticDependencyUpdatesEnabled = onSetAutomaticDependencyUpdatesEnabled,
+                            onCheckForDependencyUpdates = onCheckForDependencyUpdates,
+                        )
                     }
 
                     is UpdatesUiState.Error -> UpdatesError()
@@ -202,4 +130,74 @@ private fun UpdatesError(
         alignment = Alignment.Center,
         text = stringResource(R.string.error_failed_to_load_update_settings),
     )
+}
+
+@Composable
+private fun UpdatesContent(
+    data: UpdatesUiData,
+    onSetAutomaticAppUpdatesEnabled: (Boolean) -> Unit,
+    onCheckForAvailableUpdate: () -> Unit,
+    onSetAutomaticDependencyUpdatesEnabled: (Boolean) -> Unit,
+    onCheckForDependencyUpdates: () -> Unit,
+) {
+    val refineryDimens = LocalRefineryDimens.current
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = refineryDimens.spacingMediumAlt)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        StaticSettingsSection(
+            icon = Icons.Outlined.SystemUpdate,
+            title = stringResource(R.string.settings_section_app),
+        ) {
+            SwitchSetting(
+                text = stringResource(R.string.settings_title_automatic_updates),
+                description = stringResource(R.string.settings_description_automatic_updates),
+                checked = data.settings.automaticAppUpdatesEnabled,
+                onCheckedChange = onSetAutomaticAppUpdatesEnabled,
+            )
+            TextSetting(
+                text = stringResource(R.string.settings_title_check_now),
+                description = stringResource(R.string.settings_description_check_for_app_updates),
+            ) {
+                onCheckForAvailableUpdate()
+            }
+            TextSetting(
+                text = stringResource(R.string.settings_title_last_checked),
+                description = UiFormatter.formatLastCheckedTime(
+                    context,
+                    data.info.lastAvailableUpdateCheckMillis,
+                ),
+            )
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+        StaticSettingsSection(
+            icon = Icons.Outlined.Extension,
+            title = stringResource(R.string.settings_section_dependencies),
+        ) {
+            SwitchSetting(
+                text = stringResource(R.string.settings_title_automatic_updates),
+                description = stringResource(R.string.settings_description_automatic_dependency_updates),
+                checked = data.settings.automaticDependencyUpdatesEnabled,
+                onCheckedChange = onSetAutomaticDependencyUpdatesEnabled,
+            )
+            TextSetting(
+                text = stringResource(R.string.settings_title_check_now),
+                description = stringResource(R.string.settings_description_check_dependencies_now),
+            ) {
+                onCheckForDependencyUpdates()
+            }
+            TextSetting(
+                text = stringResource(R.string.settings_title_last_checked),
+                description = UiFormatter.formatLastCheckedTime(
+                    context,
+                    data.info.lastDependencyUpdateCheckMillis,
+                ),
+            )
+        }
+        Spacer(modifier = Modifier.height(refineryDimens.spacingSmall))
+    }
 }

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPageContent.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPageContent.kt
@@ -75,7 +75,7 @@ internal fun DownloadPageContent(
     onSaveClick: () -> Unit,
     onShareClick: () -> Unit,
     onRetryClick: () -> Unit,
-    onRefreshMetadataClick: () -> Unit,
+    onPageVisible: () -> Unit,
     onUrlClick: (String) -> Unit,
     onCopyText: (String, String) -> Unit,
 ) {
@@ -140,23 +140,20 @@ internal fun DownloadPageContent(
             val canActOnSelected = status == DownloadStatusUiData.COMPLETED
                     && !selectedPath.isNullOrBlank()
 
-            val hasThumbnailFile = (
-                    metadata?.thumbnailFilePath
-                        ?.let(::File)
-                        ?.let { it.exists() && it.length() > 0L }
-                    ) == true
-
-            val needsMetadataRefresh = status == DownloadStatusUiData.COMPLETED &&
-                    !hasThumbnailFile
-
-            LaunchedEffect(id, isCurrentPage, needsMetadataRefresh) {
-                if (isCurrentPage && needsMetadataRefresh) {
-                    onRefreshMetadataClick()
+            LaunchedEffect(
+                id,
+                isCurrentPage,
+                status,
+                metadata?.thumbnailFilePath,
+                thumbnailAvailable
+            ) {
+                if (isCurrentPage) {
+                    onPageVisible()
                 }
             }
 
             ThumbnailCard(
-                thumbnailFilePath = metadata?.thumbnailFilePath,
+                thumbnailFilePath = metadata?.thumbnailFilePath.takeIf { thumbnailAvailable },
                 durationSeconds = metadata?.durationSeconds,
                 isCompleted = status == DownloadStatusUiData.COMPLETED,
                 showRetry = status == DownloadStatusUiData.FAILED || status == DownloadStatusUiData.STOPPED,
@@ -325,7 +322,6 @@ private fun ThumbnailCard(
     val dimens = LocalDimens.current
     val thumbnailFile = thumbnailFilePath
         ?.let { File(it) }
-        ?.takeIf { it.exists() && it.length() > 0 }
 
     val thumbnailContentDescription = stringResource(R.string.content_description_thumbnail)
     val hasThumbnailFile = thumbnailFile != null

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPager.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadPager.kt
@@ -41,7 +41,7 @@ internal fun DownloadPager(
     onSaveClick: (Long) -> Unit,
     onShareClick: (Long) -> Unit,
     onRetryClick: (Long) -> Unit,
-    onRefreshMetadataClick: (Long) -> Unit,
+    onPageVisible: (Long) -> Unit,
     onUrlClick: (String) -> Unit,
     onCopyText: (String, String) -> Unit,
     pagePadding: PaddingValues,
@@ -150,8 +150,8 @@ internal fun DownloadPager(
                         onRetryClick = {
                             onRetryClick(download.id)
                         },
-                        onRefreshMetadataClick = {
-                            onRefreshMetadataClick(download.id)
+                        onPageVisible = {
+                            onPageVisible(download.id)
                         },
                         onUrlClick = onUrlClick,
                         onCopyText = onCopyText,

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/download/DownloadScreen.kt
@@ -142,7 +142,7 @@ fun DownloadScreen(
             view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
             viewModel.retryDownload(downloadId)
         },
-        onRefreshMetadataClick = viewModel::refreshDownloadMetadata,
+        onPageVisible = viewModel::onPageVisible,
         onUrlClick = uriHandler::openUri,
         onCopyText = context::copyToClipboard,
         modifier = modifier,
@@ -168,7 +168,7 @@ internal fun DownloadScreenContent(
     onSaveClick: (Long) -> Unit,
     onShareClick: (Long) -> Unit,
     onRetryClick: (Long) -> Unit,
-    onRefreshMetadataClick: (Long) -> Unit,
+    onPageVisible: (Long) -> Unit,
     onUrlClick: (String) -> Unit,
     onCopyText: (String, String) -> Unit,
     modifier: Modifier = Modifier,
@@ -286,7 +286,7 @@ internal fun DownloadScreenContent(
                         onSaveClick = onSaveClick,
                         onShareClick = onShareClick,
                         onRetryClick = onRetryClick,
-                        onRefreshMetadataClick = onRefreshMetadataClick,
+                        onPageVisible = onPageVisible,
                         onUrlClick = onUrlClick,
                         onCopyText = onCopyText,
                         pagePadding = PaddingValues(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsScreen.kt
@@ -11,10 +11,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,7 +20,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -163,15 +160,12 @@ internal fun DownloadsScreenContent(
     val searchFocusRequester = remember { FocusRequester() }
     val snackbarHostState = remember { SnackbarHostState() }
     var searchActive by rememberSaveable { mutableStateOf(false) }
-    var selectedIds by rememberSaveable { mutableStateOf(setOf<Long>()) }
-    var dismissingIds by rememberSaveable { mutableStateOf(setOf<Long>()) }
-    var archivingIds by rememberSaveable { mutableStateOf(setOf<Long>()) }
-    var snackbarUndoDeleteIds by rememberSaveable { mutableStateOf(setOf<Long>()) }
-    val downloadsData = (uiState as? DownloadsUiState.Data)?.data
+    val selection = rememberSaveable(saver = DownloadsSelectionState.Saver) {
+        DownloadsSelectionState()
+    }
 
+    val downloadsData = (uiState as? DownloadsUiState.Data)?.data
     val bulkSelectedLabel = stringResource(R.string.bulk_selected)
-    val snackbarSingleDeleteMessage = stringResource(R.string.snackbar_delete_single_delete)
-    val snackbarBulkDeleteMessage = stringResource(R.string.snackbar_bulk_delete_bulk_delete)
 
     BackHandler(enabled = searchActive) {
         searchActive = false
@@ -190,26 +184,25 @@ internal fun DownloadsScreenContent(
     val allIds = downloads.map(DownloadItemUiData::id).toSet()
     val hasDownloads = allIds.isNotEmpty()
     val allSelected = areAllItemsSelected(
-        selectedIds = selectedIds,
+        selectedIds = selection.selectedIds,
         availableIds = allIds,
     )
-    val selectionMode = selectedIds.isNotEmpty()
+    val selectionMode = selection.selectedIds.isNotEmpty()
     val pendingDeleteIds = downloadsData?.pendingDeleteIds.orEmpty()
-    val hasPendingDeletes = pendingDeleteIds.isNotEmpty()
     val retryFailedDownloadIds = downloadsData?.retryFailedDownloadIds.orEmpty()
     val hasFailedDownloads = retryFailedDownloadIds.isNotEmpty()
     val hasActiveDownloads = remember(downloads) {
         downloads.any { it.status.isActive }
     }
-    val selectedBytes = remember(downloads, selectedIds) {
+    val selectedBytes = remember(downloads, selection.selectedIds) {
         downloads
             .asSequence()
-            .filter { it.id in selectedIds }
+            .filter { it.id in selection.selectedIds }
             .sumOf { it.bytesDownloaded }
     }
-    val selectionCountTitle = remember(selectedIds, bulkSelectedLabel) {
+    val selectionCountTitle = remember(selection.selectedIds, bulkSelectedLabel) {
         buildString {
-            append(selectedIds.size)
+            append(selection.selectedIds.size)
             append(' ')
             append(bulkSelectedLabel)
         }
@@ -217,11 +210,10 @@ internal fun DownloadsScreenContent(
     val selectionSizeTitle = remember(selectedBytes) {
         UiFormatter.formatBytes(selectedBytes)
     }
-    val shouldMarkSelectionSeen = remember(downloads, selectedIds) {
-        downloads.any { it.id in selectedIds && !it.seen }
+    val shouldMarkSelectionSeen = remember(downloads, selection.selectedIds) {
+        downloads.any { it.id in selection.selectedIds && !it.seen }
     }
 
-    val snackbarUndoActionLabel = stringResource(R.string.snackbar_delete_undo)
     val onScrollToTop: () -> Unit = {
         coroutineScope.launch {
             lazyGridState.animateScrollToItem(0)
@@ -236,23 +228,14 @@ internal fun DownloadsScreenContent(
     }
 
     BackHandler(enabled = selectionMode) {
-        selectedIds = emptySet()
+        selection.selectedIds = emptySet()
     }
     LaunchedEffect(downloadsData != null, allIds) {
-        selectedIds = pruneSelectedItemIds(
-            selectedIds = selectedIds,
-            availableIds = allIds.takeIf { downloadsData != null },
-        )
+        selection.prune(allIds.takeIf { downloadsData != null })
     }
     PendingDeleteSnackbarEffect(
         pendingDeleteIds = pendingDeleteIds,
-        hasPendingDeletes = hasPendingDeletes,
-        snackbarUndoDeleteIds = snackbarUndoDeleteIds,
-        onSnackbarUndoDeleteIdsChange = { snackbarUndoDeleteIds = it },
         snackbarHostState = snackbarHostState,
-        snackbarSingleDeleteMessage = snackbarSingleDeleteMessage,
-        snackbarBulkDeleteMessage = snackbarBulkDeleteMessage,
-        snackbarUndoActionLabel = snackbarUndoActionLabel,
         onUndoPendingDelete = { ids ->
             onMarkDownloadsPendingDelete(ids, false)
         },
@@ -269,32 +252,20 @@ internal fun DownloadsScreenContent(
                     selectionSizeTitle = selectionSizeTitle,
                     shouldMarkSelectionSeen = shouldMarkSelectionSeen,
                     isArchived = isArchived,
-                    onClearSelection = { selectedIds = emptySet() },
+                    onClearSelection = { selection.selectedIds = emptySet() },
                     onToggleAll = {
-                        selectedIds = if (allSelected) emptySet() else allIds
+                        selection.selectedIds = if (allSelected) emptySet() else allIds
                     },
-                    onToggleSeen = { onToggleDownloadsSeen(selectedIds) },
+                    onToggleSeen = { onToggleDownloadsSeen(selection.selectedIds) },
                     onArchive = {
-                        val selectedItemIds = splitSelectedItemIds(
-                            selectedIds = selectedIds,
-                            visibleItemKeys = lazyGridState.layoutInfo.visibleItemsInfo.map { it.key },
-                        )
-                        archivingIds += selectedItemIds.visible
-                        if (selectedItemIds.offscreen.isNotEmpty()) {
-                            onUpdateDownloadsArchived(selectedItemIds.offscreen, !isArchived)
+                        selection.archiveSelected(lazyGridState.layoutInfo.visibleItemsInfo.map { it.key }) { ids ->
+                            onUpdateDownloadsArchived(ids, !isArchived)
                         }
-                        selectedIds = emptySet()
                     },
                     onDelete = {
-                        val selectedItemIds = splitSelectedItemIds(
-                            selectedIds = selectedIds,
-                            visibleItemKeys = lazyGridState.layoutInfo.visibleItemsInfo.map { it.key },
-                        )
-                        dismissingIds += selectedItemIds.visible
-                        if (selectedItemIds.offscreen.isNotEmpty()) {
-                            onMarkDownloadsPendingDelete(selectedItemIds.offscreen, true)
+                        selection.deleteSelected(lazyGridState.layoutInfo.visibleItemsInfo.map { it.key }) { ids ->
+                            onMarkDownloadsPendingDelete(ids, true)
                         }
-                        selectedIds = emptySet()
                     },
                 )
             } else {
@@ -312,7 +283,7 @@ internal fun DownloadsScreenContent(
                     onNavigateBack = onNavigateBack,
                     onNavigateToArchived = onNavigateToArchived,
                     onNavigateToSettings = onNavigateToSettings,
-                    onSelectAll = { selectedIds = allIds },
+                    onSelectAll = { selection.selectedIds = allIds },
                     onScrollToTop = onScrollToTop,
                     onRetryFailedAndScrollToTop = onRetryFailedAndScrollToTop,
                     onStopAllDownloads = onStopAllDownloads,
@@ -361,9 +332,9 @@ internal fun DownloadsScreenContent(
                             }
                             DownloadsContent(
                                 items = downloads,
-                                selectedIds = selectedIds,
-                                dismissingIds = dismissingIds,
-                                archivingIds = archivingIds,
+                                selectedIds = selection.selectedIds,
+                                dismissingIds = selection.dismissingIds,
+                                archivingIds = selection.archivingIds,
                                 pendingDeleteIds = pendingDeleteIds,
                                 archived = isArchived,
                                 leftSwipeAction = leftSwipeAction,
@@ -388,14 +359,14 @@ internal fun DownloadsScreenContent(
                                     }
                                 },
                                 onSelectionChange = {
-                                    selectedIds = it
+                                    selection.selectedIds = it
                                 },
                                 onBulkDismissAnimationFinished = { itemId ->
-                                    dismissingIds = dismissingIds - itemId
+                                    selection.finishDismiss(itemId)
                                     onMarkDownloadsPendingDelete(setOf(itemId), true)
                                 },
                                 onBulkArchiveAnimationFinished = { itemId ->
-                                    archivingIds = archivingIds - itemId
+                                    selection.finishArchive(itemId)
                                     onUpdateDownloadsArchived(setOf(itemId), !isArchived)
                                 },
                                 onToggleSeen = { itemId ->
@@ -416,57 +387,6 @@ internal fun DownloadsScreenContent(
 }
 
 @Composable
-private fun PendingDeleteSnackbarEffect(
-    pendingDeleteIds: Set<Long>,
-    hasPendingDeletes: Boolean,
-    snackbarUndoDeleteIds: Set<Long>,
-    onSnackbarUndoDeleteIdsChange: (Set<Long>) -> Unit,
-    snackbarHostState: SnackbarHostState,
-    snackbarSingleDeleteMessage: String,
-    snackbarBulkDeleteMessage: String,
-    snackbarUndoActionLabel: String,
-    onUndoPendingDelete: (Set<Long>) -> Unit,
-    onConfirmPendingDelete: () -> Unit,
-) {
-    val latestSnackbarUndoDeleteIds by rememberUpdatedState(snackbarUndoDeleteIds)
-
-    LaunchedEffect(pendingDeleteIds) {
-        onSnackbarUndoDeleteIdsChange(
-            if (pendingDeleteIds.isEmpty()) {
-                emptySet()
-            } else {
-                snackbarUndoDeleteIds + pendingDeleteIds
-            }
-        )
-    }
-    LaunchedEffect(hasPendingDeletes) {
-        if (!hasPendingDeletes) {
-            snackbarHostState.currentSnackbarData?.dismiss()
-            return@LaunchedEffect
-        }
-        val snackbarDeleteIds = snackbarUndoDeleteIds.ifEmpty { pendingDeleteIds.toSet() }
-        val snackbarPendingDeleteMessage = getPendingDeleteSnackbarMessage(
-            snackbarDeleteIds = snackbarDeleteIds,
-            snackbarSingleDeleteMessage = snackbarSingleDeleteMessage,
-            snackbarBulkDeleteMessage = snackbarBulkDeleteMessage,
-        )
-        val snackbarResult = snackbarHostState.showSnackbar(
-            message = snackbarPendingDeleteMessage,
-            actionLabel = snackbarUndoActionLabel,
-            duration = SnackbarDuration.Indefinite,
-            withDismissAction = true,
-        )
-        if (snackbarResult == SnackbarResult.ActionPerformed) {
-            onUndoPendingDelete(latestSnackbarUndoDeleteIds.ifEmpty { snackbarDeleteIds })
-            return@LaunchedEffect
-        }
-        if (snackbarDeleteIds.isNotEmpty()) {
-            onConfirmPendingDelete()
-        }
-    }
-}
-
-@Composable
 private fun DownloadsError(
     modifier: Modifier = Modifier,
 ) {
@@ -476,56 +396,3 @@ private fun DownloadsError(
         text = stringResource(R.string.error_failed_to_load_downloads),
     )
 }
-
-private fun getPendingDeleteSnackbarMessage(
-    snackbarDeleteIds: Set<Long>,
-    snackbarSingleDeleteMessage: String,
-    snackbarBulkDeleteMessage: String,
-): String {
-    val deletedCount = snackbarDeleteIds.size
-    return if (deletedCount > 1) {
-        "$deletedCount $snackbarBulkDeleteMessage"
-    } else {
-        snackbarSingleDeleteMessage
-    }
-}
-
-internal fun splitSelectedItemIds(
-    selectedIds: Set<Long>,
-    visibleItemKeys: List<Any>,
-): SelectedItemIds {
-    if (selectedIds.isEmpty() || visibleItemKeys.isEmpty()) {
-        return SelectedItemIds(
-            visible = emptySet(),
-            offscreen = selectedIds,
-        )
-    }
-    val visibleIds = visibleItemKeys
-        .filterIsInstance<Long>()
-        .toSet()
-    val visibleSelectedIds = selectedIds.intersect(visibleIds)
-
-    return SelectedItemIds(
-        visible = visibleSelectedIds,
-        offscreen = selectedIds - visibleSelectedIds,
-    )
-}
-
-internal fun areAllItemsSelected(
-    selectedIds: Set<Long>,
-    availableIds: Set<Long>,
-): Boolean {
-    return availableIds.isNotEmpty() && availableIds.all(selectedIds::contains)
-}
-
-internal fun pruneSelectedItemIds(
-    selectedIds: Set<Long>,
-    availableIds: Set<Long>?,
-): Set<Long> {
-    return availableIds?.let(selectedIds::intersect) ?: selectedIds
-}
-
-internal data class SelectedItemIds(
-    val visible: Set<Long>,
-    val offscreen: Set<Long>,
-)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsSelectionState.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsSelectionState.kt
@@ -1,0 +1,101 @@
+package org.strigate.ferrot.presentation.screen.downloads
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.setValue
+
+internal class DownloadsSelectionState(
+    selectedIds: Set<Long> = emptySet(),
+    dismissingIds: Set<Long> = emptySet(),
+    archivingIds: Set<Long> = emptySet(),
+) {
+    var selectedIds by mutableStateOf(selectedIds)
+    var dismissingIds by mutableStateOf(dismissingIds)
+        private set
+    var archivingIds by mutableStateOf(archivingIds)
+        private set
+
+    fun prune(availableIds: Set<Long>?) {
+        selectedIds = pruneSelectedItemIds(selectedIds, availableIds)
+    }
+
+    fun archiveSelected(visibleItemKeys: List<Any>, onArchive: (Set<Long>) -> Unit) {
+        val selection = splitSelectedItemIds(selectedIds, visibleItemKeys)
+        archivingIds += selection.visible
+        if (selection.offscreen.isNotEmpty()) {
+            onArchive(selection.offscreen)
+        }
+        selectedIds = emptySet()
+    }
+
+    fun deleteSelected(visibleItemKeys: List<Any>, onDelete: (Set<Long>) -> Unit) {
+        val selection = splitSelectedItemIds(selectedIds, visibleItemKeys)
+        dismissingIds += selection.visible
+        if (selection.offscreen.isNotEmpty()) {
+            onDelete(selection.offscreen)
+        }
+        selectedIds = emptySet()
+    }
+
+    fun finishDismiss(itemId: Long) {
+        dismissingIds -= itemId
+    }
+
+    fun finishArchive(itemId: Long) {
+        archivingIds -= itemId
+    }
+
+    companion object {
+        val Saver = listSaver<DownloadsSelectionState, LongArray>(
+            save = {
+                listOf(
+                    it.selectedIds.toLongArray(),
+                    it.dismissingIds.toLongArray(),
+                    it.archivingIds.toLongArray()
+                )
+            },
+            restore = { DownloadsSelectionState(it[0].toSet(), it[1].toSet(), it[2].toSet()) },
+        )
+    }
+}
+
+internal fun splitSelectedItemIds(
+    selectedIds: Set<Long>,
+    visibleItemKeys: List<Any>,
+): SelectedItemIds {
+    if (selectedIds.isEmpty() || visibleItemKeys.isEmpty()) {
+        return SelectedItemIds(
+            visible = emptySet(),
+            offscreen = selectedIds,
+        )
+    }
+    val visibleIds = visibleItemKeys
+        .filterIsInstance<Long>()
+        .toSet()
+    val visibleSelectedIds = selectedIds.intersect(visibleIds)
+
+    return SelectedItemIds(
+        visible = visibleSelectedIds,
+        offscreen = selectedIds - visibleSelectedIds,
+    )
+}
+
+internal fun areAllItemsSelected(
+    selectedIds: Set<Long>,
+    availableIds: Set<Long>,
+): Boolean {
+    return availableIds.isNotEmpty() && availableIds.all(selectedIds::contains)
+}
+
+internal fun pruneSelectedItemIds(
+    selectedIds: Set<Long>,
+    availableIds: Set<Long>?,
+): Set<Long> {
+    return availableIds?.let(selectedIds::intersect) ?: selectedIds
+}
+
+internal data class SelectedItemIds(
+    val visible: Set<Long>,
+    val offscreen: Set<Long>,
+)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/PendingDeleteSnackbarEffect.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/downloads/PendingDeleteSnackbarEffect.kt
@@ -1,0 +1,79 @@
+package org.strigate.ferrot.presentation.screen.downloads
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import org.strigate.ferrot.R
+
+@Composable
+internal fun PendingDeleteSnackbarEffect(
+    pendingDeleteIds: Set<Long>,
+    snackbarHostState: SnackbarHostState,
+    onUndoPendingDelete: (Set<Long>) -> Unit,
+    onConfirmPendingDelete: () -> Unit,
+) {
+    val hasPendingDeletes = pendingDeleteIds.isNotEmpty()
+
+    val snackbarSingleDeleteMessage = stringResource(R.string.snackbar_delete_single_delete)
+    val snackbarBulkDeleteMessage = stringResource(R.string.snackbar_bulk_delete_bulk_delete)
+    val snackbarUndoActionLabel = stringResource(R.string.snackbar_delete_undo)
+
+    var snackbarUndoDeleteIds by rememberSaveable { mutableStateOf(setOf<Long>()) }
+    val latestUndoPendingDelete by rememberUpdatedState(onUndoPendingDelete)
+    val latestConfirmPendingDelete by rememberUpdatedState(onConfirmPendingDelete)
+    val latestSnackbarUndoDeleteIds by rememberUpdatedState(snackbarUndoDeleteIds)
+
+    LaunchedEffect(pendingDeleteIds) {
+        snackbarUndoDeleteIds = if (pendingDeleteIds.isEmpty()) {
+            emptySet()
+        } else {
+            snackbarUndoDeleteIds + pendingDeleteIds
+        }
+    }
+    LaunchedEffect(hasPendingDeletes) {
+        if (!hasPendingDeletes) {
+            snackbarHostState.currentSnackbarData?.dismiss()
+            return@LaunchedEffect
+        }
+        val snackbarDeleteIds = snackbarUndoDeleteIds.ifEmpty { pendingDeleteIds.toSet() }
+        val snackbarPendingDeleteMessage = getPendingDeleteSnackbarMessage(
+            snackbarDeleteIds = snackbarDeleteIds,
+            snackbarSingleDeleteMessage = snackbarSingleDeleteMessage,
+            snackbarBulkDeleteMessage = snackbarBulkDeleteMessage,
+        )
+        val snackbarResult = snackbarHostState.showSnackbar(
+            message = snackbarPendingDeleteMessage,
+            actionLabel = snackbarUndoActionLabel,
+            duration = SnackbarDuration.Indefinite,
+            withDismissAction = true,
+        )
+        if (snackbarResult == SnackbarResult.ActionPerformed) {
+            latestUndoPendingDelete(latestSnackbarUndoDeleteIds.ifEmpty { snackbarDeleteIds })
+            return@LaunchedEffect
+        }
+        if (snackbarDeleteIds.isNotEmpty()) {
+            latestConfirmPendingDelete()
+        }
+    }
+}
+
+private fun getPendingDeleteSnackbarMessage(
+    snackbarDeleteIds: Set<Long>,
+    snackbarSingleDeleteMessage: String,
+    snackbarBulkDeleteMessage: String,
+): String {
+    val deletedCount = snackbarDeleteIds.size
+    return if (deletedCount > 1) {
+        "$deletedCount $snackbarBulkDeleteMessage"
+    } else {
+        snackbarSingleDeleteMessage
+    }
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/getcookies/GetCookiesScreen.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/getcookies/GetCookiesScreen.kt
@@ -1,14 +1,5 @@
-package org.strigate.ferrot.presentation.screen
+package org.strigate.ferrot.presentation.screen.getcookies
 
-import android.annotation.SuppressLint
-import android.content.Intent
-import android.view.ViewGroup
-import android.webkit.CookieManager
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebSettings
-import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
@@ -36,7 +27,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,8 +45,6 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.view.doOnLayout
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import org.strigate.ferrot.R
@@ -86,7 +74,6 @@ fun GetCookiesScreen(
     var requestedUrl by rememberSaveable { mutableStateOf<String?>(null) }
     var currentUrl by rememberSaveable { mutableStateOf<String?>(null) }
     var pageTitle by rememberSaveable { mutableStateOf<String?>(null) }
-    var webView by remember { mutableStateOf<WebView?>(null) }
     var overwritePrompt by remember { mutableStateOf<CookieOverwritePrompt?>(null) }
 
     val saveUrl = currentUrl ?: requestedUrl
@@ -111,11 +98,9 @@ fun GetCookiesScreen(
 
     fun saveCookies(url: String?, confirmOverwrite: Boolean = true) {
         val targetUrl = url ?: return
-        val cookieManager = CookieManager.getInstance()
-        cookieManager.flush()
         viewModel.saveCookies(
             url = targetUrl,
-            cookieHeader = cookieManager.getCookie(targetUrl).orEmpty(),
+            cookieHeader = readWebViewCookieHeader(targetUrl),
             confirmOverwrite = confirmOverwrite,
         )
     }
@@ -142,11 +127,6 @@ fun GetCookiesScreen(
 
                 is GetCookiesEvent.Saved -> navController.popBackStack()
             }
-        }
-    }
-    DisposableEffect(Unit) {
-        onDispose {
-            webView?.destroy()
         }
     }
 
@@ -177,7 +157,6 @@ fun GetCookiesScreen(
             GetCookiesWebView(
                 modifier = webViewModifier,
                 requestedUrl = requestedUrl,
-                onWebViewCreated = { webView = it },
                 onCurrentUrlChanged = { url ->
                     currentUrl = url
                     addressText = url.toTextFieldValue()
@@ -346,108 +325,6 @@ private fun CookieLoginWarning(
             text = stringResource(R.string.cookies_webview_warning),
         )
     }
-}
-
-@SuppressLint("SetJavaScriptEnabled")
-@Composable
-private fun GetCookiesWebView(
-    requestedUrl: String?,
-    onWebViewCreated: (WebView) -> Unit,
-    onCurrentUrlChanged: (String) -> Unit,
-    onTitleChanged: (String?) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AndroidView(
-        modifier = modifier,
-        factory = { context ->
-            CookieManager.getInstance().setAcceptCookie(true)
-            WebView(context).apply {
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                )
-                settings.apply {
-                    cacheMode = WebSettings.LOAD_DEFAULT
-                    javaScriptEnabled = true
-                    javaScriptCanOpenWindowsAutomatically = true
-                    domStorageEnabled = true
-                    loadsImagesAutomatically = true
-                    safeBrowsingEnabled = true
-                    userAgentString = WebSettings.getDefaultUserAgent(context)
-                    useWideViewPort = true
-                    loadWithOverviewMode = false
-                    builtInZoomControls = false
-                    displayZoomControls = false
-                }
-                CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
-                webViewClient = object : WebViewClient() {
-                    override fun onPageFinished(view: WebView?, url: String?) {
-                        onTitleChanged(view?.title)
-                        if (!url.isNullOrBlank()) {
-                            onCurrentUrlChanged(url)
-                        }
-                    }
-
-                    override fun shouldOverrideUrlLoading(
-                        view: WebView?,
-                        request: WebResourceRequest?,
-                    ): Boolean {
-                        val uri = request?.url ?: return false
-                        if (uri.scheme != "intent") {
-                            return false
-                        }
-                        if (!request.isForMainFrame) {
-                            return true
-                        }
-                        val fallbackUrl = runCatching {
-                            Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME)
-                                .getStringExtra("browser_fallback_url")
-                        }.getOrNull()?.let(::normalizeWebViewUrl)
-                        if (fallbackUrl != null) {
-                            view?.loadUrl(fallbackUrl)
-                        }
-                        return true
-                    }
-                }
-                webChromeClient = object : WebChromeClient() {}
-                onWebViewCreated(this)
-                requestedUrl?.let { url ->
-                    loadRequestedUrl(url)
-                }
-            }
-        },
-        update = { view ->
-            val url = requestedUrl ?: return@AndroidView
-            view.loadRequestedUrl(url)
-        },
-    )
-}
-
-private fun WebView.loadRequestedUrl(url: String) {
-    if (tag == url) {
-        return
-    }
-    tag = url
-    if (width > 0 && height > 0) {
-        loadUrl(url)
-    } else {
-        doOnLayout { loadUrl(url) }
-    }
-}
-
-private fun normalizeWebViewUrl(rawUrl: String): String? {
-    val trimmed = rawUrl.trim()
-    if (trimmed.isBlank()) {
-        return null
-    }
-    val candidate = if (trimmed.contains("://")) trimmed else "$DEFAULT_URL_PREFIX$trimmed"
-    return runCatching { URI(candidate) }
-        .getOrNull()
-        ?.takeIf { uri ->
-            uri.scheme == "http" || uri.scheme == "https"
-        }
-        ?.takeIf { uri -> !uri.host.isNullOrBlank() }
-        ?.toString()
 }
 
 private fun titleFromUrl(url: String): String {

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/getcookies/GetCookiesWebView.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/screen/getcookies/GetCookiesWebView.kt
@@ -1,0 +1,128 @@
+package org.strigate.ferrot.presentation.screen.getcookies
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.doOnLayout
+import java.net.URI
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+internal fun GetCookiesWebView(
+    requestedUrl: String?,
+    onCurrentUrlChanged: (String) -> Unit,
+    onTitleChanged: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val currentOnTitleChanged by rememberUpdatedState(onTitleChanged)
+    val currentOnCurrentUrlChanged by rememberUpdatedState(onCurrentUrlChanged)
+
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            CookieManager.getInstance().setAcceptCookie(true)
+            WebView(context).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                settings.apply {
+                    cacheMode = WebSettings.LOAD_DEFAULT
+                    javaScriptEnabled = true
+                    javaScriptCanOpenWindowsAutomatically = true
+                    domStorageEnabled = true
+                    loadsImagesAutomatically = true
+                    safeBrowsingEnabled = true
+                    userAgentString = WebSettings.getDefaultUserAgent(context)
+                    useWideViewPort = true
+                    loadWithOverviewMode = false
+                    builtInZoomControls = false
+                    displayZoomControls = false
+                }
+                CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        currentOnTitleChanged(view?.title)
+                        if (!url.isNullOrBlank()) {
+                            currentOnCurrentUrlChanged(url)
+                        }
+                    }
+
+                    override fun shouldOverrideUrlLoading(
+                        view: WebView?,
+                        request: WebResourceRequest?,
+                    ): Boolean {
+                        val uri = request?.url ?: return false
+                        if (uri.scheme != "intent") {
+                            return false
+                        }
+                        if (!request.isForMainFrame) {
+                            return true
+                        }
+                        val fallbackUrl = runCatching {
+                            Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME)
+                                .getStringExtra("browser_fallback_url")
+                        }.getOrNull()?.let(::normalizeWebViewUrl)
+                        if (fallbackUrl != null) {
+                            view?.loadUrl(fallbackUrl)
+                        }
+                        return true
+                    }
+                }
+                webChromeClient = object : WebChromeClient() {}
+                requestedUrl?.let { url ->
+                    loadRequestedUrl(url)
+                }
+            }
+        },
+        onRelease = { view -> view.destroy() },
+        update = { view ->
+            val url = requestedUrl ?: return@AndroidView
+            view.loadRequestedUrl(url)
+        },
+    )
+}
+
+private fun WebView.loadRequestedUrl(url: String) {
+    if (tag == url) {
+        return
+    }
+    tag = url
+    if (width > 0 && height > 0) {
+        loadUrl(url)
+    } else {
+        doOnLayout { loadUrl(url) }
+    }
+}
+
+internal fun normalizeWebViewUrl(rawUrl: String): String? {
+    val trimmed = rawUrl.trim()
+    if (trimmed.isBlank()) {
+        return null
+    }
+    val candidate = if (trimmed.contains("://")) trimmed else "https://$trimmed"
+    return runCatching { URI(candidate) }
+        .getOrNull()
+        ?.takeIf { uri ->
+            uri.scheme == "http" || uri.scheme == "https"
+        }
+        ?.takeIf { uri -> !uri.host.isNullOrBlank() }
+        ?.toString()
+}
+
+internal fun readWebViewCookieHeader(url: String): String {
+    val cookieManager = CookieManager.getInstance()
+    cookieManager.flush()
+    return cookieManager.getCookie(url).orEmpty()
+}

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -33,11 +34,13 @@ import org.strigate.ferrot.domain.usecase.DownloadVideoUseCase
 import org.strigate.ferrot.domain.usecase.DownloadWithMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.RequestRefreshDownloadMetadataUseCase
 import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.IsDownloadThumbnailAvailableUseCase
 import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.mapper.toPageUiData
 import org.strigate.ferrot.presentation.model.DownloadPageUiData
+import org.strigate.ferrot.presentation.model.DownloadStatusUiData
 import org.strigate.ferrot.presentation.model.DownloadUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
 import javax.inject.Inject
@@ -55,6 +58,7 @@ class DownloadViewModel @Inject constructor(
     private val clearNotificationsByDownloadIdUseCase: ClearNotificationsByDownloadIdUseCase,
     private val startDownloadUseCase: StartDownloadUseCase,
     private val requestRefreshDownloadMetadataUseCase: RequestRefreshDownloadMetadataUseCase,
+    private val isDownloadThumbnailAvailableUseCase: IsDownloadThumbnailAvailableUseCase,
     downloadWithMetadataUseCase: DownloadWithMetadataUseCase,
 ) : ViewModel() {
     private val initialId: Long? = savedStateHandle[Screen.Download.ARG_DOWNLOAD_ID]
@@ -156,7 +160,6 @@ class DownloadViewModel @Inject constructor(
             )
         }
             .distinctUntilChanged()
-            .flowOn(Dispatchers.Default)
     }
 
     fun getDownloadPageUiData(downloadId: Long): Flow<DownloadPageUiData?> {
@@ -166,24 +169,63 @@ class DownloadViewModel @Inject constructor(
             .getDownloadVideoByDownloadIdAsFlowUseCase(downloadId)
         val audioFlow = downloadAudioUseCase
             .getDownloadAudioByDownloadIdAsFlowUseCase(downloadId)
-        val metadataFlow = downloadMetadataUseCase
-            .getDownloadMetadataByIdAsFlowUseCase(downloadId)
+        val metadataFlow = flow {
+            var emissionIndex = 0
+            downloadMetadataUseCase
+                .getDownloadMetadataByIdAsFlowUseCase(downloadId)
+                .collect { metadata ->
+                    emit(IndexedValue(emissionIndex++, metadata))
+                }
+        }
         val progressFlow = downloadProgressUseCase
             .getDownloadProgressByDownloadIdAsFlowUseCase(downloadId)
 
-        return combine(
-            downloadFlow,
-            videoFlow,
-            audioFlow,
-            metadataFlow,
-            progressFlow,
-        ) { base, video, audio, metadata, progress ->
-            base?.toPageUiData(
-                video = video,
-                audio = audio,
-                metadata = metadata,
-                progress = progress,
-            )
+        return flow {
+            var previousStatus: DownloadStatus? = null
+            var previousMetadataEmissionIndex = -1
+            var thumbnailAvailable: Boolean? = null
+
+            combine(
+                downloadFlow,
+                videoFlow,
+                audioFlow,
+                metadataFlow,
+                progressFlow,
+            ) { base, video, audio, metadataEmission, progress ->
+                Triple(
+                    base?.toPageUiData(
+                        video = video,
+                        audio = audio,
+                        metadata = metadataEmission.value,
+                        progress = progress,
+                    ),
+                    base?.status,
+                    metadataEmission.index,
+                )
+            }.collect { (data, status, metadataEmissionIndex) ->
+                if (data == null) {
+                    previousStatus = null
+                    previousMetadataEmissionIndex = -1
+                    thumbnailAvailable = null
+                    emit(null)
+                    return@collect
+                }
+
+                val completedNow = status == DownloadStatus.COMPLETED &&
+                        previousStatus != DownloadStatus.COMPLETED
+                if (
+                    thumbnailAvailable == null ||
+                    metadataEmissionIndex != previousMetadataEmissionIndex ||
+                    completedNow
+                ) {
+                    thumbnailAvailable = isDownloadThumbnailAvailableUseCase(
+                        data.metadata?.thumbnailFilePath,
+                    )
+                }
+                previousStatus = status
+                previousMetadataEmissionIndex = metadataEmissionIndex
+                emit(data.copy(thumbnailAvailable = thumbnailAvailable == true))
+            }
         }.flowOn(Dispatchers.Default)
     }
 
@@ -280,9 +322,11 @@ class DownloadViewModel @Inject constructor(
         startDownloadUseCase(downloadId)
     }
 
-    fun refreshDownloadMetadata(id: Long? = null) = viewModelScope.launch {
-        val downloadId = resolveDownloadId(id) ?: return@launch
-        requestRefreshDownloadMetadataUseCase(downloadId)
+    fun onPageVisible(downloadId: Long) = viewModelScope.launch {
+        val download = getDownloadPageUiData(downloadId).first() ?: return@launch
+        if (download.status == DownloadStatusUiData.COMPLETED && !download.thumbnailAvailable) {
+            requestRefreshDownloadMetadataUseCase(downloadId)
+        }
     }
 
     private fun getSelectedMediaFilePath(

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -46,7 +47,7 @@ class SettingsViewModel @Inject constructor(
             cookiesEnabled,
             leftSwipeAction,
             rightSwipeAction ->
-            SettingsUiState.Data(
+            val uiState: SettingsUiState = SettingsUiState.Data(
                 SettingsUiData(
                     wifiOnlyDownloadsEnabled = wifiOnlyDownloadsEnabled,
                     automaticDuplicateDownloadDeletionEnabled = automaticDuplicateDownloadDeletionEnabled,
@@ -55,7 +56,8 @@ class SettingsViewModel @Inject constructor(
                     rightSwipeAction = rightSwipeAction.toUiData(),
                 )
             )
-        }
+            uiState
+        }.catch { emit(SettingsUiState.Error) }
     }
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.SETTINGS)

--- a/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
+++ b/app/src/main/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -56,7 +57,7 @@ class UpdatesViewModel @Inject constructor(
             automaticDependencyUpdatesEnabled,
             lastAvailableUpdateCheckMillis,
             lastDependencyUpdateCheckMillis ->
-            UpdatesUiState.Data(
+            val uiState: UpdatesUiState = UpdatesUiState.Data(
                 UpdatesUiData(
                     settings = UpdatesSettingsUiData(
                         automaticAppUpdatesEnabled = automaticAppUpdatesEnabled,
@@ -68,7 +69,8 @@ class UpdatesViewModel @Inject constructor(
                     ),
                 ),
             )
-        }
+            uiState
+        }.catch { emit(UpdatesUiState.Error) }
     }
 
     fun logShown() = analyticsLogger.logScreen(AnalyticsEvents.Screens.UPDATES)

--- a/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/downloadmetadata/IsDownloadThumbnailAvailableUseCaseTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/domain/usecase/downloadmetadata/IsDownloadThumbnailAvailableUseCaseTest.kt
@@ -1,0 +1,32 @@
+package org.strigate.ferrot.domain.usecase.downloadmetadata
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class IsDownloadThumbnailAvailableUseCaseTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private val useCase = IsDownloadThumbnailAvailableUseCase()
+
+    @Test
+    fun rejectsMissingEmptyAndDirectoryPaths() = runTest {
+        assertFalse(useCase(null))
+        assertFalse(useCase(""))
+        assertFalse(useCase(temporaryFolder.root.resolve("missing.jpg").path))
+        assertFalse(useCase(temporaryFolder.newFile().path))
+        assertFalse(useCase(temporaryFolder.root.path))
+    }
+
+    @Test
+    fun acceptsNonemptyFile() = runTest {
+        val file = temporaryFolder.newFile()
+        file.writeBytes(byteArrayOf(1))
+
+        assertTrue(useCase(file.path))
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsSelectionStateTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/screen/downloads/DownloadsSelectionStateTest.kt
@@ -1,0 +1,45 @@
+package org.strigate.ferrot.presentation.screen.downloads
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadsSelectionStateTest {
+    @Test
+    fun delete_defersVisibleItemsAndImmediatelyDeletesOffscreenItems() {
+        val state = DownloadsSelectionState(selectedIds = setOf(1L, 2L, 3L))
+        var deletedIds = emptySet<Long>()
+
+        state.deleteSelected(listOf(1L, 3L)) { deletedIds = it }
+
+        assertEquals(setOf(2L), deletedIds)
+        assertEquals(setOf(1L, 3L), state.dismissingIds)
+        assertEquals(emptySet<Long>(), state.selectedIds)
+        state.finishDismiss(1L)
+        assertEquals(setOf(3L), state.dismissingIds)
+    }
+
+    @Test
+    fun archive_preservesPendingDeleteAnimations() {
+        val state = DownloadsSelectionState(selectedIds = setOf(1L, 2L), dismissingIds = setOf(3L))
+        var archivedIds = emptySet<Long>()
+
+        state.archiveSelected(listOf(1L)) { archivedIds = it }
+
+        assertEquals(setOf(2L), archivedIds)
+        assertEquals(setOf(1L), state.archivingIds)
+        assertEquals(setOf(3L), state.dismissingIds)
+        assertEquals(emptySet<Long>(), state.selectedIds)
+        state.finishArchive(1L)
+        assertEquals(emptySet<Long>(), state.archivingIds)
+    }
+
+    @Test
+    fun pruning_preservesSelectionWhileLoadingAndRemovesUnavailableIdsAfterLoading() {
+        val state = DownloadsSelectionState(selectedIds = setOf(1L, 2L))
+
+        state.prune(null)
+        assertEquals(setOf(1L, 2L), state.selectedIds)
+        state.prune(setOf(2L, 3L))
+        assertEquals(setOf(2L), state.selectedIds)
+    }
+}

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadViewModelTest.kt
@@ -1,15 +1,19 @@
 package org.strigate.ferrot.presentation.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -22,6 +26,7 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.ArgumentMatchers.nullable
 import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
@@ -29,7 +34,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
-import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.Download
@@ -54,6 +58,7 @@ import org.strigate.ferrot.domain.usecase.download.StartDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
 import org.strigate.ferrot.domain.usecase.downloadaudio.GetDownloadAudioByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadmetadata.GetDownloadMetadataByIdAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.downloadmetadata.IsDownloadThumbnailAvailableUseCase
 import org.strigate.ferrot.domain.usecase.downloadprogress.GetDownloadProgressByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadvideo.GetDownloadVideoByDownloadIdAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
@@ -62,6 +67,8 @@ import org.strigate.ferrot.presentation.Screen
 import org.strigate.ferrot.presentation.event.DownloadEvent
 import org.strigate.ferrot.presentation.model.DownloadPageUiData
 import org.strigate.ferrot.presentation.state.DownloadUiState
+import org.strigate.ferrot.test.MainDispatcherRule
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -71,6 +78,10 @@ class DownloadViewModelTest {
 
     private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
     private lateinit var autoCloseable: AutoCloseable
+    private val viewModels = mutableListOf<DownloadViewModel>()
+
+    @Mock
+    private lateinit var isDownloadThumbnailAvailableUseCase: IsDownloadThumbnailAvailableUseCase
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger
@@ -130,8 +141,10 @@ class DownloadViewModelTest {
     private lateinit var getDownloadProgressByDownloadIdAsFlowUseCase: GetDownloadProgressByDownloadIdAsFlowUseCase
 
     @Before
-    fun setUp() {
-        autoCloseable = MockitoAnnotations.openMocks(this)
+    fun setUp() = runTest(testDispatcher) {
+        autoCloseable = MockitoAnnotations.openMocks(this@DownloadViewModelTest)
+        `when`(isDownloadThumbnailAvailableUseCase.invoke(nullable(String::class.java)))
+            .thenReturn(false)
     }
 
     @Test
@@ -179,7 +192,7 @@ class DownloadViewModelTest {
             val mediaCollector = collectSelectedMedia(backgroundScope, viewModel)
             val eventDeferred = backgroundScope.async {
                 runCatching {
-                    withTimeout(250L) {
+                    withTimeout(250L.milliseconds) {
                         viewModel.events.first()
                     }
                 }
@@ -193,7 +206,6 @@ class DownloadViewModelTest {
             viewModel.saveDownload()
             viewModel.playDownload()
             viewModel.retryDownload()
-            viewModel.refreshDownloadMetadata()
             advanceUntilIdle()
 
             assertEquals(DownloadMediaType.VIDEO, viewModel.selectedMedia.value)
@@ -548,33 +560,6 @@ class DownloadViewModelTest {
     }
 
     @Test
-    fun refreshDownloadMetadata_refreshesExplicitOrSelected() = runTest(testDispatcher) {
-        val viewModel = createViewModel(initialId = 20L)
-
-        viewModel.refreshDownloadMetadata(88L)
-        advanceUntilIdle()
-
-        viewModel.refreshDownloadMetadata()
-        advanceUntilIdle()
-
-        verify(requestRefreshDownloadMetadataUseCase)
-            .invoke(88L)
-        verify(requestRefreshDownloadMetadataUseCase)
-            .invoke(20L)
-    }
-
-    @Test
-    fun refreshDownloadMetadata_enqueuesWithoutExtraUiTracking() = runTest(testDispatcher) {
-        val viewModel = createViewModel(initialId = 20L)
-
-        viewModel.refreshDownloadMetadata()
-        advanceUntilIdle()
-
-        verify(requestRefreshDownloadMetadataUseCase)
-            .invoke(20L)
-    }
-
-    @Test
     fun shareSaveAndPlay_emitEventsUsingSelectedMediaPath() = runTest(testDispatcher) {
         stubPageData(
             downloadId = 20L,
@@ -852,8 +837,161 @@ class DownloadViewModelTest {
         )
     }
 
+    @Test
+    fun getDownloadPageUiData_doesNotRecheckThumbnailForUnrelatedChanges() =
+        runTest(testDispatcher) {
+            val downloadId = 20L
+            val thumbnailPath = "/tmp/thumb.jpg"
+            val metadata = DownloadMetadata(
+                downloadId = downloadId,
+                videoId = "video-id",
+                source = "yt",
+                title = "Example title",
+                thumbnailFilePath = thumbnailPath,
+                durationSeconds = 42,
+            )
+            val downloadFlow = MutableStateFlow(createDownload(downloadId))
+            val videoFlow = MutableStateFlow<DownloadVideo?>(null)
+            val audioFlow = MutableStateFlow<DownloadAudio?>(null)
+            val progressFlow = MutableStateFlow<DownloadProgress?>(null)
+            `when`(getDownloadByIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(downloadFlow)
+            `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(videoFlow)
+            `when`(getDownloadAudioByDownloadIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(audioFlow)
+            `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(MutableStateFlow(metadata))
+            `when`(getDownloadProgressByDownloadIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(progressFlow)
+            val viewModel = createViewModel()
+            val emissions = Channel<DownloadPageUiData?>(Channel.UNLIMITED)
+            val collector = backgroundScope.launch {
+                viewModel.getDownloadPageUiData(downloadId).collect(emissions::send)
+            }
+            emissions.receive()
+
+            videoFlow.value = DownloadVideo(
+                downloadId = downloadId,
+                filePath = "/tmp/video.mp4",
+                fileExtension = "mp4",
+                sha256 = null,
+            )
+            emissions.receive()
+            audioFlow.value = DownloadAudio(
+                downloadId = downloadId,
+                filePath = "/tmp/audio.mp3",
+                fileExtension = "mp3",
+            )
+            emissions.receive()
+            downloadFlow.value = downloadFlow.value.copy(seen = true)
+            emissions.receive()
+            progressFlow.value = DownloadProgress(
+                downloadId = downloadId,
+                updatedAtMillis = 10L,
+                progressPercent = 1f,
+                bytesDownloaded = 10L,
+                etaSeconds = 12L,
+                expectedBytes = 1000L,
+            )
+            emissions.receive()
+
+            verify(isDownloadThumbnailAvailableUseCase, times(1))
+                .invoke(thumbnailPath)
+            collector.cancel()
+        }
+
+    @Test
+    fun getDownloadPageUiData_rechecksThumbnailForMetadataAndCompletionChanges() =
+        runTest(testDispatcher) {
+            val downloadId = 20L
+            val thumbnailPath = "/tmp/thumb.jpg"
+            val downloadFlow = MutableStateFlow<Download?>(createDownload(downloadId))
+            val metadataFlow = MutableStateFlow(
+                DownloadMetadata(
+                    downloadId = downloadId,
+                    videoId = "video-id",
+                    source = "yt",
+                    title = "Example title",
+                    thumbnailFilePath = thumbnailPath,
+                    durationSeconds = 42,
+                )
+            )
+            `when`(getDownloadByIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(downloadFlow)
+            `when`(getDownloadVideoByDownloadIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(flowOf(null))
+            `when`(getDownloadAudioByDownloadIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(flowOf(null))
+            `when`(getDownloadMetadataByIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(metadataFlow)
+            `when`(getDownloadProgressByDownloadIdAsFlowUseCase.invoke(downloadId))
+                .thenReturn(flowOf(null))
+            val viewModel = createViewModel()
+            val emissions = Channel<DownloadPageUiData?>(Channel.UNLIMITED)
+            val collector = backgroundScope.launch {
+                viewModel.getDownloadPageUiData(downloadId).collect(emissions::send)
+            }
+            emissions.receive()
+
+            metadataFlow.value = metadataFlow.value.copy(title = "Updated title")
+            emissions.receive()
+            verify(isDownloadThumbnailAvailableUseCase, times(2))
+                .invoke(thumbnailPath)
+
+            downloadFlow.value = requireNotNull(downloadFlow.value).copy(
+                status = DownloadStatus.COMPLETED,
+            )
+            emissions.receive()
+            verify(isDownloadThumbnailAvailableUseCase, times(3))
+                .invoke(thumbnailPath)
+
+            downloadFlow.value = null
+            emissions.receive()
+            downloadFlow.value = createDownload(downloadId, status = DownloadStatus.COMPLETED)
+            emissions.receive()
+
+            verify(isDownloadThumbnailAvailableUseCase, times(4))
+                .invoke(thumbnailPath)
+            collector.cancel()
+        }
+
+    @Test
+    fun visibleCompletedPage_refreshesMissingThumbnail() = runTest(testDispatcher) {
+        stubPageData(20L, createDownload(20L, status = DownloadStatus.COMPLETED))
+        val viewModel = createViewModel(initialId = 20L)
+
+        viewModel.onPageVisible(20L).join()
+
+        verify(requestRefreshDownloadMetadataUseCase)
+            .invoke(20L)
+    }
+
+    @Test
+    fun visiblePage_doesNotRefreshAvailableThumbnail() = runTest(testDispatcher) {
+        stubPageData(20L, createDownload(20L, status = DownloadStatus.COMPLETED))
+        `when`(isDownloadThumbnailAvailableUseCase.invoke(null))
+            .thenReturn(true)
+        val viewModel = createViewModel(initialId = 20L)
+
+        viewModel.onPageVisible(20L).join()
+
+        verifyNoInteractions(requestRefreshDownloadMetadataUseCase)
+    }
+
+    @Test
+    fun visiblePage_doesNotRefreshIncompleteDownload() = runTest(testDispatcher) {
+        stubPageData(20L, createDownload(20L, status = DownloadStatus.QUEUED))
+        val viewModel = createViewModel(initialId = 20L)
+
+        viewModel.onPageVisible(20L).join()
+
+        verifyNoInteractions(requestRefreshDownloadMetadataUseCase)
+    }
+
     @After
-    fun tearDown() {
+    fun tearDown() = runTest(testDispatcher) {
+        viewModels.forEach { it.viewModelScope.coroutineContext.job.cancelAndJoin() }
         autoCloseable.close()
     }
 
@@ -909,7 +1047,8 @@ class DownloadViewModelTest {
             startDownloadUseCase = startDownloadUseCase,
             requestRefreshDownloadMetadataUseCase = requestRefreshDownloadMetadataUseCase,
             downloadWithMetadataUseCase = downloadWithMetadataUseCase,
-        )
+            isDownloadThumbnailAvailableUseCase = isDownloadThumbnailAvailableUseCase,
+        ).also { viewModels += it }
     }
 
     private fun stubPageData(

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/DownloadsViewModelTest.kt
@@ -1,11 +1,14 @@
 package org.strigate.ferrot.presentation.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -21,16 +24,14 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.never
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
-import org.strigate.ferrot.test.MainDispatcherRule
 import org.strigate.ferrot.analytics.AnalyticsEvents
 import org.strigate.ferrot.analytics.AnalyticsLogger
 import org.strigate.ferrot.domain.model.AvailableUpdate
-import org.strigate.ferrot.domain.model.DownloadSwipeAction
 import org.strigate.ferrot.domain.model.DownloadStatus
+import org.strigate.ferrot.domain.model.DownloadSwipeAction
 import org.strigate.ferrot.domain.model.DownloadWithMetadata
 import org.strigate.ferrot.domain.usecase.AvailableUpdateUseCase
 import org.strigate.ferrot.domain.usecase.DownloadProgressUseCase
@@ -46,18 +47,19 @@ import org.strigate.ferrot.domain.usecase.download.StopDownloadUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadStatusUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsPendingDeleteUseCase
 import org.strigate.ferrot.domain.usecase.download.UpdateDownloadsSeenUseCase
+import org.strigate.ferrot.domain.usecase.downloadprogress.UpdateDownloadProgressUseCase
+import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
+import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetLeftSwipeActionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.settings.GetRightSwipeActionSettingAsFlowUseCase
 import org.strigate.ferrot.domain.usecase.state.GetArchivedDownloadsGridLayoutEnabledUseCase
 import org.strigate.ferrot.domain.usecase.state.GetDownloadsGridLayoutEnabledUseCase
 import org.strigate.ferrot.domain.usecase.state.ToggleArchivedDownloadsGridLayoutEnabledUseCase
 import org.strigate.ferrot.domain.usecase.state.ToggleDownloadsGridLayoutEnabledUseCase
-import org.strigate.ferrot.domain.usecase.downloadprogress.UpdateDownloadProgressUseCase
-import org.strigate.ferrot.domain.usecase.downloadwithmetadata.GetDownloadsWithMetadataAsFlowUseCase
-import org.strigate.ferrot.domain.usecase.notifications.ClearNotificationsByDownloadIdUseCase
 import org.strigate.ferrot.presentation.event.DownloadsEvent
 import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.DownloadsUiState
+import org.strigate.ferrot.test.MainDispatcherRule
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -67,6 +69,7 @@ class DownloadsViewModelTest {
 
     private val testDispatcher: TestDispatcher = mainDispatcherRule.testDispatcher
     private lateinit var autoCloseable: AutoCloseable
+    private val viewModels = mutableListOf<DownloadsViewModel>()
 
     @Mock
     private lateinit var analyticsLogger: AnalyticsLogger
@@ -780,7 +783,8 @@ class DownloadsViewModelTest {
     }
 
     @After
-    fun tearDown() {
+    fun tearDown() = runTest(testDispatcher) {
+        viewModels.forEach { it.viewModelScope.coroutineContext.job.cancelAndJoin() }
         autoCloseable.close()
     }
 
@@ -845,7 +849,7 @@ class DownloadsViewModelTest {
             clearNotificationsByDownloadIdUseCase = clearNotificationsByDownloadIdUseCase,
             settingsUseCase = settingsUseCase,
             stateUseCase = stateUseCase,
-        )
+        ).also { viewModels += it }
     }
 
     private suspend fun waitForUiState(

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/SettingsViewModelTest.kt
@@ -1,8 +1,10 @@
 package org.strigate.ferrot.presentation.viewmodel
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -37,6 +39,7 @@ import org.strigate.ferrot.domain.usecase.settings.SaveWifiOnlyDownloadsEnabledS
 import org.strigate.ferrot.presentation.model.DownloadSwipeActionUiData
 import org.strigate.ferrot.presentation.state.SettingsUiState
 import org.strigate.ferrot.test.MainDispatcherRule
+import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -222,13 +225,29 @@ class SettingsViewModelTest {
             .invoke(DownloadSwipeAction.ARCHIVE)
     }
 
+    @Test
+    fun uiState_exposesErrorWhenSettingsCannotBeRead() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            wifiOnlyDownloadsEnabledFlow = flow { throw IOException("unavailable") },
+            automaticDuplicateDownloadDeletionEnabledFlow = MutableStateFlow(false),
+            leftSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.NONE),
+            rightSwipeActionFlow = MutableStateFlow(DownloadSwipeAction.NONE),
+        )
+        val collector = backgroundScope.launch { viewModel.uiState.collect() }
+
+        waitForUiState(viewModel) { it is SettingsUiState.Error }
+        assertEquals(SettingsUiState.Error, viewModel.uiState.value)
+
+        collector.cancel()
+    }
+
     @After
     fun tearDown() {
         autoCloseable.close()
     }
 
     private fun createViewModel(
-        wifiOnlyDownloadsEnabledFlow: MutableStateFlow<Boolean>,
+        wifiOnlyDownloadsEnabledFlow: Flow<Boolean>,
         automaticDuplicateDownloadDeletionEnabledFlow: MutableStateFlow<Boolean>,
         cookiesEnabledFlow: MutableStateFlow<Boolean> = MutableStateFlow(true),
         leftSwipeActionFlow: MutableStateFlow<DownloadSwipeAction>,

--- a/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
+++ b/app/src/test/kotlin/org/strigate/ferrot/presentation/viewmodel/UpdatesViewModelTest.kt
@@ -2,8 +2,10 @@ package org.strigate.ferrot.presentation.viewmodel
 
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -35,6 +37,7 @@ import org.strigate.ferrot.domain.usecase.state.GetLastAvailableUpdateCheckMilli
 import org.strigate.ferrot.domain.usecase.state.GetLastDependencyUpdateCheckMillisUseCase
 import org.strigate.ferrot.presentation.state.UpdatesUiState
 import org.strigate.ferrot.test.MainDispatcherRule
+import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -210,13 +213,29 @@ class UpdatesViewModelTest {
         collector.cancel()
     }
 
+    @Test
+    fun uiState_exposesErrorWhenSettingsCannotBeRead() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            automaticAppUpdatesEnabledFlow = flow { throw IOException("unavailable") },
+            automaticDependencyUpdatesEnabledFlow = MutableStateFlow(false),
+            lastAvailableCheckFlow = MutableStateFlow(0L),
+            lastDependencyCheckFlow = MutableStateFlow(0L),
+        )
+        val collector = backgroundScope.launch { viewModel.uiState.collect() }
+
+        waitForUiState(viewModel) { it is UpdatesUiState.Error }
+        assertEquals(UpdatesUiState.Error, viewModel.uiState.value)
+
+        collector.cancel()
+    }
+
     @After
     fun tearDown() {
         autoCloseable.close()
     }
 
     private fun createViewModel(
-        automaticAppUpdatesEnabledFlow: MutableStateFlow<Boolean>,
+        automaticAppUpdatesEnabledFlow: Flow<Boolean>,
         automaticDependencyUpdatesEnabledFlow: MutableStateFlow<Boolean>,
         lastAvailableCheckFlow: MutableStateFlow<Long>,
         lastDependencyCheckFlow: MutableStateFlow<Long>,


### PR DESCRIPTION
- Extract shared `BackTopAppBar` and feature-specific screen state helpers
- Release `GetCookiesWebView` resources and keep callback references current
- Refresh missing download thumbnails without repeated filesystem checks
- Surface settings and update flow failures through typed UI states
- Stabilize selection behavior and ViewModel state tests